### PR TITLE
add internal/storetesting JSONCallParams

### DIFF
--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -78,13 +78,17 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 }
 
 func assertServesVersion(c *gc.C, h http.Handler, vers string) {
-	storetesting.AssertJSONCall(c, h, "GET", "http://0.1.2.3/"+vers+"/some/path", "", http.StatusOK, versionResponse{
-		Version: vers,
-		Path:    "/some/path",
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler: h,
+		URL:     "http://0.1.2.3/" + vers + "/some/path",
+		ExpectBody: versionResponse{
+			Version: vers,
+			Path:    "/some/path",
+		},
 	})
 }
 
 func assertDoesNotServeVersion(c *gc.C, h http.Handler, vers string) {
-	rec := storetesting.DoRequest(c, h, "GET", "http://0.1.2.3/"+vers+"/some/path", "", nil)
+	rec := storetesting.DoRequest(c, h, "GET", "http://0.1.2.3/"+vers+"/some/path", "", "", nil)
 	c.Assert(rec.Code, gc.Equals, http.StatusNotFound)
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -921,7 +921,6 @@ func (s *RouterSuite) TestServeMux(c *gc.C) {
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler:    mux,
 		URL:        "http://0.1.2.3/data",
-		ExpectCode: http.StatusOK,
 		ExpectBody: Foo{"hello"},
 	})
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -687,7 +687,12 @@ func (s *RouterSuite) TestRouter(c *gc.C) {
 		// Note that fieldSelectHandler increments this each time
 		// a query is made.
 		queryCount = 0
-		storetesting.AssertJSONCall(c, router, "GET", test.urlStr, "", test.expectCode, test.expectBody)
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    router,
+			URL:        test.urlStr,
+			ExpectCode: test.expectCode,
+			ExpectBody: test.expectBody,
+		})
 		c.Assert(queryCount, gc.Equals, test.expectQueryCount)
 	}
 }
@@ -913,10 +918,20 @@ func (s *RouterSuite) TestServeMux(c *gc.C) {
 	mux.Handle("/data", HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
 		return Foo{"hello"}, nil
 	}))
-	storetesting.AssertJSONCall(c, mux, "GET", "http://0.1.2.3/data", "", http.StatusOK, Foo{"hello"})
-	storetesting.AssertJSONCall(c, mux, "GET", "http://0.1.2.3/foo", "", http.StatusNotFound, params.Error{
-		Message: "not found",
-		Code:    params.ErrNotFound,
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    mux,
+		URL:        "http://0.1.2.3/data",
+		ExpectCode: http.StatusOK,
+		ExpectBody: Foo{"hello"},
+	})
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    mux,
+		URL:        "http://0.1.2.3/foo",
+		ExpectCode: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Message: "not found",
+			Code:    params.ErrNotFound,
+		},
 	})
 }
 
