### PR TITLE
internal/router: do not always resolve ids

### DIFF
--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -31,7 +31,7 @@ type RouterSuite struct {
 
 var _ = gc.Suite(&RouterSuite{})
 
-var routerTests = []struct {
+var routerGetTests = []struct {
 	about            string
 	handlers         Handlers
 	urlStr           string
@@ -676,15 +676,15 @@ func noResolveURL(*charm.Reference) error {
 	return nil
 }
 
-func (s *RouterSuite) TestRouter(c *gc.C) {
-	for i, test := range routerTests {
+func (s *RouterSuite) TestRouterGet(c *gc.C) {
+	for i, test := range routerGetTests {
 		c.Logf("test %d: %s", i, test.about)
 		resolve := noResolveURL
 		if test.resolveURL != nil {
 			resolve = test.resolveURL
 		}
 		router := New(&test.handlers, resolve)
-		// Note that fieldSelectHandler increments this each time
+		// Note that fieldSelectHandler increments queryCount each time
 		// a query is made.
 		queryCount = 0
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
@@ -694,6 +694,53 @@ func (s *RouterSuite) TestRouter(c *gc.C) {
 			ExpectBody: test.expectBody,
 		})
 		c.Assert(queryCount, gc.Equals, test.expectQueryCount)
+	}
+}
+
+func (s *RouterSuite) TestRouterMethodsThatPassThroughUnresolvedId(c *gc.C) {
+	alwaysResolves := map[string]bool{
+		"POST":   false,
+		"PUT":    false,
+		"GET":    true,
+		"HEAD":   true,
+		"DELETE": true,
+	}
+	for method, resolves := range alwaysResolves {
+		c.Logf("test %s", method)
+		// First try with a metadata handler. This should always resolve,
+		// regardless of the method.
+		handlers := Handlers{
+			Id: map[string]IdHandler{
+				"idhandler": testIdHandler,
+			},
+			Meta: map[string]BulkIncludeHandler{
+				"metahandler": testMetaHandler,
+			},
+		}
+		router := New(&handlers, newResolveURL("series", 1234))
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler: router,
+			Method:  method,
+			URL:     "http://0.1.2.3/wordpress/meta/metahandler",
+			ExpectBody: &metaHandlerTestResp{
+				CharmURL: "cs:series/wordpress-1234",
+			},
+		})
+
+		// Then try with an id handler. This should only resolve
+		// for some methods.
+		var resp idHandlerTestResp
+		if resolves {
+			resp.CharmURL = "cs:series/wordpress-1234"
+		} else {
+			resp.CharmURL = "cs:wordpress"
+		}
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    router,
+			Method:     method,
+			URL:        "http://0.1.2.3/wordpress/idhandler",
+			ExpectBody: resp,
+		})
 	}
 }
 
@@ -921,7 +968,6 @@ func (s *RouterSuite) TestServeMux(c *gc.C) {
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler:    mux,
 		URL:        "http://0.1.2.3/data",
-		ExpectCode: http.StatusOK,
 		ExpectBody: Foo{"hello"},
 	})
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{

--- a/internal/storetesting/http.go
+++ b/internal/storetesting/http.go
@@ -5,7 +5,6 @@ package storetesting
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -32,7 +31,8 @@ type JSONCallParams struct {
 	Body string
 
 	// BodyContentType holds the content type of the
-	// body. If this is empty, the default content type is assumed.
+	// body. If this is empty, the a content type of
+	// "text/plain; charset=utf-8"  is assumed.
 	BodyContentType string
 
 	// ExpectCode holds the expected HTTP status code.
@@ -78,18 +78,15 @@ func AssertJSONCall(c *gc.C, p JSONCallParams) {
 // DoRequest invokes a request on the given handler with the given
 // method, URL, body, body content type and headers.
 func DoRequest(c *gc.C, handler http.Handler, method string, urlStr string, body, bodyContentType string, header map[string][]string) *httptest.ResponseRecorder {
-	var r io.Reader
-	if body != "" {
-		r = strings.NewReader(body)
-	}
-	req, err := http.NewRequest(method, urlStr, r)
+	req, err := http.NewRequest(method, urlStr, strings.NewReader(body))
 	c.Assert(err, gc.IsNil)
 	if header != nil {
 		req.Header = header
 	}
-	if bodyContentType != "" {
-		req.Header.Set("Content-Type", bodyContentType)
+	if bodyContentType == "" {
+		bodyContentType = "text/plain; charset=utf-8"
 	}
+	req.Header.Set("Content-Type", bodyContentType)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	return rec

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -281,15 +281,14 @@ func (s *APISuite) TestBulkMeta(c *gc.C) {
 
 	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	_, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(
-		c, storetesting.JSONCallParams{
-			Handler: s.srv,
-			URL:     storeURL("meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10"),
-			ExpectBody: map[string]*charm.Meta{
-				"precise/wordpress-23": wordpress.Meta(),
-				"precise/mysql-10":     mysql.Meta(),
-			},
-		})
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler: s.srv,
+		URL:     storeURL("meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10"),
+		ExpectBody: map[string]*charm.Meta{
+			"precise/wordpress-23": wordpress.Meta(),
+			"precise/mysql-10":     mysql.Meta(),
+		},
+	})
 }
 
 func (s *APISuite) TestBulkMetaAny(c *gc.C) {
@@ -299,27 +298,26 @@ func (s *APISuite) TestBulkMetaAny(c *gc.C) {
 
 	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	mysqlURL, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(
-		c, storetesting.JSONCallParams{
-			Handler: s.srv,
-			URL:     storeURL("meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10"),
-			ExpectBody: map[string]params.MetaAnyResponse{
-				"precise/wordpress-23": {
-					Id: wordpressURL,
-					Meta: map[string]interface{}{
-						"charm-config":   wordpress.Config(),
-						"charm-metadata": wordpress.Meta(),
-					},
-				},
-				"precise/mysql-10": {
-					Id: mysqlURL,
-					Meta: map[string]interface{}{
-						"charm-config":   mysql.Config(),
-						"charm-metadata": mysql.Meta(),
-					},
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler: s.srv,
+		URL:     storeURL("meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10"),
+		ExpectBody: map[string]params.MetaAnyResponse{
+			"precise/wordpress-23": {
+				Id: wordpressURL,
+				Meta: map[string]interface{}{
+					"charm-config":   wordpress.Config(),
+					"charm-metadata": wordpress.Meta(),
 				},
 			},
-		})
+			"precise/mysql-10": {
+				Id: mysqlURL,
+				Meta: map[string]interface{}{
+					"charm-config":   mysql.Config(),
+					"charm-metadata": mysql.Meta(),
+				},
+			},
+		},
+	})
 }
 
 func (s *APISuite) TestIdsAreResolved(c *gc.C) {


### PR DESCRIPTION
When there's a PUT or a POST, we might actually be
creating a new entity, so defer id resolution
in that case so the specific handler can
deal with it.

For POSTs and PUTs to metadata, the id must already
exist, because otherwise there could not be
metadata about it, so we always resolve in that
case.
