### PR TITLE
internal/charmstore: add Store.AddCharm method

### DIFF
--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -51,7 +51,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	db := s.Session.DB("foo")
 	serveVersion := func(vers string) func(store *Store) http.Handler {
 		return func(store *Store) http.Handler {
-			c.Assert(store.DB(), gc.Equals, db)
+			c.Assert(store.DB.Database, gc.Equals, db)
 			return router.HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
 				return versionResponse{
 					Version: vers,

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -40,15 +40,15 @@ func (s *Store) AddCharm(url *charm.URL, c charm.Charm) error {
 }
 
 func interfacesForRelations(rels map[string]charm.Relation) []string {
+	// Eliminate duplicates by storing interface names into a map.
 	interfaces := make(map[string]bool)
 	for _, rel := range rels {
 		interfaces[rel.Interface] = true
 	}
 	result := make([]string, 0, len(interfaces))
-	for int := range interfaces {
-		result = append(result, int)
+	for iface := range interfaces {
+		result = append(result, iface)
 	}
-	// TODO is it worth sorting this?
 	return result
 }
 

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -5,7 +5,6 @@ package charmstore
 
 import (
 	"fmt"
-	"log"
 
 	"gopkg.in/juju/charm.v2"
 	"labix.org/v2/mgo"
@@ -21,26 +20,7 @@ func newStore(db *mgo.Database) *Store {
 	s := &Store{
 		DB: StoreDatabase{db},
 	}
-	s.ensureIndexes()
 	return s
-}
-
-func (s *Store) ensureIndexes() error {
-	indexes := []struct {
-		c *mgo.Collection
-		i mgo.Index
-	}{{
-		s.DB.Entities(),
-		mgo.Index{Key: []string{"url", "revision"}, Unique: true},
-	}}
-	for _, idx := range indexes {
-		err := idx.c.EnsureIndex(idx.i)
-		if err != nil {
-			log.Printf("error ensuring %s index: %v", idx.c.Name, err)
-			return err
-		}
-	}
-	return nil
 }
 
 // AddCharm adds a charm to the entities collection

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -9,6 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/juju/charm.v2"
 	"gopkg.in/juju/charm.v2/testing"
+	"labix.org/v2/mgo"
 	"labix.org/v2/mgo/bson"
 	gc "launchpad.net/gocheck"
 
@@ -43,6 +44,11 @@ func (s *StoreSuite) TestAddCharm(c *gc.C) {
 		CharmProvidedInterfaces: []string{"http", "logging", "monitoring"},
 		CharmRequiredInterfaces: []string{"mysql", "varnish"},
 	})
+
+	// Try inserting the charm again - it should fail because the charm is already
+	// there
+	err = store.AddCharm(url, wordpress)
+	c.Assert(err, jc.Satisfies, mgo.IsDup)
 }
 
 func mustParseReference(urlStr string) *charm.Reference {

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -1,0 +1,54 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charmstore
+
+import (
+	"sort"
+
+	jc "github.com/juju/testing/checkers"
+	"gopkg.in/juju/charm.v2"
+	"gopkg.in/juju/charm.v2/testing"
+	"labix.org/v2/mgo/bson"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/charmstore/internal/mongodoc"
+	"github.com/juju/charmstore/internal/storetesting"
+)
+
+type StoreSuite struct {
+	storetesting.IsolatedMgoSuite
+}
+
+var _ = gc.Suite(&StoreSuite{})
+
+func (s *StoreSuite) TestAddCharm(c *gc.C) {
+	store := newStore(s.Session.DB("foo"))
+	url := charm.MustParseURL("cs:precise/wordpress-23")
+	wordpress := testing.Charms.CharmDir("wordpress")
+	err := store.AddCharm(url, wordpress)
+	c.Assert(err, gc.IsNil)
+
+	var doc mongodoc.Entity
+	err = store.DB.Entities().Find(bson.D{{"_id", "cs:precise/wordpress-23"}}).One(&doc)
+	c.Assert(err, gc.IsNil)
+	sort.Strings(doc.CharmProvidedInterfaces)
+	sort.Strings(doc.CharmRequiredInterfaces)
+	c.Assert(doc, jc.DeepEquals, mongodoc.Entity{
+		URL:                     url,
+		BaseURL:                 mustParseReference("cs:wordpress"),
+		CharmMeta:               wordpress.Meta(),
+		CharmActions:            wordpress.Actions(),
+		CharmConfig:             wordpress.Config(),
+		CharmProvidedInterfaces: []string{"http", "logging", "monitoring"},
+		CharmRequiredInterfaces: []string{"mysql", "varnish"},
+	})
+}
+
+func mustParseReference(urlStr string) *charm.Reference {
+	ref, _, err := charm.ParseReference(urlStr)
+	if err != nil {
+		panic(err)
+	}
+	return &ref
+}

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/juju/charm.v2"
 	"gopkg.in/juju/charm.v2/testing"
 	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/mongodoc"
@@ -31,7 +30,7 @@ func (s *StoreSuite) TestAddCharm(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	var doc mongodoc.Entity
-	err = store.DB.Entities().Find(bson.D{{"_id", "cs:precise/wordpress-23"}}).One(&doc)
+	err = store.DB.Entities().FindId("cs:precise/wordpress-23").One(&doc)
 	c.Assert(err, gc.IsNil)
 	sort.Strings(doc.CharmProvidedInterfaces)
 	sort.Strings(doc.CharmRequiredInterfaces)
@@ -46,7 +45,7 @@ func (s *StoreSuite) TestAddCharm(c *gc.C) {
 	})
 
 	// Try inserting the charm again - it should fail because the charm is already
-	// there
+	// there.
 	err = store.AddCharm(url, wordpress)
 	c.Assert(err, jc.Satisfies, mgo.IsDup)
 }

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -13,17 +13,18 @@ type Entity struct {
 	// e.g. cs:precise/wordpress-34, cs:~user/quantal/foo-2
 	URL *charm.URL `bson:"_id"`
 
-	// BaseURL holds the URL of the charm or bundle with the
-	// series and revision omitted.
+	// BaseURL holds the reference URL of the charm or bundle
+	// (this omits the series and revision from URL)
 	// e.g. cs:wordpress, cs:~user/foo
-	BaseURL *charm.URL
+	BaseURL *charm.Reference
 
-	Revision int
-	Sha256   string // This is also used as a blob reference.
-	Size     int64
+	Sha256 string // This is also used as a blob reference.
+	Size   int64
 
 	UploadTime time.Time
 
+	// TODO(rog) verify that all these types marshal to the expected
+	// JSON form.
 	CharmMeta    *charm.Meta
 	CharmConfig  *charm.Config
 	CharmActions *charm.Actions

--- a/server_test.go
+++ b/server_test.go
@@ -55,7 +55,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	db := s.Session.DB("foo")
 	serveVersion := func(vers string) func(store *internalCharmstore.Store) http.Handler {
 		return func(store *internalCharmstore.Store) http.Handler {
-			c.Assert(store.DB(), gc.Equals, db)
+			c.Assert(store.DB.Database, gc.Equals, db)
 			return router.HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
 				return versionResponse{
 					Version: vers,


### PR DESCRIPTION
This is just a stop-gap measure so that tests can add charms to
the database and implement endpoints before charm archive
upload is implemented.