@@ -1036,7 +1051,12 @@ type ReqInfo struct {
 func (s *RouterSuite) TestHandlers(c *gc.C) {
 	for i, test := range handlerTests {
 		c.Logf("test %d: %s", i, test.about)
-		storetesting.AssertJSONCall(c, test.handler, "GET", "http://0.1.2.3", "", test.expectCode, test.expectBody)
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    test.handler,
+			URL:        "http://0.1.2.3",
+			ExpectCode: test.expectCode,
+			ExpectBody: test.expectBody,
+		})
 	}
 }
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -281,15 +281,14 @@ func (s *APISuite) TestBulkMeta(c *gc.C) {
 
 	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	_, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(
-		c, storetesting.JSONCallParams{
-			Handler: s.srv,
-			URL:     storeURL("meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10"),
-			ExpectBody: map[string]*charm.Meta{
-				"precise/wordpress-23": wordpress.Meta(),
-				"precise/mysql-10":     mysql.Meta(),
-			},
-		})
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler: s.srv,
+		URL:     storeURL("meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10"),
+		ExpectBody: map[string]*charm.Meta{
+			"precise/wordpress-23": wordpress.Meta(),
+			"precise/mysql-10":     mysql.Meta(),
+		},
+	})
 }
 
 func (s *APISuite) TestBulkMetaAny(c *gc.C) {
@@ -299,27 +298,26 @@ func (s *APISuite) TestBulkMetaAny(c *gc.C) {
 
 	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	mysqlURL, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(
-		c, storetesting.JSONCallParams{
-			Handler: s.srv,
-			URL:     storeURL("meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10"),
-			ExpectBody: map[string]params.MetaAnyResponse{
-				"precise/wordpress-23": {
-					Id: wordpressURL,
-					Meta: map[string]interface{}{
-						"charm-config":   wordpress.Config(),
-						"charm-metadata": wordpress.Meta(),
-					},
-				},
-				"precise/mysql-10": {
-					Id: mysqlURL,
-					Meta: map[string]interface{}{
-						"charm-config":   mysql.Config(),
-						"charm-metadata": mysql.Meta(),
-					},
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler: s.srv,
+		URL:     storeURL("meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10"),
+		ExpectBody: map[string]params.MetaAnyResponse{
+			"precise/wordpress-23": {
+				Id: wordpressURL,
+				Meta: map[string]interface{}{
+					"charm-config":   wordpress.Config(),
+					"charm-metadata": wordpress.Meta(),
 				},
 			},
-		})
+			"precise/mysql-10": {
+				Id: mysqlURL,
+				Meta: map[string]interface{}{
+					"charm-config":   mysql.Config(),
+					"charm-metadata": mysql.Meta(),
+				},
+			},
+		},
+	})
 }
 
 func (s *APISuite) TestIdsAreResolved(c *gc.C) {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -139,7 +139,7 @@ func (s *APISuite) TestArchiveGet(c *gc.C) {
 	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
 	c.Assert(err, gc.IsNil)
 
-	rec := storetesting.DoRequest(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/archive", "", nil)
+	rec := storetesting.DoRequest(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/archive", "", "", nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
@@ -147,7 +147,7 @@ func (s *APISuite) TestArchiveGet(c *gc.C) {
 	// Check that the HTTP range logic is plugged in OK. If this
 	// is working, we assume that the whole thing is working OK,
 	// as net/http is well-tested.
-	rec = storetesting.DoRequest(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/archive", "", http.Header{"Range": {"bytes=10-100"}})
+	rec = storetesting.DoRequest(c, s.srv, "GET", "http://0.1.2.3/v4/precise/wordpress-23/archive", "", "", http.Header{"Range": {"bytes=10-100"}})
 	c.Assert(err, gc.IsNil)
 	c.Assert(rec.Code, gc.Equals, http.StatusPartialContent, gc.Commentf("body: %q", rec.Body.Bytes()))
 	c.Assert(rec.Body.Bytes(), gc.HasLen, 100-10+1)
@@ -189,14 +189,24 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 			c.Assert(err, gc.IsNil)
 			c.Logf("	expected data for %q: %#v", url, expectData)
 			if isNull(expectData) {
-				storetesting.AssertJSONCall(c, s.srv, "GET", storeURL, "", http.StatusNotFound, params.Error{
-					Message: params.ErrMetadataNotFound.Error(),
-					Code:    params.ErrMetadataNotFound,
+				storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+					Handler:    s.srv,
+					URL:        storeURL,
+					ExpectCode: http.StatusNotFound,
+					ExpectBody: params.Error{
+						Message: params.ErrMetadataNotFound.Error(),
+						Code:    params.ErrMetadataNotFound,
+					},
 				})
 				continue
 			}
 			tested = true
-			storetesting.AssertJSONCall(c, s.srv, "GET", storeURL, "", http.StatusOK, expectData)
+			storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+				Handler:    s.srv,
+				URL:        storeURL,
+				ExpectBody: expectData,
+			})
+
 		}
 		if !tested {
 			c.Errorf("endpoint %q is null for all endpoints, so is not properly tested", ep.name)
@@ -235,8 +245,11 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 			}
 		}
 		storeURL := storeURL(charmId + "/meta/any?" + strings.Join(flags, "&"))
-		storetesting.AssertJSONCall(c, s.srv, "GET", storeURL, "",
-			http.StatusOK, expectData)
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    s.srv,
+			URL:        storeURL,
+			ExpectBody: expectData,
+		})
 	}
 }
 
