### PR TITLE
internal/v4: refactor tests

### DIFF
--- a/_old/server_test.go
+++ b/_old/server_test.go
@@ -15,7 +15,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/juju/charm.v2"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore"

--- a/_old/store.go
+++ b/_old/store.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/juju/loggo"
 	"gopkg.in/juju/charm.v2"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 var logger = loggo.GetLogger("juju.store")

--- a/_old/store_test.go
+++ b/_old/store_test.go
@@ -17,7 +17,7 @@ import (
 	jujutesting "github.com/juju/testing"
 	"gopkg.in/juju/charm.v2"
 	charmtesting "gopkg.in/juju/charm.v2/testing"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore"

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,17 +1,17 @@
-code.google.com/p/go.crypto	hg	5478be1963aafa9025e9bf0837aff6013eb92e5b	199
-github.com/juju/blobstore	git	95a336cf8665ad6a7369cb620d1d2fd06f175a3a	
-github.com/juju/errgo	git	26caa7d4884f6048c5687fa44c410e5d5d95e554	
-github.com/juju/errors	git	075df0417dbcc39d24ee18248d2f8d6e3eed598b	
+code.google.com/p/go.crypto	hg	aa2644fe4aa50e3b38d75187b4799b1f0c9ddcef	212
+github.com/juju/blobstore	git	cb12cc93f02a9b83d4f8cc635b505d8423be4181	
+github.com/juju/errgo	git	2cf7b553faddc588f903020c33e71c527d5e0838	
+github.com/juju/errors	git	11f260fcce20d158a2c68d6d2a7fb6b98e83b658	
 github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	
 github.com/juju/gojsonreference	git	0673d58f64bacac2db34c7d1e87a599d58923981	
 github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098	
-github.com/juju/loggo	git	7e8c70b24b80b95b2284f09306aac0bd93588db8	
-github.com/juju/names	git	dcbff5554ce4e75cbce298a5283883eaca0b2444	
-github.com/juju/schema	git	1887e824896b58a0f376fb8517b5eebb825828b8	
-github.com/juju/testing	git	b0941ff1bf4d3db1ffbbe09f75fa8383eae5764c	
-github.com/juju/txn	git	5694f17794c492e3c8a83908f0e8b9a7cff9b9f8	
-github.com/juju/utils	git	71ae858adb3bf5cc619c3200dfbdf6762de1a94a	
-gopkg.in/juju/charm.v2	git	72fd4e827c9bed2d46290884443f1eaf559c23e3	
-labix.org/v2/mgo	bzr	gustavo@niemeyer.net-20140331185009-fhnh3xzfdpicup0j	273
+github.com/juju/loggo	git	158009fb40c4a52b3d2c23eb56e72859cfc5321a	
+github.com/juju/names	git	93fc8cbf8111c11d4ff47e603f668a0e29fb7cec	
+github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	
+github.com/juju/testing	git	8bdbb45d87dd9724c254eb6afeacd84b127d7e76	
+github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
+github.com/juju/utils	git	7f3110a0b4f01e5800e72b50cc92c8e9de4ea658	
+gopkg.in/juju/charm.v2	git	ffe7392a3c6128c088b05d681fad336c4d3a8c22	
+gopkg.in/mgo.v2	git	d6023fc8b7c4dee09548b307d611aad734796e3b	
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
 launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50

--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/juju/blobstore"
 	"github.com/juju/errors"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/charmstore/internal/multihash"
 )

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 )
 
 // NewAPIHandler returns a new API handler that

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -8,8 +8,8 @@ import (
 	"io"
 
 	"gopkg.in/juju/charm.v2"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/charmstore/internal/blobstore"
 	"github.com/juju/charmstore/internal/mongodoc"

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -14,7 +14,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/juju/charm.v2"
 	"gopkg.in/juju/charm.v2/testing"
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/blobstore"

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -360,8 +360,8 @@ var routerTests = []struct {
 	urlStr: "http://example.com/precise/wordpress-42/meta/any?include=ok&include=nil",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
-			"ok":  testMetaHandler,
-			"nil": constMetaHandler(nil),
+			"ok":       testMetaHandler,
+			"nil":      constMetaHandler(nil),
 			"typednil": constMetaHandler((*struct{})(nil)),
 		},
 	},

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/mongodoc"
 	"github.com/juju/charmstore/internal/router"
