### PR TITLE
Implement the store.AddBundle method

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,17 +1,17 @@
 code.google.com/p/go.crypto	hg	5478be1963aafa9025e9bf0837aff6013eb92e5b	199
-github.com/binary132/gojsonpointer	git	57ab5e9c764219a3e0c4d7759797fefdcab22e9c	
-github.com/binary132/gojsonreference	git	75785fb7b21f9bf2051dca600da83ff57bc6582a	
-github.com/binary132/gojsonschema	git	640782bf48d45ba2b22fd1e8a80842667c52af00	
 github.com/juju/blobstore	git	95a336cf8665ad6a7369cb620d1d2fd06f175a3a	
 github.com/juju/errgo	git	26caa7d4884f6048c5687fa44c410e5d5d95e554	
 github.com/juju/errors	git	075df0417dbcc39d24ee18248d2f8d6e3eed598b	
+github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	
+github.com/juju/gojsonreference	git	0673d58f64bacac2db34c7d1e87a599d58923981	
+github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098	
 github.com/juju/loggo	git	7e8c70b24b80b95b2284f09306aac0bd93588db8	
-github.com/juju/names	git	b2e06a0ab1c09f138853d1ef6b11f94ca9f7b675	
+github.com/juju/names	git	dcbff5554ce4e75cbce298a5283883eaca0b2444	
 github.com/juju/schema	git	1887e824896b58a0f376fb8517b5eebb825828b8	
 github.com/juju/testing	git	b0941ff1bf4d3db1ffbbe09f75fa8383eae5764c	
 github.com/juju/txn	git	5694f17794c492e3c8a83908f0e8b9a7cff9b9f8	
 github.com/juju/utils	git	71ae858adb3bf5cc619c3200dfbdf6762de1a94a	
-gopkg.in/juju/charm.v2	git	f6fc338cf94b02f0408ce72122fcbf6712d62bc4	
+gopkg.in/juju/charm.v2	git	72fd4e827c9bed2d46290884443f1eaf559c23e3	
 labix.org/v2/mgo	bzr	gustavo@niemeyer.net-20140331185009-fhnh3xzfdpicup0j	273
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
 launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,17 +1,17 @@
 code.google.com/p/go.crypto	hg	5478be1963aafa9025e9bf0837aff6013eb92e5b	199
-github.com/binary132/gojsonpointer	git	57ab5e9c764219a3e0c4d7759797fefdcab22e9c
-github.com/binary132/gojsonreference	git	75785fb7b21f9bf2051dca600da83ff57bc6582a
-github.com/binary132/gojsonschema	git	640782bf48d45ba2b22fd1e8a80842667c52af00
-github.com/juju/blobstore	git	95a336cf8665ad6a7369cb620d1d2fd06f175a3a
-github.com/juju/errgo	git	26caa7d4884f6048c5687fa44c410e5d5d95e554
-github.com/juju/errors	git	075df0417dbcc39d24ee18248d2f8d6e3eed598b
-github.com/juju/loggo	git	7e8c70b24b80b95b2284f09306aac0bd93588db8
-github.com/juju/names	git	b2e06a0ab1c09f138853d1ef6b11f94ca9f7b675
-github.com/juju/schema	git	1887e824896b58a0f376fb8517b5eebb825828b8
-github.com/juju/testing	git	b0941ff1bf4d3db1ffbbe09f75fa8383eae5764c
-github.com/juju/txn	git	5694f17794c492e3c8a83908f0e8b9a7cff9b9f8
-github.com/juju/utils	git	71ae858adb3bf5cc619c3200dfbdf6762de1a94a
-gopkg.in/juju/charm.v2	git	f6fc338cf94b02f0408ce72122fcbf6712d62bc4
+github.com/binary132/gojsonpointer	git	57ab5e9c764219a3e0c4d7759797fefdcab22e9c	
+github.com/binary132/gojsonreference	git	75785fb7b21f9bf2051dca600da83ff57bc6582a	
+github.com/binary132/gojsonschema	git	640782bf48d45ba2b22fd1e8a80842667c52af00	
+github.com/juju/blobstore	git	95a336cf8665ad6a7369cb620d1d2fd06f175a3a	
+github.com/juju/errgo	git	26caa7d4884f6048c5687fa44c410e5d5d95e554	
+github.com/juju/errors	git	075df0417dbcc39d24ee18248d2f8d6e3eed598b	
+github.com/juju/loggo	git	7e8c70b24b80b95b2284f09306aac0bd93588db8	
+github.com/juju/names	git	b2e06a0ab1c09f138853d1ef6b11f94ca9f7b675	
+github.com/juju/schema	git	1887e824896b58a0f376fb8517b5eebb825828b8	
+github.com/juju/testing	git	b0941ff1bf4d3db1ffbbe09f75fa8383eae5764c	
+github.com/juju/txn	git	5694f17794c492e3c8a83908f0e8b9a7cff9b9f8	
+github.com/juju/utils	git	71ae858adb3bf5cc619c3200dfbdf6762de1a94a	
+gopkg.in/juju/charm.v2	git	f6fc338cf94b02f0408ce72122fcbf6712d62bc4	
 labix.org/v2/mgo	bzr	gustavo@niemeyer.net-20140331185009-fhnh3xzfdpicup0j	273
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
-launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20140305200416-7gh64vkcckre5mob	51
+launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,17 +1,17 @@
 code.google.com/p/go.crypto	hg	5478be1963aafa9025e9bf0837aff6013eb92e5b	199