@@ -244,18 +257,21 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 // dummy charm that has actions included.
 func (s *APISuite) TestMetaCharmActions(c *gc.C) {
 	url, dummy := s.addCharm(c, "dummy", "cs:precise/dummy-10")
-	storetesting.AssertJSONCall(c, s.srv,
-		"GET", storeURL("precise/dummy-10/meta/charm-actions"), "",
-		http.StatusOK, dummy.Actions())
-
-	storetesting.AssertJSONCall(c, s.srv,
-		"GET", storeURL("precise/dummy-10/meta/any?include=charm-actions"), "",
-		http.StatusOK, params.MetaAnyResponse{
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    s.srv,
+		URL:        storeURL("precise/dummy-10/meta/charm-actions"),
+		ExpectBody: dummy.Actions(),
+	})
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler: s.srv,
+		URL:     storeURL("precise/dummy-10/meta/any?include=charm-actions"),
+		ExpectBody: params.MetaAnyResponse{
 			Id: url,
 			Meta: map[string]interface{}{
 				"charm-actions": dummy.Actions(),
 			},
-		})
+		},
+	})
 }
 
 func (s *APISuite) TestBulkMeta(c *gc.C) {
@@ -265,10 +281,15 @@ func (s *APISuite) TestBulkMeta(c *gc.C) {
 
 	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	_, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(c, s.srv, "GET", storeURL("meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10"), "", http.StatusOK, map[string]*charm.Meta{
-		"precise/wordpress-23": wordpress.Meta(),
-		"precise/mysql-10":     mysql.Meta(),
-	})
+	storetesting.AssertJSONCall(
+		c, storetesting.JSONCallParams{
+			Handler: s.srv,
+			URL:     storeURL("meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10"),
+			ExpectBody: map[string]*charm.Meta{
+				"precise/wordpress-23": wordpress.Meta(),
+				"precise/mysql-10":     mysql.Meta(),
+			},
+		})
 }
 
 func (s *APISuite) TestBulkMetaAny(c *gc.C) {
@@ -278,22 +299,27 @@ func (s *APISuite) TestBulkMetaAny(c *gc.C) {
 
 	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	mysqlURL, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(c, s.srv, "GET", storeURL("meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10"), "", http.StatusOK, map[string]params.MetaAnyResponse{
-		"precise/wordpress-23": {
-			Id: wordpressURL,
-			Meta: map[string]interface{}{
-				"charm-config":   wordpress.Config(),
-				"charm-metadata": wordpress.Meta(),
+	storetesting.AssertJSONCall(
+		c, storetesting.JSONCallParams{
+			Handler: s.srv,
+			URL:     storeURL("meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10"),
+			ExpectBody: map[string]params.MetaAnyResponse{
+				"precise/wordpress-23": {
+					Id: wordpressURL,
+					Meta: map[string]interface{}{
+						"charm-config":   wordpress.Config(),
+						"charm-metadata": wordpress.Meta(),
+					},
+				},
+				"precise/mysql-10": {
+					Id: mysqlURL,
+					Meta: map[string]interface{}{
+						"charm-config":   mysql.Config(),
+						"charm-metadata": mysql.Meta(),
+					},
+				},
 			},
-		},
-		"precise/mysql-10": {
-			Id: mysqlURL,
-			Meta: map[string]interface{}{
-				"charm-config":   mysql.Config(),
-				"charm-metadata": mysql.Meta(),
-			},
-		},
-	})
+		})
 }
 
 func (s *APISuite) TestIdsAreResolved(c *gc.C) {
@@ -302,7 +328,11 @@ func (s *APISuite) TestIdsAreResolved(c *gc.C) {
 	// defined, and the ResolveURL tests, this should
 	// be sufficient to "join the dots".
 	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
-	storetesting.AssertJSONCall(c, s.srv, "GET", storeURL("wordpress/meta/charm-metadata"), "", http.StatusOK, wordpress.Meta())
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    s.srv,
+		URL:        storeURL("wordpress/meta/charm-metadata"),
+		ExpectBody: wordpress.Meta(),
+	})
 }
 
 func (s *APISuite) TestMetaCharmNotFound(c *gc.C) {
@@ -312,9 +342,19 @@ func (s *APISuite) TestMetaCharmNotFound(c *gc.C) {
 			Message: params.ErrNotFound.Error(),
 			Code:    params.ErrNotFound,
 		}
-		storetesting.AssertJSONCall(c, s.srv, "GET", storeURL("precise/wordpress-23/meta/"+ep.name), "", http.StatusNotFound, expected)
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    s.srv,
+			URL:        storeURL("precise/wordpress-23/meta/" + ep.name),
+			ExpectCode: http.StatusNotFound,
+			ExpectBody: expected,
+		})
 		expected.Message = `no matching charm or bundle for "cs:wordpress"`
-		storetesting.AssertJSONCall(c, s.srv, "GET", storeURL("wordpress/meta/"+ep.name), "", http.StatusNotFound, expected)
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    s.srv,
+			URL:        storeURL("wordpress/meta/" + ep.name),
+			ExpectCode: http.StatusNotFound,
+			ExpectBody: expected,
+		})
 	}
 }
 
