### PR TITLE
internal/router: handle not-found metadata as newly specified in charm API document

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 
 	charm "gopkg.in/juju/charm.v2"
@@ -222,6 +223,7 @@ func (r *Router) metaNames() []string {
 	for name := range r.handlers.Meta {
 		names = append(names, strings.TrimSuffix(name, "/"))
 	}
+	sort.Strings(names)
 	return names
 }
 

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -173,7 +173,7 @@ var routerTests = []struct {
 	},
 	urlStr:     "http://example.com/precise/wordpress-42/meta",
 	expectCode: http.StatusOK,
-	expectBody: []string{"foo", "bar"},
+	expectBody: []string{"bar", "foo"},
 }, {
 	about: "meta handler",
 	handlers: Handlers{


### PR DESCRIPTION
Also drive-by fix untested meta listing endpoint and add test for it.