-github.com/binary132/gojsonpointer	git	57ab5e9c764219a3e0c4d7759797fefdcab22e9c	
-github.com/binary132/gojsonreference	git	75785fb7b21f9bf2051dca600da83ff57bc6582a	
-github.com/binary132/gojsonschema	git	640782bf48d45ba2b22fd1e8a80842667c52af00	
-github.com/juju/blobstore	git	95a336cf8665ad6a7369cb620d1d2fd06f175a3a	
-github.com/juju/errgo	git	26caa7d4884f6048c5687fa44c410e5d5d95e554	
-github.com/juju/errors	git	075df0417dbcc39d24ee18248d2f8d6e3eed598b	
-github.com/juju/loggo	git	7e8c70b24b80b95b2284f09306aac0bd93588db8	
-github.com/juju/names	git	b2e06a0ab1c09f138853d1ef6b11f94ca9f7b675	
-github.com/juju/schema	git	1887e824896b58a0f376fb8517b5eebb825828b8	
-github.com/juju/testing	git	b0941ff1bf4d3db1ffbbe09f75fa8383eae5764c	
-github.com/juju/txn	git	5694f17794c492e3c8a83908f0e8b9a7cff9b9f8	
-github.com/juju/utils	git	71ae858adb3bf5cc619c3200dfbdf6762de1a94a	
-gopkg.in/juju/charm.v2	git	f6fc338cf94b02f0408ce72122fcbf6712d62bc4	
+github.com/binary132/gojsonpointer	git	57ab5e9c764219a3e0c4d7759797fefdcab22e9c
+github.com/binary132/gojsonreference	git	75785fb7b21f9bf2051dca600da83ff57bc6582a
+github.com/binary132/gojsonschema	git	640782bf48d45ba2b22fd1e8a80842667c52af00
+github.com/juju/blobstore	git	95a336cf8665ad6a7369cb620d1d2fd06f175a3a
+github.com/juju/errgo	git	26caa7d4884f6048c5687fa44c410e5d5d95e554
+github.com/juju/errors	git	075df0417dbcc39d24ee18248d2f8d6e3eed598b
+github.com/juju/loggo	git	7e8c70b24b80b95b2284f09306aac0bd93588db8
+github.com/juju/names	git	b2e06a0ab1c09f138853d1ef6b11f94ca9f7b675
+github.com/juju/schema	git	1887e824896b58a0f376fb8517b5eebb825828b8
+github.com/juju/testing	git	b0941ff1bf4d3db1ffbbe09f75fa8383eae5764c
+github.com/juju/txn	git	5694f17794c492e3c8a83908f0e8b9a7cff9b9f8
+github.com/juju/utils	git	71ae858adb3bf5cc619c3200dfbdf6762de1a94a
+gopkg.in/juju/charm.v2	git	f6fc338cf94b02f0408ce72122fcbf6712d62bc4
 labix.org/v2/mgo	bzr	gustavo@niemeyer.net-20140331185009-fhnh3xzfdpicup0j	273
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
-launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50
+launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20140305200416-7gh64vkcckre5mob	51

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -88,12 +88,18 @@ func (s *Store) AddBundle(url *charm.URL, b charm.Bundle) error {
 }
 
 func bundleCharms(data *charm.BundleData) ([]*params.CharmURL, error) {
-	urls := make([]*params.CharmURL, 0, len(data.Services))
+	// Use a map to de-duplicate the URL list: a bundle can include services
+	// deployed by the same charm.
+	urlMap := make(map[string]*params.CharmURL)
 	for _, service := range data.Services {
 		url, err := params.ParseURL(service.Charm)
 		if err != nil {
 			return nil, err
 		}
+		urlMap[url.String()] = url
+	}
+	urls := make([]*params.CharmURL, 0, len(urlMap))
+	for _, url := range urlMap {
 		urls = append(urls, url)
 	}
 	return urls, nil

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/charmstore/internal/mongodoc"
 	"github.com/juju/charmstore/internal/router"
+	"github.com/juju/charmstore/params"
 )
 
 // Store represents the underlying charm store data store.
