### PR TITLE
internal/v4: resolve ids

### DIFF
--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -9,11 +9,11 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/juju/blobstore"
+	"github.com/juju/errors"
 	"labix.org/v2/mgo"
 
-	"github.com/juju/blobstore"
 	"github.com/juju/charmstore/internal/multihash"
-	"github.com/juju/errors"
 )
 
 type ReadSeekCloser interface {

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -71,7 +71,10 @@ func matchURL(url, pattern *charm.URL) bool {
 	if pattern.Revision != -1 && url.Revision != pattern.Revision {
 		return false
 	}
-	return true
+	// Check the name for completness only - the
+	// query should only be returning URLs with
+	// matching names.
+	return url.Name == pattern.Name
 }
 
 func interfacesForRelations(rels map[string]charm.Relation) []string {

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -50,14 +50,15 @@ func (s *Store) AddCharm(url *charm.URL, c charm.Charm) error {
 func (s *Store) ExpandURL(url *charm.URL) ([]*charm.URL, error) {
 	var docs []mongodoc.Entity
 	err := s.DB.Entities().Find(bson.D{{
-		}}).Select(bson.D{{"_id", 1}}).All(&docs)
+		"baseurl", baseURL((*params.CharmURL)(url)),
+	}}).Select(bson.D{{"_id", 1}}).All(&docs)
 	if err != nil {
 		return nil, err
 	}
 	urls := make([]*charm.URL, 0, len(docs))
 	for _, doc := range docs {
-		if matchURL(doc.URL, url) {
-			urls = append(urls, doc.URL)
+		if matchURL((*charm.URL)(doc.URL), url) {
+			urls = append(urls, (*charm.URL)(doc.URL))
 		}
 	}
 	return urls, nil

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -37,7 +37,7 @@ func (s *StoreSuite) TestAddCharm(c *gc.C) {
 	sort.Strings(doc.CharmRequiredInterfaces)
 	c.Assert(doc, jc.DeepEquals, mongodoc.Entity{
 		URL:                     (*params.CharmURL)(url),
-		BaseURL:                 mustParseURL("cs:wordpress"),
+		BaseURL:                 (*params.CharmURL)(mustParseURL("cs:wordpress")),
 		CharmMeta:               wordpress.Meta(),
 		CharmActions:            wordpress.Actions(),
 		CharmConfig:             wordpress.Config(),
@@ -63,12 +63,12 @@ func (s *StoreSuite) TestAddBundle(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(doc, jc.DeepEquals, mongodoc.Entity{
 		URL:          (*params.CharmURL)(url),
-		BaseURL:      mustParseURL("cs:wordpress-simple"),
+		BaseURL:      (*params.CharmURL)(mustParseURL("cs:wordpress-simple")),
 		BundleData:   bundle.Data(),
 		BundleReadMe: bundle.ReadMe(),
 		BundleCharms: []*params.CharmURL{
-			mustParseURL("wordpress"),
-			mustParseURL("mysql"),
+			(*params.CharmURL)(mustParseURL("wordpress")),
+			(*params.CharmURL)(mustParseURL("mysql")),
 		},
 	})
 
@@ -163,15 +163,5 @@ func mustParseURL(s string) *charm.URL {
 	return &charm.URL{
 		Reference: ref,
 		Series:    series,
-	}
-}
-
-func mustParseReference(urlStr string) *charm.Reference {
-	ref, _, err := charm.ParseReference(urlStr)
-	if err != nil {
-		panic(err)
-	}
-	return &params.CharmURL{
-		Reference: ref,
 	}
 }

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -57,7 +57,8 @@ func New(store *charmstore.Store) http.Handler {
 }
 
 // ResolveURL resolves the series and revision of the given URL
-// if unspecified.
+// if either is unspecified by filling them out with information retrieved
+// from the store.
 func ResolveURL(store *charmstore.Store, url *charm.URL) error {
 	if url.Series != "" && url.Revision != -1 {
 		return nil

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -40,10 +40,11 @@ func (s *APISuite) SetUpTest(c *gc.C) {
 	s.srv = srv
 }
 
-func (s *APISuite) addCharmToStore(c *gc.C) (*charm.URL, charm.Charm) {
-	url := charm.MustParseURL("cs:precise/wordpress-23")
-	wordpress := charmtesting.Charms.CharmDir("wordpress")
-	err := s.store.AddCharm(url, wordpress)
+func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.URL, charm.Charm) {
+	url, err := charm.ParseURL(curl)
+	c.Assert(err, gc.IsNil)
+	wordpress := charmtesting.Charms.CharmDir(charmName)
+	err = s.store.AddCharm(url, wordpress)
 	c.Assert(err, gc.IsNil)
 	return url, wordpress
 }
@@ -53,7 +54,7 @@ func (s *APISuite) TestArchive(c *gc.C) {
 }
 
 func (s *APISuite) TestMetaCharmConfig(c *gc.C) {
-	url, wordpress := s.addCharmToStore(c)
+	url, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/meta/charm-config", "", http.StatusOK, wordpress.Config())
 
 	type includeMetadata struct {
@@ -74,7 +75,7 @@ func (s *APISuite) TestMetaCharmConfigFails(c *gc.C) {
 }
 
 func (s *APISuite) TestMetaCharmMetadata(c *gc.C) {
-	url, wordpress := s.addCharmToStore(c)
+	url, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/meta/charm-metadata", "", http.StatusOK, wordpress.Meta())
 
 	type includeMetadata struct {
@@ -89,9 +90,86 @@ func (s *APISuite) TestMetaCharmMetadata(c *gc.C) {
 	})
 }
 
+func (s *APISuite) TestIdsAreResolved(c *gc.C) {
+	// This is just testing that ResolveURL is actually
+	// passed to the router. Given how Router is
+	// defined, and the ResolveURL tests, this should
+	// be sufficient to "join the dots".
+	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
+	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/wordpress/meta/charm-metadata", "", http.StatusOK, wordpress.Meta())
+}
+
 func (s *APISuite) TestMetaCharmMetadataFails(c *gc.C) {
 	expected := params.Error{Message: router.ErrNotFound.Error()}
 	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/meta/charm-metadata", "", http.StatusInternalServerError, expected)
+}
+
+var resolveURLTests = []struct {
+	url      string
+	expect   string
+	notFound bool
+}{{
+	url:    "wordpress",
+	expect: "cs:trusty/wordpress-25",
+}, {
+	url:    "precise/wordpress",
+	expect: "cs:precise/wordpress-24",
+}, {
+	url:    "utopic/bigdata",
+	expect: "cs:utopic/bigdata-10",
+}, {
+	url:    "bigdata",
+	expect: "cs:utopic/bigdata-10",
+}, {
+	url:    "wordpress-24",
+	expect: "cs:trusty/wordpress-24",
+}, {
+	url:    "bundlelovin",
+	expect: "cs:bundle/bundlelovin-10",
+}, {
+	url:      "wordpress-26",
+	notFound: true,
+}, {
+	url:      "foo",
+	notFound: true,
+}, {
+	url:      "trusty/bigdata",
+	notFound: true,
+}}
+
+func (s *APISuite) TestResolveURL(c *gc.C) {
+	s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
+	s.addCharm(c, "wordpress", "cs:precise/wordpress-24")
+	s.addCharm(c, "wordpress", "cs:trusty/wordpress-24")
+	s.addCharm(c, "wordpress", "cs:trusty/wordpress-25")
+	s.addCharm(c, "wordpress", "cs:utopic/wordpress-10")
+	s.addCharm(c, "wordpress", "cs:saucy/bigdata-99")
+	s.addCharm(c, "wordpress", "cs:utopic/bigdata-10")
+	s.addCharm(c, "wordpress", "cs:bundle/bundlelovin-10")
+	s.addCharm(c, "wordpress", "cs:bundle/wordpress-10")
+
+	for i, test := range resolveURLTests {
+		c.Logf("test %d: %s", i, test.url)
+		url := mustParseURL(test.url)
+		err := v4.ResolveURL(s.store, url)
+		if test.notFound {
+			c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for ".*"`)
+			continue
+		}
+		c.Assert(err, gc.IsNil)
+		c.Assert(url.String(), gc.Equals, test.expect)
+	}
+}
+
+func mustParseURL(s string) *charm.URL {
+	ref, series, err := charm.ParseReference(s)
+	if err != nil {
+		panic(err)
+	}
+	return &charm.URL{
+		Reference: ref,
+		Series:    series,
+	}
 }
 
 func assertNotImplemented(c *gc.C, h http.Handler, path string) {


### PR DESCRIPTION
This allows all charm store paths to contain charm URLs that are
not fully specified.