-	"github.com/juju/charmstore/params"
 )
 
 type handler struct {
@@ -144,8 +143,6 @@ func preferredURL(url0, url1 *charm.URL) bool {
 	return ltsReleases[url0.Series]
 }
 
-var ErrMetadataNotRelevant = fmt.Errorf("metadata not relevant for the given entity")
-
 var errNotImplemented = fmt.Errorf("method not implemented")
 
 // GET stats/counter/key[:key]...?[by=unit]&start=date][&stop=date][&list=1]
@@ -208,18 +205,12 @@ func (h *handler) serveArchiveFile(charmId *charm.URL, w http.ResponseWriter, re
 // GET id/meta/charm-metadata
 // http://tinyurl.com/poeoulw
 func (h *handler) metaCharmMetadata(entity *mongodoc.Entity, id *charm.URL, path string, flags url.Values) (interface{}, error) {
-	if params.IsBundle(id) {
-		return nil, ErrMetadataNotRelevant
-	}
 	return entity.CharmMeta, nil
 }
 
 // GET id/meta/bundle-metadata
 // http://tinyurl.com/ozshbtb
 func (h *handler) metaBundleMetadata(entity *mongodoc.Entity, id *charm.URL, path string, flags url.Values) (interface{}, error) {
-	if !params.IsBundle(id) {
-		return nil, ErrMetadataNotRelevant
-	}
 	return entity.BundleData, nil
 }
 
@@ -232,18 +223,12 @@ func (h *handler) metaManifest(id *charm.URL, path string, flags url.Values) (in
 // GET id/meta/charm-actions
 // http://tinyurl.com/kfd2h34
 func (h *handler) metaCharmActions(entity *mongodoc.Entity, id *charm.URL, path string, flags url.Values) (interface{}, error) {
-	if params.IsBundle(id) {
-		return nil, ErrMetadataNotRelevant
-	}
 	return entity.CharmActions, nil
 }
 
 // GET id/meta/charm-config
 // http://tinyurl.com/oxxyujx
 func (h *handler) metaCharmConfig(entity *mongodoc.Entity, id *charm.URL, path string, flags url.Values) (interface{}, error) {
-	if params.IsBundle(id) {
-		return nil, ErrMetadataNotRelevant
-	}
 	return entity.CharmConfig, nil
 }
 

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 
 	"gopkg.in/juju/charm.v2"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/mongodoc"

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -4,15 +4,21 @@
 package v4_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 	"testing"
 
 	jujutesting "github.com/juju/testing"
 	"gopkg.in/juju/charm.v2"
 	charmtesting "gopkg.in/juju/charm.v2/testing"
+	"labix.org/v2/mgo/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/mongodoc"
 	"github.com/juju/charmstore/internal/router"
 	"github.com/juju/charmstore/internal/storetesting"
 	"github.com/juju/charmstore/internal/v4"
@@ -40,49 +46,123 @@ func (s *APISuite) SetUpTest(c *gc.C) {
 	s.srv = srv
 }
 
-func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.URL, charm.Charm) {
-	url, err := charm.ParseURL(curl)
-	c.Assert(err, gc.IsNil)
-	wordpress := charmtesting.Charms.CharmDir(charmName)
-	err = s.store.AddCharm(url, wordpress)
-	c.Assert(err, gc.IsNil)
-	return url, wordpress
+type metaEndpoint struct {
+	name       string
+	exclusive  int
+	bundleOnly bool
+	get        func(*charmstore.Store, *charm.URL) (interface{}, error)
 }
 
-func (s *APISuite) addBundle(c *gc.C, bundleName string, curl string) (*charm.URL, charm.Bundle) {
-	url := charm.MustParseURL(curl)
-	bundle := charmtesting.Charms.BundleDir(bundleName)
-	err := s.store.AddBundle(url, bundle)
-	c.Assert(err, gc.IsNil)
-	return url, bundle
-}
+const (
+	charmOnly = iota + 1
+	bundleOnly
+)
+
+var metaEndpoints = []metaEndpoint{{
+	name:      "charm-config",
+	exclusive: charmOnly,
+	get:       entityFieldGetter("CharmConfig"),
+}, {
+	name:      "charm-metadata",
+	exclusive: charmOnly,
+	get:       entityFieldGetter("CharmMeta"),
+}, {
+	name:      "bundle-metadata",
+	exclusive: bundleOnly,
+	get:       entityFieldGetter("BundleData"),
+}, {
+	name:      "charm-actions",
+	exclusive: charmOnly,
+	get:       entityFieldGetter("CharmActions"),
+}}
 
 func (s *APISuite) TestArchive(c *gc.C) {
 	assertNotImplemented(c, s.srv, "precise/wordpress-23/archive")
 }
 
-func (s *APISuite) TestMetaCharmConfig(c *gc.C) {
-	url, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
-	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/meta/charm-config", "", http.StatusOK, wordpress.Config())
-
-	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/meta/any?include=charm-config", "", http.StatusOK, &params.MetaAnyResponse{
-		Id: url,
-		Meta: map[string]interface{}{
-			"charm-config": wordpress.Config(),
-		},
-	})
+var testEntities = []string{
+	// A stock charm.
+	"cs:precise/wordpress-23",
+	// A stock bundle.
+	"cs:bundle/wordpress-42",
+	// A charm with some actions.
+	"cs:precise/dummy-10",
 }
 
-func (s *APISuite) TestMetaCharmMetadata(c *gc.C) {
-	url, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
-	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/meta/charm-metadata", "", http.StatusOK, wordpress.Meta())
+func (s *APISuite) addTestEntities(c *gc.C) []*charm.URL {
+	urls := make([]*charm.URL, len(testEntities))
+	for i, e := range testEntities {
+		url := charm.MustParseURL(e)
+		if url.Series == "bundle" {
+			s.addBundle(c, url.Name, e)
+		} else {
+			s.addCharm(c, url.Name, e)
+		}
+		urls[i] = url
+	}
+	return urls
+}
 
-	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/meta/any?include=charm-metadata", "", http.StatusOK, params.MetaAnyResponse{
-		Id: url,
-		Meta: map[string]interface{}{
-			"charm-metadata": wordpress.Meta(),
-		},
-	})
+func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
+	urls := s.addTestEntities(c)
+	for i, ep := range metaEndpoints {
+		c.Logf("test %d. %s", i, ep.name)
+		tested := false
+		for _, url := range urls {
+			charmId := strings.TrimPrefix(url.String(), "cs:")
+			storeURL := "http://0.1.2.3/v4/" + charmId + "/meta/" + ep.name
+			expectData, err := ep.get(s.store, url)
+			c.Assert(err, gc.IsNil)
+			c.Logf("	expected data for %q: %#v", url, expectData)
+			if isNull(expectData) {
+				storetesting.AssertJSONCall(c, s.srv, "GET", storeURL, "", http.StatusInternalServerError, params.Error{
+					Message: router.ErrDataNotFound.Error(),
+				})
+				continue
+			}
+			tested = true
+			storetesting.AssertJSONCall(c, s.srv, "GET", storeURL, "", http.StatusOK, expectData)
+		}
+		if !tested {
+			c.Errorf("endpoint %q is null for all endpoints, so is not properly tested", ep.name)
+		}
+	}
+}
+
+func isNull(v interface{}) bool {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(data) == "null"
+}
+
+func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
+	urls := s.addTestEntities(c)
+	for _, url := range urls {
+		charmId := strings.TrimPrefix(url.String(), "cs:")
+		var flags []string
+		expectData := params.MetaAnyResponse{
+			Id:   url,
+			Meta: make(map[string]interface{}),
+		}
+		for _, ep := range metaEndpoints {
+			flags = append(flags, "include="+ep.name)
+			isBundle := url.Series == "bundle"
+			if ep.exclusive != 0 && isBundle != (ep.exclusive == bundleOnly) {
+				// endpoint not relevant.
+				continue
+			}
+			val, err := ep.get(s.store, url)
+			c.Assert(err, gc.IsNil)
+			if val != nil {
+				expectData.Meta[ep.name] = val
+			}
+		}
+		storeURL := "http://0.1.2.3/v4/" + charmId + "/meta/any?" + strings.Join(flags, "&")
+		storetesting.AssertJSONCall(c, s.srv, "GET", storeURL, "",
+			http.StatusOK, expectData)
+	}
 }
 
 // In this test we rely on the charm.v2 testing repo package and