@@ -377,8 +417,13 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 }
 
 func assertNotImplemented(c *gc.C, h http.Handler, path string) {
-	storetesting.AssertJSONCall(c, h, "GET", storeURL(path), "", http.StatusInternalServerError, params.Error{
-		Message: "method not implemented",
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    h,
+		URL:        storeURL(path),
+		ExpectCode: http.StatusInternalServerError,
+		ExpectBody: params.Error{
+			Message: "method not implemented",
+		},
 	})
 }
 

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -98,14 +98,15 @@ func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 	}}
 	for i, test := range tests {
 		c.Logf("test %d. %s", i, test.path)
-		url := storeURL(test.path)
-		storetesting.AssertJSONCall(c, s.srv, "GET", url, "",
-			test.status,
-			params.Error{
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    s.srv,
+			URL:        storeURL(test.path),
+			ExpectCode: test.status,
+			ExpectBody: params.Error{
 				Message: test.message,
 				Code:    test.code,
 			},
-		)
+		})
 	}
 }
 
@@ -137,9 +138,13 @@ func (s *StatsSuite) TestStatsCounter(c *gc.C) {
 	for counter, n := range expected {
 		c.Logf("test %q", counter)
 		url := storeURL("stats/counter/" + counter)
-		storetesting.AssertJSONCall(c, s.srv, "GET", url, "", http.StatusOK, []params.Statistic{{
-			Count: n,
-		}})
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler: s.srv,
+			URL:     url,
+			ExpectBody: []params.Statistic{{
+				Count: n,
+			}},
+		})
 	}
 }
 
@@ -221,7 +226,11 @@ func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("test %d: %s", i, test.key)
 		url := storeURL("stats/counter/" + test.key + "?list=1")
-		storetesting.AssertJSONCall(c, s.srv, "GET", url, "", http.StatusOK, test.result)
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    s.srv,
+			URL:        url,
+			ExpectBody: test.result,
+		})
 	}
 }
 
@@ -424,6 +433,10 @@ func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {
 			url += "?" + flags.Encode()
 		}
 		c.Logf("test %d: %s", i, url)
-		storetesting.AssertJSONCall(c, s.srv, "GET", url, "", http.StatusOK, test.result)
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    s.srv,
+			URL:        url,
+			ExpectBody: test.result,
+		})
 	}
 }


### PR DESCRIPTION
This makes the tests look prettier and also
allows us to specify the body content
type without further burdening the call sites.
