### PR TITLE
Update 'go get' instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Store and publish Juju charms.
 
 To start using the charm store, run the following:
 
-    go get github.com/juju/charmstore
+    go get -u -v -t github.com/juju/charmstore/...
 
 ## Go dependencies
 
@@ -18,7 +18,7 @@ to the revision specified in the `dependencies.tsv` file with the following:
 
 Use `make create-deps` to update the dependencies file.
 
-## Devlopment environment
+## Development environment
 
 A couple of system packages are required in order to set up a charm store
 development environment. To install them, run the following:


### PR DESCRIPTION
Update instructions for use of 'go get'.  The -t causes test dependencies to be fetched. The '...' allows all dependencies to be fetched.

The original intent may have been to not use '...' but rely on the use of godeps to get everything at the correct version. Unfortunately it did not work as it didn't fetch missing packages.