@@ -104,6 +184,10 @@ func (s *APISuite) TestMetaCharmActions(c *gc.C) {
 }
 
 func (s *APISuite) TestBulkMeta(c *gc.C) {
+	// We choose an arbitrary set of ids and metadata here, just to smoke-test
+	// whether the meta/any logic is hooked up correctly.
+	// Detailed tests for this feature are in the router package.
+
 	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	_, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
 	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10", "", http.StatusOK, map[string]*charm.Meta{
@@ -113,6 +197,10 @@ func (s *APISuite) TestBulkMeta(c *gc.C) {
 }
 
 func (s *APISuite) TestBulkMetaAny(c *gc.C) {
+	// We choose an arbitrary set of metadata here, just to smoke-test
+	// whether the meta/any logic is hooked up correctly.
+	// Detailed tests for this feature are in the router package.
+
 	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	mysqlURL, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
 	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10", "", http.StatusOK, map[string]params.MetaAnyResponse{
@@ -142,65 +230,10 @@ func (s *APISuite) TestIdsAreResolved(c *gc.C) {
 	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/wordpress/meta/charm-metadata", "", http.StatusOK, wordpress.Meta())
 }
 
-func (s *APISuite) TestMetaCharmMetadataFails(c *gc.C) {
+func (s *APISuite) TestMetaCharmNotFound(c *gc.C) {
 	expected := params.Error{Message: router.ErrNotFound.Error()}
-	storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/meta/charm-metadata", "", http.StatusInternalServerError, expected)
-}
-
-func (s *APISuite) TestMetaBundleMetadata(c *gc.C) {
-	url, bundle := s.addBundle(c, "wordpress", "cs:bundle/wordpress-simple-42")
-	storetesting.AssertJSONCall(c, s.srv, "GET",
-		"http://0.1.2.3/v4/bundle/wordpress-simple-42/meta/bundle-metadata",
-		"", http.StatusOK, bundle.Data())
-
-	storetesting.AssertJSONCall(c, s.srv, "GET",
-		"http://0.1.2.3/v4/bundle/wordpress-simple-42/meta/any?include=bundle-metadata",
-		"", http.StatusOK, params.MetaAnyResponse{
-			Id: url,
-			Meta: map[string]interface{}{
-				"bundle-metadata": bundle.Data(),
-			},
-		})
-}
-
-var errorTests = []struct {
-	name     string
-	expected error
-	path     string
-}{{
-	name:     "charm-config: charm not found",
-	expected: router.ErrNotFound,
-	path:     "/precise/nothing-23/meta/charm-config",
-}, {
-	name:     "charm-config: not relevant",
-	expected: v4.ErrMetadataNotRelevant,
-	path:     "/bundle/wordpress-simple-42/meta/charm-config",
-}, {
-	name:     "charm-metadata: charm not found",
-	expected: router.ErrNotFound,
-	path:     "/precise/nothing-23/meta/charm-metadata",
-}, {
-	name:     "charm-config: not relevant",
-	expected: v4.ErrMetadataNotRelevant,
-	path:     "/bundle/wordpress-simple-42/meta/charm-config",
-}, {
-	name:     "bundle-metadata: bundle not found",
-	expected: router.ErrNotFound,
-	path:     "/bundle/django-app-23/meta/bundle-metadata",
-}, {
-	name:     "bundle-metadata: not relevant",
-	expected: v4.ErrMetadataNotRelevant,
-	path:     "/precise/wordpress-23/meta/bundle-metadata",
-}}
-
-func (s *APISuite) TestError(c *gc.C) {
-	s.addBundle(c, "wordpress", "cs:bundle/wordpress-simple-42")
-	s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
-	for i, test := range errorTests {
-		c.Logf("%d: %s", i, test.name)
-		expectedError := params.Error{Message: test.expected.Error()}
-		storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4"+test.path,
-			"", http.StatusInternalServerError, expectedError)
+	for _, ep := range metaEndpoints {
+		storetesting.AssertJSONCall(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/meta/"+ep.name, "", http.StatusInternalServerError, expected)
 	}
 }
 
@@ -276,4 +309,42 @@ func assertNotImplemented(c *gc.C, h http.Handler, path string) {
 	storetesting.AssertJSONCall(c, h, "GET", "http://0.1.2.3/v4/"+path, "", http.StatusInternalServerError, params.Error{
 		Message: "method not implemented",
 	})
+}
+
+func entityFieldGetter(fieldName string) func(*charmstore.Store, *charm.URL) (interface{}, error) {
+	return entityGetter(func(entity *mongodoc.Entity) interface{} {
+		field := reflect.ValueOf(entity).Elem().FieldByName(fieldName)
+		if !field.IsValid() {
+			panic(fmt.Errorf("entity has no field %q", fieldName))
+		}
+		return field.Interface()
+	})
+}
+
+func entityGetter(get func(*mongodoc.Entity) interface{}) func(*charmstore.Store, *charm.URL) (interface{}, error) {
+	return func(store *charmstore.Store, url *charm.URL) (interface{}, error) {
+		var doc mongodoc.Entity
+		err := store.DB.Entities().Find(bson.D{{"_id", url}}).One(&doc)
+		if err != nil {
+			return nil, err
+		}
+		return get(&doc), nil
+	}
+}
+
+func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.URL, charm.Charm) {
+	url, err := charm.ParseURL(curl)
+	c.Assert(err, gc.IsNil)
+	wordpress := charmtesting.Charms.CharmDir(charmName)
+	err = s.store.AddCharm(url, wordpress)
+	c.Assert(err, gc.IsNil)
+	return url, wordpress
+}
+
+func (s *APISuite) addBundle(c *gc.C, bundleName string, curl string) (*charm.URL, charm.Bundle) {
+	url := charm.MustParseURL(curl)
+	bundle := charmtesting.Charms.BundleDir(bundleName)
+	err := s.store.AddBundle(url, bundle)
+	c.Assert(err, gc.IsNil)
+	return url, bundle
 }

--- a/params/url.go
+++ b/params/url.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 
 	"gopkg.in/juju/charm.v2"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // IsBundle reports whether the given URL represents a bundle.

--- a/params/url_test.go
+++ b/params/url_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/juju/charm.v2"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/params"

--- a/server.go
+++ b/server.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"sort"
 
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/v4"


### PR DESCRIPTION
We create a table with an entry for each kind of metadata so
that it's easy to add new entries and new tests that
test the metadata in arbitrary configurations without
writing reams of duplicated test code.

We also fix router so that it works correctly with
typed nil data, which avoids an if statement in
every metadata handler.
