### PR TITLE
internal/router: support for efficient include retrieval

### DIFF
--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/juju/charmstore/internal/blobstore"
 	"github.com/juju/charmstore/internal/mongodoc"
-	"github.com/juju/charmstore/internal/router"
 	"github.com/juju/charmstore/params"
 )
 
@@ -25,12 +24,10 @@ type Store struct {
 
 // NewStore returns a Store that uses the given database.
 func NewStore(db *mgo.Database) *Store {
-	s := &Store{
+	return &Store{
 		DB:        StoreDatabase{db},
 		BlobStore: blobstore.New(db, "entitystore"),
 	}
-	router.RegisterCollection(s.DB.Entities().Name, (*mongodoc.Entity)(nil))
-	return s
 }
 
 func (s *Store) putArchive(archive blobstore.ReadSeekCloser) (string, int64, error) {

--- a/internal/router/fieldinclude.go
+++ b/internal/router/fieldinclude.go
@@ -11,7 +11,7 @@ import (
 type FieldQueryFunc func(id *charm.URL, selector map[string]int) (interface{}, error)
 
 // A FieldHandlerFunc returns some data from the given document. The
-// document will have been returned from an earlier call totp the
+// document will have been returned from an earlier call to the
 // associated QueryFunc.
 type FieldHandlerFunc func(doc interface{}, id *charm.URL, path string, flags url.Values) (interface{}, error)
 

--- a/internal/router/fieldinclude.go
+++ b/internal/router/fieldinclude.go
@@ -1,0 +1,77 @@
+package router
+
+import (
+	"net/url"
+
+	"gopkg.in/juju/charm.v2"
+)
+
+// A FieldQueryFunc is used to retrieve a metadata document for the given URL,
+// selecting only those fields specified in keys of the given selector.
+type FieldQueryFunc func(id *charm.URL, selector map[string]int) (interface{}, error)
+
+// A FieldHandlerFunc returns some data from the given document. The
+// document will have been returned from an earlier call totp the
+// associated QueryFunc.
+type FieldHandlerFunc func(doc interface{}, id *charm.URL, path string, flags url.Values) (interface{}, error)
+
+// FieldIncludeHandler returns a BulkIncludeHandler that will perform
+// only a single database query for several requests. The given key is
+// used to group together similar FieldIncludeHandlers (the same query
+// should be generated for a given key). The given query is used to
+// retrieve the document from the database, and the given handle
+// function is used to actually retrieve the metadata after the query.
+//
+// The fields specify which fields are required by the given handler.
+// The fields passed to the query will be the union of all fields found
+// in all the handlers in the bulk request.
+func FieldIncludeHandler(key interface{}, q FieldQueryFunc, fields []string, handle FieldHandlerFunc) BulkIncludeHandler {
+	return &fieldIncludeHandler{
+		key:    key,
+		query:  q,
+		fields: fields,
+		handle: handle,
+	}
+}
+
+type fieldIncludeHandler struct {
+	key    interface{}
+	query  FieldQueryFunc
+	fields []string
+	handle FieldHandlerFunc
+}
+
+func (h *fieldIncludeHandler) Key() interface{} {
+	return h.key
+}
+
+func (h *fieldIncludeHandler) Handle(hs []BulkIncludeHandler, id *charm.URL, paths []string, flags url.Values) ([]interface{}, error) {
+	funcs := make([]FieldHandlerFunc, len(hs))
+	selector := make(map[string]int)
+	// Extract the handler functions and union all the fields.
+	for i, h := range hs {
+		h := h.(*fieldIncludeHandler)
+		funcs[i] = h.handle
+		for _, field := range h.fields {
+			selector[field] = 1
+		}
+	}
+	// Make the single query.
+	doc, err := h.query(id, selector)
+	if err != nil {
+		return nil, err
+	}
+	// Call all the handlers with the resulting query document
+	results := make([]interface{}, len(hs))
+	for i, f := range funcs {
+		var err error
+		results[i], err = f(doc, id, paths[i], flags)
+		if err != nil {
+			// TODO correlate error with handler (perhaps return
+			// an error that identifies the slice position of the handler that
+			// failed
+			return nil, err
+		}
+	}
+	return results, nil
+}

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -87,15 +87,16 @@ type entityHandlerFunc func(entity *mongodoc.Entity, id *charm.URL, path string,
 // entityHandler returns a handler that calls f with a *mongodoc.Entity that
 // contains at least the given fields.
 func (h *handler) entityHandler(f entityHandlerFunc, fields ...string) router.BulkIncludeHandler {
+	handle := func(doc interface{}, id *charm.URL, path string, flags url.Values) (interface{}, error) {
+		edoc := doc.(*mongodoc.Entity)
+		return f(edoc, id, path, flags)
+	}
 	type entityHandlerKey struct{}
 	return router.FieldIncludeHandler(
 		entityHandlerKey{},
 		h.entityQuery,
 		fields,
-		func(doc interface{}, id *charm.URL, path string, flags url.Values) (interface{}, error) {
-			edoc := doc.(*mongodoc.Entity)
-			return f(edoc, id, path, flags)
-		},
+		handle,
 	)
 }
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -150,32 +150,34 @@ var errorTests = []struct {
 	expected error
 	path     string
 }{{
-	name:     "MetaCharmConfig: charm not found",
+	name:     "charm-config: charm not found",
 	expected: router.ErrNotFound,
-	path:     "/precise/wordpress-23/meta/charm-config",
+	path:     "/precise/nothing-23/meta/charm-config",
 }, {
-	name:     "MetaCharmConfig: not relevant",
+	name:     "charm-config: not relevant",
 	expected: v4.ErrMetadataNotRelevant,
 	path:     "/bundle/wordpress-simple-42/meta/charm-config",
 }, {
-	name:     "MetaCharmMetadata: charm not found",
+	name:     "charm-metadata: charm not found",
 	expected: router.ErrNotFound,
-	path:     "/precise/wordpress-23/meta/charm-metadata",
+	path:     "/precise/nothing-23/meta/charm-metadata",
 }, {
-	name:     "MetaCharmMetadata: not relevant",
+	name:     "charm-config: not relevant",
 	expected: v4.ErrMetadataNotRelevant,
 	path:     "/bundle/wordpress-simple-42/meta/charm-config",
 }, {
-	name:     "MetaBundleMetadata: bundle not found",
+	name:     "bundle-metadata: bundle not found",
 	expected: router.ErrNotFound,
 	path:     "/bundle/django-app-23/meta/bundle-metadata",
 }, {
-	name:     "MetaBundleMetadata: not relevant",
+	name:     "bundle-metadata: not relevant",
 	expected: v4.ErrMetadataNotRelevant,
-	path:     "/trusty/django-42/meta/bundle-metadata",
+	path:     "/precise/wordpress-23/meta/bundle-metadata",
 }}
 
 func (s *APISuite) TestError(c *gc.C) {
+	s.addBundle(c, "wordpress", "cs:bundle/wordpress-simple-42")
+	s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	for i, test := range errorTests {
 		c.Logf("%d: %s", i, test.name)
 		expectedError := params.Error{Message: test.expected.Error()}


### PR DESCRIPTION
We drop the ItemGetter logic - it was more indirect
and inefficient than necessary - and introduce the
notion of a BulkIncludeHandler which knows how
to group itself with other like-minded handlers
to make a single shared request.

This has the nice side effect that the RegisterCollection
magic is no longer needed, and the shared request
can be anything we like. The router no longer needs
mgo as a dependency.
