### PR TITLE
Update 'go get' instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Store and publish Juju charms.
 
 To start using the charm store, run the following:
 
-    go get github.com/juju/charmstore
+    go get -u -v -t github.com/juju/charmstore/...
 
 ## Go dependencies
 


### PR DESCRIPTION
Simple fix to the instructions for getting the charmstore.
Without the -t 'make check' fails.  The trailing '...' ensures all dependencies are fetched.

The original intent may have been to not use 'go get' to fetch dependencies, but ensure they correct version is gotten by using 'make deps'.  Unfortunately that doesn't work as it doesn't fetch missing packages.
