### PR TITLE
internal/v4: implement serveArchive

### DIFF
--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -85,6 +85,6 @@ func assertServesVersion(c *gc.C, h http.Handler, vers string) {
 }
 
 func assertDoesNotServeVersion(c *gc.C, h http.Handler, vers string) {
-	rec := storetesting.DoRequest(c, h, "GET", "http://0.1.2.3/"+vers+"/some/path", "")
+	rec := storetesting.DoRequest(c, h, "GET", "http://0.1.2.3/"+vers+"/some/path", "", nil)
 	c.Assert(rec.Code, gc.Equals, http.StatusNotFound)
 }

--- a/internal/storetesting/http.go
+++ b/internal/storetesting/http.go
@@ -26,7 +26,7 @@ func AssertJSONCall(
 	expectCode int,
 	expectBody interface{},
 ) {
-	rec := DoRequest(c, handler, method, urlStr, body)
+	rec := DoRequest(c, handler, method, urlStr, body, nil)
 	c.Assert(rec.Code, gc.Equals, expectCode, gc.Commentf("body: %s", rec.Body.Bytes()))
 	if expectBody == nil {
 		c.Assert(rec.Body.Bytes(), gc.HasLen, 0)
@@ -51,13 +51,16 @@ func AssertJSONCall(
 
 // DoRequest invokes a request on the given handler with the given
 // method, URL and body.
-func DoRequest(c *gc.C, handler http.Handler, method string, urlStr string, body string) *httptest.ResponseRecorder {
+func DoRequest(c *gc.C, handler http.Handler, method string, urlStr string, body string, header map[string][]string) *httptest.ResponseRecorder {
 	var r io.Reader
 	if body != "" {
 		r = strings.NewReader(body)
 	}
 	req, err := http.NewRequest(method, urlStr, r)
 	c.Assert(err, gc.IsNil)
+	if header != nil {
+		req.Header = header
+	}
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	return rec

--- a/internal/storetesting/http.go
+++ b/internal/storetesting/http.go
@@ -50,7 +50,7 @@ func AssertJSONCall(
 }
 
 // DoRequest invokes a request on the given handler with the given
-// method, URL and body.
+// method, URL, body and headers.
 func DoRequest(c *gc.C, handler http.Handler, method string, urlStr string, body string, header map[string][]string) *httptest.ResponseRecorder {
 	var r io.Reader
 	if body != "" {

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -201,17 +201,17 @@ func (h *handler) serveExpandId(charmId *charm.Reference, w http.ResponseWriter,
 func (h *handler) serveArchive(charmId *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	var entity mongodoc.Entity
 	if err := h.store.DB.Entities().
-		Find(bson.D{{"_id", charmId}}).
+		FindId(charmId).
 		Select(bson.D{{"blobhash", 1}}).
 		One(&entity); err != nil {
 		if err == mgo.ErrNotFound {
 			return params.ErrNotFound
 		}
-		return errgo.Notef(err, "cannot find entity")
+		return errgo.Notef(err, "cannot get %s", charmId)
 	}
 	r, size, err := h.store.BlobStore.Open(entity.BlobHash)
 	if err != nil {
-		return errgo.Notef(err, "cannot open archive data")
+		return errgo.Notef(err, "cannot open archive data for %s", charmId)
 	}
 	defer r.Close()
 	serveContent(w, req, size, r)

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -199,7 +199,23 @@ func (h *handler) serveExpandId(charmId *charm.Reference, w http.ResponseWriter,
 // POST id/archive?sha256=hash
 // http://tinyurl.com/lzrzrgb
 func (h *handler) serveArchive(charmId *charm.Reference, w http.ResponseWriter, req *http.Request) error {
-	return errNotImplemented
+	var entity mongodoc.Entity
+	if err := h.store.DB.Entities().
+		Find(bson.D{{"_id", charmId}}).
+		Select(bson.D{{"blobhash", 1}}).
+		One(&entity); err != nil {
+		if err == mgo.ErrNotFound {
+			return params.ErrNotFound
+		}
+		return errgo.Notef(err, "cannot find entity")
+	}
+	r, size, err := h.store.BlobStore.Open(entity.BlobHash)
+	if err != nil {
+		return errgo.Notef(err, "cannot open archive data")
+	}
+	defer r.Close()
+	serveContent(w, req, size, r)
+	return nil
 }
 
 // GET id/archive/…

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -126,7 +126,7 @@ func (s *APISuite) TestArchiveGet(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
 
-	// Check that the http range logic is plugged in OK. If this
+	// Check that the HTTP range logic is plugged in OK. If this
 	// is working, we assume that the whole thing is working OK,
 	// as net/http is well-tested.
 	rec = storetesting.DoRequest(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/archive", "", http.Header{"Range": {"bytes=10-100"}})

--- a/internal/v4/httpfs.go
+++ b/internal/v4/httpfs.go
@@ -13,7 +13,7 @@ import (
 
 // serveContent serves the given content as a single HTTP endpoint.
 // We use http.FileServer under the covers because that
-// provides us with all the http Content-Range goodness
+// provides us with all the HTTP Content-Range goodness
 // that we'd like.
 func serveContent(w http.ResponseWriter, req *http.Request, length int64, content io.ReadSeeker) {
 	fs := &archiveFS{
@@ -23,31 +23,42 @@ func serveContent(w http.ResponseWriter, req *http.Request, length int64, conten
 	// Copy the request and mutate the path to pretend
 	// we're looking for the given file.
 	nreq := *req
-	nreq.URL.Path = "/archive"
+	nreq.URL.Path = "/archive.zip"
 	h := http.FileServer(fs)
 	h.ServeHTTP(w, &nreq)
 }
 
+// archiveFS implements http.FileSystem to serve a single file.
+// http.FileSystem.Open returns an http.File; http.File.Stat returns an
+// os.FileInfo. We implement methods for all of those interfaces on the
+// same type, and return the same value for all the aforementioned
+// methods, since we only ever need one instance of any of them.
 type archiveFS struct {
 	length int64
 	io.ReadSeeker
 }
 
+// Open implements http.FileSystem.Open.
 func (fs *archiveFS) Open(name string) (http.File, error) {
-	if name != "/archive" {
+	if name != "/archive.zip" {
 		return nil, fmt.Errorf("unexpected name %q", name)
 	}
 	return fs, nil
 }
 
+// Close implements http.File.Close.
+// It does not actually close anything because
+// that responsibility is left to the caller of serveContent.
 func (fs *archiveFS) Close() error {
 	return nil
 }
 
+// Stat implements http.File.Stat.
 func (fs *archiveFS) Stat() (os.FileInfo, error) {
 	return fs, nil
 }
 
+// Readdir implements http.File.Readdir.
 func (fs *archiveFS) Readdir(count int) ([]os.FileInfo, error) {
 	return nil, fmt.Errorf("not a directory")
 }

--- a/internal/v4/httpfs.go
+++ b/internal/v4/httpfs.go
@@ -1,0 +1,83 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// serveContent serves the given content as a single HTTP endpoint.
+// We use http.FileServer under the covers because that
+// provides us with all the http Content-Range goodness
+// that we'd like.
+func serveContent(w http.ResponseWriter, req *http.Request, length int64, content io.ReadSeeker) {
+	fs := &archiveFS{
+		length:     length,
+		ReadSeeker: content,
+	}
+	// Copy the request and mutate the path to pretend
+	// we're looking for the given file.
+	nreq := *req
+	nreq.URL.Path = "/archive"
+	h := http.FileServer(fs)
+	h.ServeHTTP(w, &nreq)
+}
+
+type archiveFS struct {
+	length int64
+	io.ReadSeeker
+}
+
+func (fs *archiveFS) Open(name string) (http.File, error) {
+	if name != "/archive" {
+		return nil, fmt.Errorf("unexpected name %q", name)
+	}
+	return fs, nil
+}
+
+func (fs *archiveFS) Close() error {
+	return nil
+}
+
+func (fs *archiveFS) Stat() (os.FileInfo, error) {
+	return fs, nil
+}
+
+func (fs *archiveFS) Readdir(count int) ([]os.FileInfo, error) {
+	return nil, fmt.Errorf("not a directory")
+}
+
+// Name implements os.FileInfo.Name.
+func (fs *archiveFS) Name() string {
+	return "archive"
+}
+
+// Size implements os.FileInfo.Size.
+func (fs *archiveFS) Size() int64 {
+	return fs.length
+}
+
+// Mode implements os.FileInfo.Mode.
+func (fs *archiveFS) Mode() os.FileMode {
+	return 0444
+}
+
+// ModTime implements os.FileInfo.ModTime.
+func (fs *archiveFS) ModTime() time.Time {
+	return time.Time{}
+}
+
+// IsDir implements os.FileInfo.IsDir.
+func (fs *archiveFS) IsDir() bool {
+	return false
+}
+
+// Sys implements os.FileInfo.Sys.
+func (fs *archiveFS) Sys() interface{} {
+	return nil
+}

--- a/server_test.go
+++ b/server_test.go
@@ -68,6 +68,6 @@ func assertServesVersion(c *gc.C, h http.Handler, vers string) {
 }
 
 func assertDoesNotServeVersion(c *gc.C, h http.Handler, vers string) {
-	rec := storetesting.DoRequest(c, h, "GET", "http://0.1.2.3/"+vers+"/debug", "")
+	rec := storetesting.DoRequest(c, h, "GET", "http://0.1.2.3/"+vers+"/debug", "", nil)
 	c.Assert(rec.Code, gc.Equals, http.StatusNotFound)
 }


### PR DESCRIPTION
Use http.FileServer so that clients can resume downloads if they need to.
