### PR TITLE
internal/v4: implement stats endpoint

### DIFF
--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/juju/errgo"
 	"gopkg.in/mgo.v2"
+
+	"github.com/juju/charmstore/internal/router"
 )
 
 // NewAPIHandler returns a new API handler that
@@ -28,13 +30,13 @@ func NewServer(db *mgo.Database, versions map[string]NewAPIHandler) (http.Handle
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot make store")
 	}
-	mux := http.NewServeMux()
+	mux := router.NewServeMux()
 	for vers, newAPI := range versions {
 		handle(mux, "/"+vers, newAPI(store))
 	}
 	return mux, nil
 }
 
-func handle(mux *http.ServeMux, path string, handler http.Handler) {
+func handle(mux *router.ServeMux, path string, handler http.Handler) {
 	mux.Handle(path+"/", http.StripPrefix(path, handler))
 }

--- a/internal/charmstore/stats_test.go
+++ b/internal/charmstore/stats_test.go
@@ -36,7 +36,7 @@ func (s *StatsSuite) TearDownTest(c *gc.C) {
 
 func (s *StatsSuite) TestSumCounters(c *gc.C) {
 	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB javascript not available")
+		c.Skip("MongoDB JavaScript not available")
 	}
 
 	req := charmstore.CounterRequest{Key: []string{"a"}}
@@ -113,7 +113,7 @@ func (s *StatsSuite) TestSumCounters(c *gc.C) {
 
 func (s *StatsSuite) TestCountersReadOnlySum(c *gc.C) {
 	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB javascript not available")
+		c.Skip("MongoDB JavaScript not available")
 	}
 
 	// Summing up an unknown key shouldn't add the key to the database.
@@ -129,7 +129,7 @@ func (s *StatsSuite) TestCountersReadOnlySum(c *gc.C) {
 
 func (s *StatsSuite) TestCountersTokenCaching(c *gc.C) {
 	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB javascript not available")
+		c.Skip("MongoDB JavaScript not available")
 	}
 
 	assertSum := func(i int, want int64) {
@@ -188,7 +188,7 @@ func (s *StatsSuite) TestCountersTokenCaching(c *gc.C) {
 
 func (s *StatsSuite) TestCounterTokenUniqueness(c *gc.C) {
 	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB javascript not available")
+		c.Skip("MongoDB JavaScript not available")
 	}
 
 	var wg0, wg1 sync.WaitGroup
@@ -213,7 +213,7 @@ func (s *StatsSuite) TestCounterTokenUniqueness(c *gc.C) {
 
 func (s *StatsSuite) TestListCounters(c *gc.C) {
 	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB javascript not available")
+		c.Skip("MongoDB JavaScript not available")
 	}
 
 	incs := [][]string{
@@ -277,7 +277,7 @@ func (s *StatsSuite) TestListCounters(c *gc.C) {
 
 func (s *StatsSuite) TestListCountersBy(c *gc.C) {
 	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB javascript not available")
+		c.Skip("MongoDB JavaScript not available")
 	}
 
 	incs := []struct {

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -106,8 +106,8 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		mux.ServeMux.ServeHTTP(w, req)
 		return
 	}
-	h, pat := mux.Handler(req)
-	if pat == "" {
+	h, pattern := mux.Handler(req)
+	if pattern == "" {
 		WriteError(w, params.ErrNotFound)
 		return
 	}

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -34,7 +34,7 @@ func HandleJSON(handle func(http.ResponseWriter, *http.Request) (interface{}, er
 	f := func(w http.ResponseWriter, req *http.Request) error {
 		val, err := handle(w, req)
 		if err != nil {
-			return errgo.Mask(err)
+			return errgo.Mask(err, errgo.Any)
 		}
 		return WriteJSON(w, http.StatusOK, val)
 	}
@@ -55,6 +55,10 @@ func WriteError(w http.ResponseWriter, err error) {
 	switch errResp.Code {
 	case params.ErrNotFound, params.ErrMetadataNotFound:
 		status = http.StatusNotFound
+	case params.ErrBadRequest:
+		status = http.StatusBadRequest
+	case params.ErrForbidden:
+		status = http.StatusForbidden
 	}
 	// TODO log writeJSON error if it happens?
 	WriteJSON(w, status, errResp)
@@ -77,4 +81,35 @@ func WriteJSON(w http.ResponseWriter, code int, val interface{}) error {
 	w.WriteHeader(code)
 	w.Write(data)
 	return nil
+}
+
+// NotFoundHandler is like http.NotFoundHandler except it
+// returns a JSON error response.
+func NotFoundHandler() http.Handler {
+	return HandleErrors(func(w http.ResponseWriter, req *http.Request) error {
+		return params.ErrNotFound
+	})
+}
+
+func NewServeMux() *ServeMux {
+	return &ServeMux{http.NewServeMux()}
+}
+
+// ServeMux is like http.ServeMux but returns
+// JSON errors when pages are not found.
+type ServeMux struct {
+	*http.ServeMux
+}
+
+func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.RequestURI == "*" {
+		mux.ServeMux.ServeHTTP(w, req)
+		return
+	}
+	h, pat := mux.Handler(req)
+	if pat == "" {
+		WriteError(w, params.ErrNotFound)
+		return
+	}
+	h.ServeHTTP(w, req)
 }

--- a/internal/storetesting/flag.go
+++ b/internal/storetesting/flag.go
@@ -1,3 +1,6 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
 package storetesting
 
 import (
@@ -7,7 +10,7 @@ import (
 	jujutesting "github.com/juju/testing"
 )
 
-var noTestMongoJs *bool = flag.Bool("notest-mongojs", false, "Disable MongoDB tests that require javascript")
+var noTestMongoJs *bool = flag.Bool("notest-mongojs", false, "Disable MongoDB tests that require JavaScript")
 
 func init() {
 	if os.Getenv("JUJU_NOTEST_MONGOJS") == "1" || jujutesting.MgoServer.WithoutV8 {
@@ -16,7 +19,7 @@ func init() {
 }
 
 // MongoJSEnabled reports whether testing code should run tests
-// that rely on Javascript inside MongoDB.
+// that rely on JavaScript inside MongoDB.
 func MongoJSEnabled() bool {
 	return !*noTestMongoJs
 }

--- a/internal/storetesting/flag.go
+++ b/internal/storetesting/flag.go
@@ -1,0 +1,22 @@
+package storetesting
+
+import (
+	"flag"
+	"os"
+
+	jujutesting "github.com/juju/testing"
+)
+
+var noTestMongoJs *bool = flag.Bool("notest-mongojs", false, "Disable MongoDB tests that require javascript")
+
+func init() {
+	if os.Getenv("JUJU_NOTEST_MONGOJS") == "1" || jujutesting.MgoServer.WithoutV8 {
+		*noTestMongoJs = true
+	}
+}
+
+// MongoJSEnabled reports whether testing code should run tests
+// that rely on Javascript inside MongoDB.
+func MongoJSEnabled() bool {
+	return !*noTestMongoJs
+}

--- a/internal/storetesting/http.go
+++ b/internal/storetesting/http.go
@@ -44,7 +44,7 @@ func AssertJSONCall(
 
 	var gotBodyVal interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &gotBodyVal)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.IsNil, gc.Commentf("json body: %q", rec.Body.Bytes()))
 
 	c.Assert(gotBodyVal, jc.DeepEquals, expectBodyVal)
 }

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -30,7 +30,8 @@ func New(store *charmstore.Store) http.Handler {
 	}
 	h.Router = router.New(&router.Handlers{
 		Global: map[string]http.Handler{
-			"stats/counter":      http.HandlerFunc(h.serveStatsCounter),
+			"stats/counter/":     router.HandleJSON(h.serveStatsCounter),
+			"stats/":             router.NotFoundHandler(),
 			"search":             http.HandlerFunc(h.serveSearch),
 			"search/interesting": http.HandlerFunc(h.serveSearchInteresting),
 			"debug":              http.HandlerFunc(h.serveDebug),
@@ -59,6 +60,10 @@ func New(store *charmstore.Store) http.Handler {
 		},
 	}, h.resolveURL)
 	return h
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h.Router.ServeHTTP(w, req)
 }
 
 // ResolveURL resolves the series and revision of the given URL
@@ -150,12 +155,6 @@ func preferredURL(url0, url1 *charm.Reference) bool {
 }
 
 var errNotImplemented = errgo.Newf("method not implemented")
-
-// GET stats/counter/key[:key]...?[by=unit]&start=date][&stop=date][&list=1]
-// http://tinyurl.com/nkdovcf
-func (h *handler) serveStatsCounter(w http.ResponseWriter, req *http.Request) {
-	router.WriteError(w, errNotImplemented)
-}
 
 // GET search[?text=text][&autocomplete=1][&filter=value…][&limit=limit][&include=meta]
 // http://tinyurl.com/qzobc69

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -33,7 +33,7 @@ func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (int
 	case "week":
 		by = charmstore.ByWeek
 	default:
-		return nil, errgo.Newf("invalid 'by' value: %q", v)
+		return nil, errgo.WithCausef(nil, params.ErrBadRequest, "invalid 'by' value: %q", v)
 	}
 	req := charmstore.CounterRequest{
 		Key:  strings.Split(base, ":"),
@@ -44,14 +44,14 @@ func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (int
 		var err error
 		req.Start, err = time.Parse("2006-01-02", v)
 		if err != nil {
-			return nil, errgo.Newf("invalid 'start' value: %q", v)
+			return nil, errgo.WithCausef(err, params.ErrBadRequest, "invalid 'start' value %q", v)
 		}
 	}
 	if v := r.Form.Get("stop"); v != "" {
 		var err error
 		req.Stop, err = time.Parse("2006-01-02", v)
 		if err != nil {
-			return nil, errgo.Notef(err, "cannot parse 'stop' value %q", v)
+			return nil, errgo.WithCausef(err, params.ErrBadRequest, "invalid 'stop' value %q", v)
 		}
 		// Cover all timestamps within the stop day.
 		req.Stop = req.Stop.Add(24*time.Hour - 1*time.Second)
@@ -65,7 +65,7 @@ func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (int
 	}
 	entries, err := s.store.Counters(&req)
 	if err != nil {
-		return nil, errgo.Newf("cannot query counters: %v", err)
+		return nil, errgo.Notef(err, "cannot query counters")
 	}
 
 	var buf []byte

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -1,0 +1,98 @@
+// Copyright 2012 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/juju/errgo"
+
+	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/params"
+)
+
+// GET stats/counter/key[:key]...?[by=unit]&start=date][&stop=date][&list=1]
+// http://tinyurl.com/nkdovcf
+func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	base := strings.TrimPrefix(r.URL.Path, "/")
+	if strings.Index(base, "/") > 0 {
+		return nil, params.ErrNotFound
+	}
+	if base == "" {
+		return nil, params.ErrForbidden
+	}
+	var by charmstore.CounterRequestBy
+	switch v := r.Form.Get("by"); v {
+	case "":
+		by = charmstore.ByAll
+	case "day":
+		by = charmstore.ByDay
+	case "week":
+		by = charmstore.ByWeek
+	default:
+		return nil, errgo.Newf("invalid 'by' value: %q", v)
+	}
+	req := charmstore.CounterRequest{
+		Key:  strings.Split(base, ":"),
+		List: r.Form.Get("list") == "1",
+		By:   by,
+	}
+	if v := r.Form.Get("start"); v != "" {
+		var err error
+		req.Start, err = time.Parse("2006-01-02", v)
+		if err != nil {
+			return nil, errgo.Newf("invalid 'start' value: %q", v)
+		}
+	}
+	if v := r.Form.Get("stop"); v != "" {
+		var err error
+		req.Stop, err = time.Parse("2006-01-02", v)
+		if err != nil {
+			return nil, errgo.Notef(err, "cannot parse 'stop' value %q", v)
+		}
+		// Cover all timestamps within the stop day.
+		req.Stop = req.Stop.Add(24*time.Hour - 1*time.Second)
+	}
+	if req.Key[len(req.Key)-1] == "*" {
+		req.Prefix = true
+		req.Key = req.Key[:len(req.Key)-1]
+		if len(req.Key) == 0 {
+			return nil, errgo.WithCausef(nil, params.ErrForbidden, "unknown key")
+		}
+	}
+	entries, err := s.store.Counters(&req)
+	if err != nil {
+		return nil, errgo.Newf("cannot query counters: %v", err)
+	}
+
+	var buf []byte
+	var items []params.Statistic
+	for i := range entries {
+		entry := &entries[i]
+		buf = buf[:0]
+		if req.List {
+			for j := range entry.Key {
+				buf = append(buf, entry.Key[j]...)
+				buf = append(buf, ':')
+			}
+			if entry.Prefix {
+				buf = append(buf, '*')
+			} else {
+				buf = buf[:len(buf)-1]
+			}
+		}
+		stat := params.Statistic{
+			Key:   string(buf),
+			Count: entry.Count,
+		}
+		if !entry.Time.IsZero() {
+			stat.Date = entry.Time.Format("2006-01-02")
+		}
+		items = append(items, stat)
+	}
+
+	return items, nil
+}

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -1,5 +1,5 @@
 // Copyright 2012 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package v4_test
 
@@ -80,6 +80,21 @@ func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 		status:  http.StatusNotFound,
 		message: "not found",
 		code:    params.ErrNotFound,
+	}, {
+		path:    "stats/counter/any?by=fortnight",
+		status:  http.StatusBadRequest,
+		message: `invalid 'by' value: "fortnight"`,
+		code:    params.ErrBadRequest,
+	}, {
+		path:    "stats/counter/any?start=tomorrow",
+		status:  http.StatusBadRequest,
+		message: `invalid 'start' value "tomorrow": parsing time "tomorrow" as "2006-01-02": cannot parse "tomorrow" as "2006"`,
+		code:    params.ErrBadRequest,
+	}, {
+		path:    "stats/counter/any?stop=3",
+		status:  http.StatusBadRequest,
+		message: `invalid 'stop' value "3": parsing time "3" as "2006-01-02": cannot parse "3" as "2006"`,
+		code:    params.ErrBadRequest,
 	}}
 	for i, test := range tests {
 		c.Logf("test %d. %s", i, test.path)
@@ -208,14 +223,6 @@ func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
 		url := storeURL("stats/counter/" + test.key + "?list=1")
 		storetesting.AssertJSONCall(c, s.srv, "GET", url, "", http.StatusOK, test.result)
 	}
-}
-
-// counterEpoch is a copy of charmstore.counterEpoch.
-var counterEpoch = time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
-
-// timeToStamp is a copy of charmstore.timeToStamp.
-func timeToStamp(t time.Time) int32 {
-	return int32(t.Unix() - counterEpoch)
 }
 
 func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -1,0 +1,422 @@
+// Copyright 2012 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package v4_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/storetesting"
+	"github.com/juju/charmstore/params"
+)
+
+type StatsSuite struct {
+	storetesting.IsolatedMgoSuite
+	srv   http.Handler
+	store *charmstore.Store
+}
+
+var _ = gc.Suite(&StatsSuite{})
+
+func (s *StatsSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	s.srv, s.store = newServer(c, s.Session)
+}
+
+// checkCounterSum checks that statistics are properly collected.
+// It retries a few times as they are generally collected in background.
+func (s *StatsSuite) checkCounterSum(c *gc.C, key []string, prefix bool, expected int64) {
+	var sum int64
+	for retry := 0; retry < 10; retry++ {
+		time.Sleep(100 * time.Millisecond)
+		req := charmstore.CounterRequest{Key: key, Prefix: prefix}
+		cs, err := s.store.Counters(&req)
+		c.Assert(err, gc.IsNil)
+		if sum = cs[0].Count; sum == expected {
+			if expected == 0 && retry < 2 {
+				continue // Wait a bit to make sure.
+			}
+			return
+		}
+	}
+	c.Errorf("counter sum for %#v is %d, want %d", key, sum, expected)
+}
+
+func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
+	tests := []struct {
+		path    string
+		status  int
+		message string
+		code    params.ErrorCode
+	}{{
+		path:    "stats/counter/",
+		status:  http.StatusForbidden,
+		message: "forbidden",
+		code:    params.ErrForbidden,
+	}, {
+		path:    "stats/counter/*",
+		status:  http.StatusForbidden,
+		message: "unknown key",
+		code:    params.ErrForbidden,
+	}, {
+		path:    "stats/counter/any/",
+		status:  http.StatusNotFound,
+		message: "not found",
+		code:    params.ErrNotFound,
+	}, {
+		path:    "stats/",
+		status:  http.StatusNotFound,
+		message: "not found",
+		code:    params.ErrNotFound,
+	}, {
+		path:    "stats/any",
+		status:  http.StatusNotFound,
+		message: "not found",
+		code:    params.ErrNotFound,
+	}}
+	for i, test := range tests {
+		c.Logf("test %d. %s", i, test.path)
+		url := storeURL(test.path)
+		storetesting.AssertJSONCall(c, s.srv, "GET", url, "",
+			test.status,
+			params.Error{
+				Message: test.message,
+				Code:    test.code,
+			},
+		)
+	}
+}
+
+func (s *StatsSuite) TestStatsCounter(c *gc.C) {
+	if !storetesting.MongoJSEnabled() {
+		c.Skip("MongoDB javascript not available")
+	}
+
+	for _, key := range [][]string{{"a", "b"}, {"a", "b"}, {"a", "c"}, {"a"}} {
+		err := s.store.IncCounter(key)
+		c.Assert(err, gc.IsNil)
+	}
+
+	var all []interface{}
+	err := s.store.DB.StatCounters().Find(nil).All(&all)
+	c.Assert(err, gc.IsNil)
+	data, err := json.Marshal(all)
+	c.Assert(err, gc.IsNil)
+	c.Logf("%s", data)
+
+	expected := map[string]int64{
+		"a:b":   2,
+		"a:b:*": 0,
+		"a:*":   3,
+		"a":     1,
+		"a:b:c": 0,
+	}
+
+	for counter, n := range expected {
+		c.Logf("test %q", counter)
+		url := storeURL("stats/counter/" + counter)
+		storetesting.AssertJSONCall(c, s.srv, "GET", url, "", http.StatusOK, []params.Statistic{{
+			Count: n,
+		}})
+	}
+}
+
+func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
+	if !storetesting.MongoJSEnabled() {
+		c.Skip("MongoDB javascript not available")
+	}
+
+	incs := [][]string{
+		{"a"},
+		{"a", "b"},
+		{"a", "b", "c"},
+		{"a", "b", "c"},
+		{"a", "b", "d"},
+		{"a", "b", "e"},
+		{"a", "f", "g"},
+		{"a", "f", "h"},
+		{"a", "i"},
+		{"j", "k"},
+	}
+	for _, key := range incs {
+		err := s.store.IncCounter(key)
+		c.Assert(err, gc.IsNil)
+	}
+
+	tests := []struct {
+		key    string
+		result []params.Statistic
+	}{{
+		key: "a",
+		result: []params.Statistic{{
+			Key:   "a",
+			Count: 1,
+		}},
+	}, {
+		key: "a:*",
+		result: []params.Statistic{{
+			Key:   "a:b:*",
+			Count: 4,
+		}, {
+			Key:   "a:f:*",
+			Count: 2,
+		}, {
+			Key:   "a:b",
+			Count: 1,
+		}, {
+			Key:   "a:i",
+			Count: 1,
+		}},
+	}, {
+		key: "a:b:*",
+		result: []params.Statistic{{
+			Key:   "a:b:c",
+			Count: 2,
+		}, {
+			Key:   "a:b:d",
+			Count: 1,
+		}, {
+			Key:   "a:b:e",
+			Count: 1,
+		}},
+	}, {
+		key: "a:*",
+		result: []params.Statistic{{
+			Key:   "a:b:*",
+			Count: 4,
+		}, {
+			Key:   "a:f:*",
+			Count: 2,
+		}, {
+			Key:   "a:b",
+			Count: 1,
+		}, {
+			Key:   "a:i",
+			Count: 1,
+		}},
+	}}
+
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.key)
+		url := storeURL("stats/counter/" + test.key + "?list=1")
+		storetesting.AssertJSONCall(c, s.srv, "GET", url, "", http.StatusOK, test.result)
+	}
+}
+
+// counterEpoch is a copy of charmstore.counterEpoch.
+var counterEpoch = time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+
+// timeToStamp is a copy of charmstore.timeToStamp.
+func timeToStamp(t time.Time) int32 {
+	return int32(t.Unix() - counterEpoch)
+}
+
+func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {
+	if !storetesting.MongoJSEnabled() {
+		c.Skip("MongoDB javascript not available")
+	}
+
+	incs := []struct {
+		key []string
+		day int
+	}{
+		{[]string{"a"}, 1},
+		{[]string{"a"}, 1},
+		{[]string{"b"}, 1},
+		{[]string{"a", "b"}, 1},
+		{[]string{"a", "c"}, 1},
+		{[]string{"a"}, 3},
+		{[]string{"a", "b"}, 3},
+		{[]string{"b"}, 9},
+		{[]string{"b"}, 9},
+		{[]string{"a", "c", "d"}, 9},
+		{[]string{"a", "c", "e"}, 9},
+		{[]string{"a", "c", "f"}, 9},
+	}
+
+	day := func(i int) time.Time {
+		return time.Date(2012, time.May, i, 0, 0, 0, 0, time.UTC)
+	}
+
+	for i, inc := range incs {
+		t := day(inc.day)
+		// Ensure each entry is unique by adding
+		// a sufficient increment for each test.
+		t = t.Add(time.Duration(i) * charmstore.StatsGranularity)
+
+		err := s.store.IncCounterAtTime(inc.key, t)
+		c.Assert(err, gc.IsNil)
+	}
+
+	tests := []struct {
+		request charmstore.CounterRequest
+		result  []params.Statistic
+	}{{
+		request: charmstore.CounterRequest{
+			Key:    []string{"a"},
+			Prefix: false,
+			List:   false,
+			By:     charmstore.ByDay,
+		},
+		result: []params.Statistic{{
+			Date:  "2012-05-01",
+			Count: 2,
+		}, {
+			Date:  "2012-05-03",
+			Count: 1,
+		}},
+	}, {
+		request: charmstore.CounterRequest{
+			Key:    []string{"a"},
+			Prefix: true,
+			List:   false,
+			By:     charmstore.ByDay,
+		},
+		result: []params.Statistic{{
+			Date:  "2012-05-01",
+			Count: 2,
+		}, {
+			Date:  "2012-05-03",
+			Count: 1,
+		}, {
+			Date:  "2012-05-09",
+			Count: 3,
+		}},
+	}, {
+		request: charmstore.CounterRequest{
+			Key:    []string{"a"},
+			Prefix: true,
+			List:   false,
+			By:     charmstore.ByDay,
+			Start:  time.Date(2012, 5, 2, 0, 0, 0, 0, time.UTC),
+		},
+		result: []params.Statistic{{
+			Date:  "2012-05-03",
+			Count: 1,
+		}, {
+			Date:  "2012-05-09",
+			Count: 3,
+		}},
+	}, {
+		request: charmstore.CounterRequest{
+			Key:    []string{"a"},
+			Prefix: true,
+			List:   false,
+			By:     charmstore.ByDay,
+			Stop:   time.Date(2012, 5, 4, 0, 0, 0, 0, time.UTC),
+		},
+		result: []params.Statistic{{
+			Date:  "2012-05-01",
+			Count: 2,
+		}, {
+			Date:  "2012-05-03",
+			Count: 1,
+		}},
+	}, {
+		request: charmstore.CounterRequest{
+			Key:    []string{"a"},
+			Prefix: true,
+			List:   false,
+			By:     charmstore.ByDay,
+			Start:  time.Date(2012, 5, 3, 0, 0, 0, 0, time.UTC),
+			Stop:   time.Date(2012, 5, 3, 0, 0, 0, 0, time.UTC),
+		},
+		result: []params.Statistic{{
+			Date:  "2012-05-03",
+			Count: 1,
+		}},
+	}, {
+		request: charmstore.CounterRequest{
+			Key:    []string{"a"},
+			Prefix: true,
+			List:   true,
+			By:     charmstore.ByDay,
+		},
+		result: []params.Statistic{{
+			Key:   "a:b",
+			Date:  "2012-05-01",
+			Count: 1,
+		}, {
+			Key:   "a:c",
+			Date:  "2012-05-01",
+			Count: 1,
+		}, {
+			Key:   "a:b",
+			Date:  "2012-05-03",
+			Count: 1,
+		}, {
+			Key:   "a:c:*",
+			Date:  "2012-05-09",
+			Count: 3,
+		}},
+	}, {
+		request: charmstore.CounterRequest{
+			Key:    []string{"a"},
+			Prefix: true,
+			List:   false,
+			By:     charmstore.ByWeek,
+		},
+		result: []params.Statistic{{
+			Date:  "2012-05-06",
+			Count: 3,
+		}, {
+			Date:  "2012-05-13",
+			Count: 3,
+		}},
+	}, {
+		request: charmstore.CounterRequest{
+			Key:    []string{"a"},
+			Prefix: true,
+			List:   true,
+			By:     charmstore.ByWeek,
+		},
+		result: []params.Statistic{{
+			Key:   "a:b",
+			Date:  "2012-05-06",
+			Count: 2,
+		}, {
+			Key:   "a:c",
+			Date:  "2012-05-06",
+			Count: 1,
+		}, {
+			Key:   "a:c:*",
+			Date:  "2012-05-13",
+			Count: 3,
+		}},
+	}}
+
+	for i, test := range tests {
+		flags := make(url.Values)
+		url := storeURL("stats/counter/" + strings.Join(test.request.Key, ":"))
+		if test.request.Prefix {
+			url += ":*"
+		}
+		if test.request.List {
+			flags.Set("list", "1")
+		}
+		if !test.request.Start.IsZero() {
+			flags.Set("start", test.request.Start.Format("2006-01-02"))
+		}
+		if !test.request.Stop.IsZero() {
+			flags.Set("stop", test.request.Stop.Format("2006-01-02"))
+		}
+		switch test.request.By {
+		case charmstore.ByDay:
+			flags.Set("by", "day")
+		case charmstore.ByWeek:
+			flags.Set("by", "week")
+		}
+		if len(flags) > 0 {
+			url += "?" + flags.Encode()
+		}
+		c.Logf("test %d: %s", i, url)
+		storetesting.AssertJSONCall(c, s.srv, "GET", url, "", http.StatusOK, test.result)
+	}
+}

--- a/params/error.go
+++ b/params/error.go
@@ -14,6 +14,8 @@ func (code ErrorCode) Error() string {
 const (
 	ErrNotFound         ErrorCode = "not found"
 	ErrMetadataNotFound ErrorCode = "metadata not found"
+	ErrForbidden        ErrorCode = "forbidden"
+	ErrBadRequest       ErrorCode = "bad request"
 )
 
 // Error represents an error - it is returned for any response

--- a/params/params.go
+++ b/params/params.go
@@ -16,3 +16,11 @@ type MetaAnyResponse struct {
 	Id   *charm.Reference
 	Meta map[string]interface{} `json:",omitempty"`
 }
+
+// Statistic holds one element of a stats/counter
+// response. See http://tinyurl.com/nkdovcf
+type Statistic struct {
+	Key   string `json:",omitempty"`
+	Date  string `json:",omitempty"`
+	Count int64
+}


### PR DESCRIPTION
internal/v4/stats.go and internal/v4/stats_test.go are directly derived from
code in _old, although simplified to return only JSON-formatted results.

This required a fair number of fixes to other code, which
unfortunately aren't that easy to pick apart now, including the
following:
- internal/charmstore: make stats counter tests less hacky.

Because the internal/v4 tests are outside charmstore, delving
directly into the database to tweak the time stamps seemed unwarranted,
so added IncCounterAtTime and changed internal/v4 tests and existing
internal/charmstore tests to use it.
- internal/charmstore: move mongojs condition into storetesting.

This avoids duplicating the logic to determine whether tests requiring
mongodb embedded javascript can be run.
- internal/router: universal ParseForm.

This clears up responsibility for who should call ParseForm.
- internal/router: strip prefix from global handlers

This makes the global handlers (including /stats/counters) consistent
with other handlers in router.Handlers.
- internal/router: add ServeMux, NotFoundHandler

The original /stats/counter tests tested http status of paths which previously
returned an http.StatusNotFound status but with a non-JSON body.
The above two handlers make the not-found pages consistent
with the rest of the API.
- params: add ErrForbidden, ErrBadRequest

The original /stats/counter tests tested for statuses which our
current code was incapable of generating. The above two
errors make it capable.