@@ -32,9 +33,10 @@ func NewStore(db *mgo.Database) *Store {
 // The charm does not have any associated content.
 // TODO fix this to add content too.
 func (s *Store) AddCharm(url *charm.URL, c charm.Charm) error {
+	charmUrl := (*params.CharmURL)(url)
 	return s.DB.Entities().Insert(&mongodoc.Entity{
-		URL:                     url,
-		BaseURL:                 baseURL(url),
+		URL:                     charmUrl,
+		BaseURL:                 baseURL(charmUrl),
 		CharmMeta:               c.Meta(),
 		CharmConfig:             c.Config(),
 		CharmActions:            c.Actions(),
@@ -56,9 +58,10 @@ func interfacesForRelations(rels map[string]charm.Relation) []string {
 	return result
 }
 
-func baseURL(url *charm.URL) *charm.Reference {
-	newURL := url.Reference
+func baseURL(url *params.CharmURL) *params.CharmURL {
+	newURL := *url
 	newURL.Revision = -1
+	newURL.Series = ""
 	return &newURL
 }
 
@@ -69,7 +72,31 @@ var errNotImplemented = fmt.Errorf("not implemented")
 // The bundle does not have any associated content.
 // TODO fix this to add content too.
 func (s *Store) AddBundle(url *charm.URL, b charm.Bundle) error {
-	return errNotImplemented
+	charmUrl := (*params.CharmURL)(url)
+	bundleData := b.Data()
+	urls, err := bundleCharms(bundleData)
+	if err != nil {
+		return err
+	}
+	return s.DB.Entities().Insert(&mongodoc.Entity{
+		URL:          charmUrl,
+		BaseURL:      baseURL(charmUrl),
+		BundleData:   bundleData,
+		BundleReadMe: b.ReadMe(),
+		BundleCharms: urls,
+	})
+}
+
+func bundleCharms(data *charm.BundleData) ([]*params.CharmURL, error) {
+	urls := make([]*params.CharmURL, 0, len(data.Services))
+	for _, service := range data.Services {
+		url, err := params.ParseURL(service.Charm)
+		if err != nil {
+			return nil, err
+		}
+		urls = append(urls, url)
+	}
+	return urls, nil
 }
 
 // StoreDatabase wraps an mgo.DB ands adds a few convenience methods.

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"gopkg.in/juju/charm.v2"
+
+	"github.com/juju/charmstore/params"
 )
 
 // Entity holds the in-database representation of charm or bundle's
@@ -11,12 +13,12 @@ import (
 type Entity struct {
 	// URL holds the fully specified URL of the charm or bundle.
 	// e.g. cs:precise/wordpress-34, cs:~user/quantal/foo-2
-	URL *charm.URL `bson:"_id"`
+	URL *params.CharmURL `bson:"_id"`
 
 	// BaseURL holds the reference URL of the charm or bundle
 	// (this omits the series and revision from URL)
 	// e.g. cs:wordpress, cs:~user/foo
-	BaseURL *charm.Reference
+	BaseURL *params.CharmURL
 
 	Sha256 string // This is also used as a blob reference.
 	Size   int64
@@ -43,7 +45,7 @@ type Entity struct {
 	// BundleCharms includes all the charm URLs referenced
 	// by the bundle, including base URLs where they are
 	// not already included.
-	BundleCharms []*charm.URL
+	BundleCharms []*params.CharmURL
 
 	// TODO Add fields denormalized for search purposes
 	// and search ranking field(s).

--- a/params/package_test.go
+++ b/params/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package params_test
+
+import (
+	"testing"
+
+	gc "launchpad.net/gocheck"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/params/url.go
+++ b/params/url.go
@@ -1,0 +1,73 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package params
+
+import (
+	"encoding/json"
+
+	"gopkg.in/juju/charm.v2"
+	"labix.org/v2/mgo/bson"
+)
+
+// CharmURL represents a charm or bundle URL. In the charm case, the URL may
+// not include the series part.
+// TODO(frankban): this type can be removed after changing charm.URL to be
+// more tolerant when de-serializing series-less URLs.
+type CharmURL charm.URL
+
+func (u *CharmURL) MarshalJSON() ([]byte, error) {
+	url := (*charm.URL)(u)
+	return url.MarshalJSON()
+}
+
+func (u *CharmURL) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	url, err := ParseURL(s)
+	if err != nil {
+		return err
+	}
+	*u = *url
+	return nil
+}
+
+// GetBSON turns u into a bson.Getter so it can be saved directly
+// on a MongoDB database with mgo.
+func (u *CharmURL) GetBSON() (interface{}, error) {
+	url := (*charm.URL)(u)
+	return url.GetBSON()
+}
+
+// SetBSON turns u into a bson.Setter so it can be loaded directly
+// from a MongoDB database with mgo.
+func (u *CharmURL) SetBSON(raw bson.Raw) error {
+	if raw.Kind == 10 {
+		return bson.SetZero
+	}
+	var s string
+	err := raw.Unmarshal(&s)
+	if err != nil {
+		return err
+	}
+	url, err := ParseURL(s)
+	if err != nil {
+		return err
+	}
+	*u = *url
+	return nil
+}
+
+// ParseURL turns a charm or bundle URL string into a CharmURL.
+func ParseURL(urlStr string) (*CharmURL, error) {
+	ref, series, err := charm.ParseReference(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	return &CharmURL{
+		Reference: ref,
+		Series:    series,
+	}, nil
+}

--- a/params/url_test.go
+++ b/params/url_test.go
@@ -1,0 +1,93 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package params_test
+
+import (
+	"encoding/json"
+
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"labix.org/v2/mgo/bson"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/charmstore/params"
+)
+
+type urlSuite struct {
+	testing.IsolationSuite
+	charmURL *params.CharmURL
+}
+
+var _ = gc.Suite(&urlSuite{})
+
+type urlDoc struct {
+	URL *params.CharmURL
+}
+
+var urlCodecs = []struct {
+	name      string
+	data      string
+	marshal   func(interface{}) ([]byte, error)
+	unmarshal func([]byte, interface{}) error
+}{{
+	name:      "bson",
+	data:      "%\x00\x00\x00\x02url\x00\x17\x00\x00\x00cs:trusty/wordpress-42\x00\x00",
+	marshal:   bson.Marshal,
+	unmarshal: bson.Unmarshal,
+}, {
+	name:      "json",
+	data:      `{"URL":"cs:trusty/wordpress-42"}`,
+	marshal:   json.Marshal,
+	unmarshal: json.Unmarshal,
+}}
+
+func (s *urlSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+	charmURL, err := params.ParseURL("cs:trusty/wordpress-42")
+	c.Assert(err, gc.IsNil)
+	s.charmURL = charmURL
+}
+
+func (s *urlSuite) TestMarshal(c *gc.C) {
+	for _, codec := range urlCodecs {
+		c.Logf("codec %s", codec.name)
+		serialized, err := codec.marshal(urlDoc{s.charmURL})
+		c.Assert(err, gc.IsNil)
+		c.Assert(string(serialized), gc.Equals, codec.data)
+	}
+}
+
+func (s *urlSuite) TestUnmarshal(c *gc.C) {
+	for _, codec := range urlCodecs {
+		c.Logf("codec %s", codec.name)
+		var doc urlDoc
+		err := codec.unmarshal([]byte(codec.data), &doc)
+		c.Assert(err, gc.IsNil)
+		c.Assert(doc.URL, jc.DeepEquals, s.charmURL)
+	}
+}
+
+func (s *urlSuite) TestParseURLFull(c *gc.C) {
+	url, err := params.ParseURL("cs:precise/django-42")
+	c.Assert(err, gc.IsNil)
+	c.Assert(url.Schema, gc.Equals, "cs")
+	c.Assert(url.Series, gc.Equals, "precise")
+	c.Assert(url.Name, gc.Equals, "django")
+	c.Assert(url.Revision, gc.Equals, 42)
+}
+
+func (s *urlSuite) TestParseURLPartial(c *gc.C) {
+	url, err := params.ParseURL("wordpress")
+	c.Assert(err, gc.IsNil)
+	c.Assert(url.Schema, gc.Equals, "cs")
+	c.Assert(url.Series, gc.Equals, "")
+	c.Assert(url.Name, gc.Equals, "wordpress")
+	c.Assert(url.Revision, gc.Equals, -1)
+}
+
+func (s *urlSuite) TestParseURLError(c *gc.C) {
+	url, err := params.ParseURL("bad:wordpress")
+	c.Assert(url, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `charm URL has invalid schema: "bad:wordpress"`)
+}


### PR DESCRIPTION
Also implement a cstomized CharmURL type so that we can easily deal with partial URLS.

Updated dependencies so that we are now using the updated names/charm.v2 packages.
