### PR TITLE
charmstore: refactor external interface

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -15,16 +15,13 @@ import (
 	"github.com/juju/charmstore/internal/router"
 )
 
-func init() {
-	charmstore.RegisterAPIVersion("v4", newHandler)
-}
-
 type handler struct {
 	*router.Router
 	store *charmstore.Store
 }
 
-func newHandler(store *charmstore.Store) http.Handler {
+// New returns a new instance of the v4 API handler.
+func New(store *charmstore.Store) http.Handler {
 	h := &handler{
 		store: store,
 	}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/storetesting"
-	_ "github.com/juju/charmstore/internal/v4"
+	"github.com/juju/charmstore/internal/v4"
 	"github.com/juju/charmstore/params"
 )
 
@@ -28,7 +28,7 @@ var _ = gc.Suite(&APISuite{})
 
 func (s *APISuite) TestArchive(c *gc.C) {
 	db := s.Session.DB("charmstore")
-	srv, err := charmstore.NewServer(db, "v4")
+	srv, err := charmstore.NewServer(db, map[string]charmstore.NewAPIHandler{"v4": v4.New})
 	c.Assert(err, gc.IsNil)
 	assertNotImplemented(c, srv, "precise/wordpress-23/archive")
 }

--- a/server.go
+++ b/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/charmstore/internal/v4"
 )
 
+// Versions of the API that can be served.
 const (
 	V4 = "v4"
 )
@@ -22,6 +23,7 @@ var versions = map[string]func(*charmstore.Store) http.Handler{
 	V4: v4.New,
 }
 
+// Versions returns all known API versions.
 func Versions() []string {
 	vs := make([]string, 0, len(versions))
 	for v := range versions {

--- a/server.go
+++ b/server.go
@@ -4,15 +4,44 @@
 package charmstore
 
 import (
+	"fmt"
 	"net/http"
+	"sort"
 
 	"labix.org/v2/mgo"
 
 	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/v4"
 )
+
+const (
+	V4 = "v4"
+)
+
+var versions = map[string]func(*charmstore.Store) http.Handler{
+	V4: v4.New,
+}
+
+func Versions() []string {
+	vs := make([]string, 0, len(versions))
+	for v := range versions {
+		vs = append(vs, v)
+	}
+	sort.Strings(vs)
+	return vs
+}
 
 // NewServer returns a new handler that handles
 // charm store requests and stores its data in the given database.
-func NewServer(db *mgo.Database, versions ...string) (http.Handler, error) {
-	return charmstore.NewServer(db, versions...)
+func NewServer(db *mgo.Database, serveVersions ...string) (http.Handler, error) {
+	newAPIs := make(map[string]charmstore.NewAPIHandler)
+	for _, vers := range serveVersions {
+		newAPI := versions[vers]
+		if newAPI == nil {
+			return nil, fmt.Errorf("unknown version %q", vers)
+		}
+		newAPIs[vers] = newAPI
+	}
+
+	return charmstore.NewServer(db, newAPIs)
 }


### PR DESCRIPTION
We lose the version registration logic, and make versions
available to external packages without exposing
internal implementation details in the godoc.
