### PR TITLE
internal/v4: implement archive uploading

### DIFF
--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -5,18 +5,12 @@ package charmstore
 
 import (
 	"net/http"
-	"testing"
 
-	jujutesting "github.com/juju/testing"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/router"
 	"github.com/juju/charmstore/internal/storetesting"
 )
-
-func TestPackage(t *testing.T) {
-	jujutesting.MgoTestPackage(t, nil)
-}
 
 type ServerSuite struct {
 	storetesting.IsolatedMgoSuite
@@ -80,7 +74,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 func assertServesVersion(c *gc.C, h http.Handler, vers string) {
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler: h,
-		URL:     "http://0.1.2.3/" + vers + "/some/path",
+		URL:     "/" + vers + "/some/path",
 		ExpectBody: versionResponse{
 			Version: vers,
 			Path:    "/some/path",
@@ -89,6 +83,6 @@ func assertServesVersion(c *gc.C, h http.Handler, vers string) {
 }
 
 func assertDoesNotServeVersion(c *gc.C, h http.Handler, vers string) {
-	rec := storetesting.DoRequest(c, h, "GET", "http://0.1.2.3/"+vers+"/some/path", "", "", nil)
+	rec := storetesting.DoRequest(c, h, "GET", "/"+vers+"/some/path", nil, 0, nil)
 	c.Assert(rec.Code, gc.Equals, http.StatusNotFound)
 }

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -82,10 +82,11 @@ func (s *Store) putArchive(archive blobstore.ReadSeekCloser) (string, int64, err
 	return blobHash, size, nil
 }
 
-// UploadCharm uploads the given charm to the blob store.
-// This method is provided for tests only. Normal clients
-// should upload charms through the API.
-func (s *Store) UploadCharm(url *charm.Reference, ch charm.Charm) error {
+// AddCharmWithArchive is like AddCharm but
+// also adds the charm archive to the blob store.
+// This method is provided principally so that
+// tests can easily create content in the store.
+func (s *Store) AddCharmWithArchive(url *charm.Reference, ch charm.Charm) error {
 	blobHash, size, err := s.uploadCharmOrBundle(ch)
 	if err != nil {
 		return errgo.Mask(err)
@@ -93,10 +94,11 @@ func (s *Store) UploadCharm(url *charm.Reference, ch charm.Charm) error {
 	return s.AddCharm(url, ch, blobHash, size)
 }
 
-// UploadBundle uploads the given bundle to the blob store.
-// This method is provided for tests only. Normal clients
-// should upload bundles through the API.
-func (s *Store) UploadBundle(url *charm.Reference, b charm.Bundle) error {
+// AddBundleWithArchive is like AddBundle but
+// also adds the charm archive to the blob store.
+// This method is provided principally so that
+// tests can easily create content in the store.
+func (s *Store) AddBundleWithArchive(url *charm.Reference, b charm.Bundle) error {
 	blobHash, size, err := s.uploadCharmOrBundle(b)
 	if err != nil {
 		return errgo.Mask(err)

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/charmstore/internal/blobstore"
 	"github.com/juju/charmstore/internal/mongodoc"
+	"github.com/juju/charmstore/params"
 )
 
 // Store represents the underlying charm and blob data stores.
@@ -81,32 +82,56 @@ func (s *Store) putArchive(archive blobstore.ReadSeekCloser) (string, int64, err
 	return blobHash, size, nil
 }
 
-// AddCharm adds a charm to the blob store and to the entities collection
-// associated with the given URL.
-func (s *Store) AddCharm(url *charm.Reference, c charm.Charm) error {
-	// Insert the charm archive into the blob store.
+// UploadCharm uploads the given charm to the blob store.
+// This method is provided for tests only. Normal clients
+// should upload charms through the API.
+func (s *Store) UploadCharm(url *charm.Reference, ch charm.Charm) error {
+	blobHash, size, err := s.uploadCharmOrBundle(ch)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	return s.AddCharm(url, ch, blobHash, size)
+}
+
+// UploadBundle uploads the given bundle to the blob store.
+// This method is provided for tests only. Normal clients
+// should upload bundles through the API.
+func (s *Store) UploadBundle(url *charm.Reference, b charm.Bundle) error {
+	blobHash, size, err := s.uploadCharmOrBundle(b)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	return s.AddBundle(url, b, blobHash, size)
+}
+
+func (s *Store) uploadCharmOrBundle(c interface{}) (blobHash string, size int64, err error) {
 	archive, err := getArchive(c)
 	if err != nil {
-		return errgo.Mask(err)
+		return "", 0, errgo.Mask(err)
 	}
 	defer archive.Close()
-	blobHash, size, err := s.putArchive(archive)
-	if err != nil {
-		return errgo.Mask(err)
-	}
+	return s.putArchive(archive)
+}
 
+// AddCharm adds a charm to the blob store and to the entities collection
+// associated with the given URL.
+func (s *Store) AddCharm(url *charm.Reference, c charm.Charm, blobHash string, blobSize int64) error {
 	// Add charm metadata to the entities collection.
-	return s.DB.Entities().Insert(&mongodoc.Entity{
+	err := s.DB.Entities().Insert(&mongodoc.Entity{
 		URL:                     url,
 		BaseURL:                 baseURL(url),
 		BlobHash:                blobHash,
-		Size:                    size,
+		Size:                    blobSize,
 		CharmMeta:               c.Meta(),
 		CharmConfig:             c.Config(),
 		CharmActions:            c.Actions(),
 		CharmProvidedInterfaces: interfacesForRelations(c.Meta().Provides),
 		CharmRequiredInterfaces: interfacesForRelations(c.Meta().Requires),
 	})
+	if mgo.IsDup(err) {
+		return params.ErrDuplicateUpload
+	}
+	return errgo.Mask(err)
 }
 
 // ExpandURL returns all the URLs that the given URL may refer to.
@@ -164,33 +189,25 @@ var errNotImplemented = errgo.Newf("not implemented")
 
 // AddBundle adds a bundle to the blob store and to the entities collection
 // associated with the given URL.
-func (s *Store) AddBundle(url *charm.Reference, b charm.Bundle) error {
-	// Insert the bundle archive into the blob store.
-	archive, err := getArchive(b)
-	if err != nil {
-		return errgo.Mask(err)
-	}
-	defer archive.Close()
-	blobHash, size, err := s.putArchive(archive)
-	if err != nil {
-		return errgo.Mask(err)
-	}
-
-	// Add bundle metadata to the entities collection.
+func (s *Store) AddBundle(url *charm.Reference, b charm.Bundle, blobHash string, blobSize int64) error {
 	bundleData := b.Data()
 	urls, err := bundleCharms(bundleData)
 	if err != nil {
 		return errgo.Mask(err)
 	}
-	return s.DB.Entities().Insert(&mongodoc.Entity{
+	err = s.DB.Entities().Insert(&mongodoc.Entity{
 		URL:          url,
 		BaseURL:      baseURL(url),
 		BlobHash:     blobHash,
-		Size:         size,
+		Size:         blobSize,
 		BundleData:   bundleData,
 		BundleReadMe: b.ReadMe(),
 		BundleCharms: urls,
 	})
+	if mgo.IsDup(err) {
+		return params.ErrDuplicateUpload
+	}
+	return errgo.Mask(err)
 }
 
 func bundleCharms(data *charm.BundleData) ([]*charm.Reference, error) {

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -33,7 +33,7 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm) {
 	store, err := NewStore(s.Session.DB("foo"))
 	c.Assert(err, gc.IsNil)
 	url := mustParseReference("cs:precise/wordpress-23")
-	err = store.UploadCharm(url, ch)
+	err = store.AddCharmWithArchive(url, ch)
 	c.Assert(err, gc.IsNil)
 
 	var doc mongodoc.Entity
@@ -71,7 +71,7 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm) {
 
 	// Try inserting the charm again - it should fail because the charm is
 	// already there.
-	err = store.UploadCharm(url, ch)
+	err = store.AddCharmWithArchive(url, ch)
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrDuplicateUpload)
 }
 
@@ -79,7 +79,7 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle) {
 	store, err := NewStore(s.Session.DB("foo"))
 	c.Assert(err, gc.IsNil)
 	url := mustParseReference("cs:bundle/wordpress-simple-42")
-	err = store.UploadBundle(url, bundle)
+	err = store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
 
 	var doc mongodoc.Entity
@@ -115,7 +115,7 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle) {
 
 	// Try inserting the bundle again - it should fail because the bundle is
 	// already there.
-	err = store.UploadBundle(url, bundle)
+	err = store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.Equals, params.ErrDuplicateUpload)
 }
 
@@ -185,7 +185,7 @@ func (s *StoreSuite) TestExpandURL(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		urls := mustParseReferences(test.inStore)
 		for _, url := range urls {
-			err := store.UploadCharm(url, wordpress)
+			err := store.AddCharmWithArchive(url, wordpress)
 			c.Assert(err, gc.IsNil)
 		}
 		gotURLs, err := store.ExpandURL((*charm.Reference)(mustParseReference(test.expand)))

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -51,7 +52,7 @@ var routerGetTests = []struct {
 			}),
 		},
 	},
-	urlStr:     "http://0.1.2.3/foo",
+	urlStr:     "/foo",
 	expectCode: http.StatusOK,
 	expectBody: ReqInfo{
 		Path: "",
@@ -68,7 +69,7 @@ var routerGetTests = []struct {
 			}),
 		},
 	},
-	urlStr:     "http://0.1.2.3/foo/bar/a/b?a=1&b=two",
+	urlStr:     "/foo/bar/a/b?a=1&b=two",
 	expectCode: http.StatusOK,
 	expectBody: ReqInfo{
 		Path: "/a/b",
@@ -79,7 +80,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:      "invalid form",
-	urlStr:     "http://0.1.2.3/foo?a=%",
+	urlStr:     "/foo?a=%",
 	expectCode: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: `cannot parse form: invalid URL escape "%"`,
@@ -91,7 +92,7 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-34/foo",
+	urlStr:     "/precise/wordpress-34/foo",
 	expectCode: http.StatusOK,
 	expectBody: idHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-34",
@@ -103,7 +104,7 @@ var routerGetTests = []struct {
 			"foo/": testIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-34/foo/blah/arble",
+	urlStr:     "/precise/wordpress-34/foo/blah/arble",
 	expectCode: http.StatusOK,
 	expectBody: idHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-34",
@@ -116,7 +117,7 @@ var routerGetTests = []struct {
 			"foo/": testIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-34/foo",
+	urlStr:     "/precise/wordpress-34/foo",
 	expectCode: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
@@ -129,7 +130,7 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-34/foo/blah",
+	urlStr:     "/precise/wordpress-34/foo/blah",
 	expectCode: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
@@ -142,7 +143,7 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/~joe/precise/wordpress-34/foo",
+	urlStr:     "/~joe/precise/wordpress-34/foo",
 	expectCode: http.StatusOK,
 	expectBody: idHandlerTestResp{
 		CharmURL: "cs:~joe/precise/wordpress-34",
@@ -154,7 +155,7 @@ var routerGetTests = []struct {
 			"foo/": testIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/~joe/precise/wordpress-34/foo/blah/arble",
+	urlStr:     "/~joe/precise/wordpress-34/foo/blah/arble",
 	expectCode: http.StatusOK,
 	expectBody: idHandlerTestResp{
 		CharmURL: "cs:~joe/precise/wordpress-34",
@@ -167,7 +168,7 @@ var routerGetTests = []struct {
 			"foo/": errorIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/~joe/precise/wordpress-34/foo/blah/arble",
+	urlStr:     "/~joe/precise/wordpress-34/foo/blah/arble",
 	expectCode: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "errorIdHandler error",
@@ -181,7 +182,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	urlStr:     "http://0.1.2.3/~joe/precise/wordpress-34/foo",
+	urlStr:     "/~joe/precise/wordpress-34/foo",
 	expectCode: http.StatusNotFound,
 	expectBody: params.Error{
 		Message: "not found",
@@ -196,7 +197,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	urlStr:     "http://0.1.2.3/~joe/precise/wordpress-34/foo",
+	urlStr:     "/~joe/precise/wordpress-34/foo",
 	expectCode: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "a message",
@@ -209,7 +210,7 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/~joe/wordpress/foo",
+	urlStr:     "/~joe/wordpress/foo",
 	resolveURL: newResolveURL("precise", 34),
 	expectCode: http.StatusOK,
 	expectBody: idHandlerTestResp{
@@ -222,7 +223,7 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/wordpress/meta",
+	urlStr:     "/wordpress/meta",
 	resolveURL: resolveURLError(errgo.New("resolve URL error")),
 	expectCode: http.StatusInternalServerError,
 	expectBody: params.Error{
@@ -235,7 +236,7 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/wordpress/meta",
+	urlStr:     "/wordpress/meta",
 	resolveURL: resolveURLError(params.ErrNotFound),
 	expectCode: http.StatusNotFound,
 	expectBody: params.Error{
@@ -250,7 +251,7 @@ var routerGetTests = []struct {
 			"bar": testMetaHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-42/meta",
+	urlStr:     "/precise/wordpress-42/meta",
 	expectCode: http.StatusOK,
 	expectBody: []string{"bar", "foo"},
 }, {
@@ -260,7 +261,7 @@ var routerGetTests = []struct {
 			"foo": testMetaHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-42/meta/foo",
+	urlStr:     "/precise/wordpress-42/meta/foo",
 	expectCode: http.StatusOK,
 	expectBody: &metaHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-42",
@@ -272,7 +273,7 @@ var routerGetTests = []struct {
 			"foo/": testMetaHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-42/meta/foo/bar/baz",
+	urlStr:     "/precise/wordpress-42/meta/foo/bar/baz",
 	expectCode: http.StatusOK,
 	expectBody: metaHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-42",
@@ -285,7 +286,7 @@ var routerGetTests = []struct {
 			"foo": testMetaHandler,
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-42/meta/foo?one=a&two=b&one=c",
+	urlStr:     "/precise/wordpress-42/meta/foo?one=a&two=b&one=c",
 	expectCode: http.StatusOK,
 	expectBody: metaHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-42",
@@ -296,7 +297,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:      "meta handler that's not found",
-	urlStr:     "http://0.1.2.3/precise/wordpress-42/meta/foo",
+	urlStr:     "/precise/wordpress-42/meta/foo",
 	expectCode: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
@@ -309,7 +310,7 @@ var routerGetTests = []struct {
 			"foo": constMetaHandler(nil),
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-42/meta/foo",
+	urlStr:     "/precise/wordpress-42/meta/foo",
 	expectCode: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrMetadataNotFound,
@@ -322,7 +323,7 @@ var routerGetTests = []struct {
 			"foo": constMetaHandler((*struct{})(nil)),
 		},
 	},
-	urlStr:     "http://0.1.2.3/precise/wordpress-42/meta/foo",
+	urlStr:     "/precise/wordpress-42/meta/foo",
 	expectCode: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrMetadataNotFound,
@@ -330,7 +331,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "meta handler with field selector",
-	urlStr: "http://0.1.2.3/precise/wordpress-42/meta/foo",
+	urlStr: "/precise/wordpress-42/meta/foo",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo": fieldSelectHandler("handler1", 0, "field1", "field2"),
@@ -348,7 +349,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "meta handler returning error with code",
-	urlStr: "http://0.1.2.3/precise/wordpress-42/meta/foo",
+	urlStr: "/precise/wordpress-42/meta/foo",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo": errorMetaHandler(errgo.WithCausef(nil, params.ErrorCode("arble"), "a message")),
@@ -361,14 +362,14 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:      "meta/any, no includes",
-	urlStr:     "http://0.1.2.3/precise/wordpress-42/meta/any",
+	urlStr:     "/precise/wordpress-42/meta/any",
 	expectCode: http.StatusOK,
 	expectBody: params.MetaAnyResponse{
 		Id: mustParseReference("cs:precise/wordpress-42"),
 	},
 }, {
 	about:  "meta/any, some includes all using same key",
-	urlStr: "http://0.1.2.3/precise/wordpress-42/meta/any?include=field1-1&include=field2&include=field1-2",
+	urlStr: "/precise/wordpress-42/meta/any?include=field1-1&include=field2&include=field1-2",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"field1-1": fieldSelectHandler("handler1", 0, "field1"),
@@ -409,7 +410,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "meta/any, includes with additional path elements",
-	urlStr: "http://0.1.2.3/precise/wordpress-42/meta/any?include=item1/foo&include=item2/bar&include=item1",
+	urlStr: "/precise/wordpress-42/meta/any?include=item1/foo&include=item2/bar&include=item1",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"item1/": fieldSelectHandler("handler1", 0, "field1"),
@@ -452,7 +453,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "meta/any, nil metadata omitted",
-	urlStr: "http://0.1.2.3/precise/wordpress-42/meta/any?include=ok&include=nil",
+	urlStr: "/precise/wordpress-42/meta/any?include=ok&include=nil",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"ok":       testMetaHandler,
@@ -471,7 +472,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "meta/any, handler returns error with cause",
-	urlStr: "http://0.1.2.3/precise/wordpress-42/meta/any?include=error",
+	urlStr: "/precise/wordpress-42/meta/any?include=error",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"error": errorMetaHandler(errgo.WithCausef(nil, params.ErrorCode("foo"), "a message")),
@@ -484,7 +485,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta handler, single id",
-	urlStr: "http://0.1.2.3/meta/foo?id=precise/wordpress-42",
+	urlStr: "/meta/foo?id=precise/wordpress-42",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo": testMetaHandler,
@@ -498,7 +499,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta handler, several ids",
-	urlStr: "http://0.1.2.3/meta/foo?id=precise/wordpress-42&id=quantal/foo-32",
+	urlStr: "/meta/foo?id=precise/wordpress-42&id=quantal/foo-32",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo": testMetaHandler,
@@ -515,7 +516,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta/any handler, several ids",
-	urlStr: "http://0.1.2.3/meta/any?id=precise/wordpress-42&id=quantal/foo-32&include=foo&include=bar/something",
+	urlStr: "/meta/any?id=precise/wordpress-42&id=quantal/foo-32&include=foo&include=bar/something",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo":  testMetaHandler,
@@ -551,7 +552,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta handler with unresolved id",
-	urlStr: "http://0.1.2.3/meta/foo/bar?id=wordpress",
+	urlStr: "/meta/foo/bar?id=wordpress",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo/": testMetaHandler,
@@ -567,7 +568,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta handler with extra flags",
-	urlStr: "http://0.1.2.3/meta/foo/bar?id=wordpress&arble=bletch&z=w&z=p",
+	urlStr: "/meta/foo/bar?id=wordpress&arble=bletch&z=w&z=p",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo/": testMetaHandler,
@@ -587,7 +588,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta handler with no ids",
-	urlStr: "http://0.1.2.3/meta/foo/bar",
+	urlStr: "/meta/foo/bar",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo/": testMetaHandler,
@@ -599,7 +600,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta handler with unresolvable id",
-	urlStr: "http://0.1.2.3/meta/foo?id=unresolved&id=precise/wordpress-23",
+	urlStr: "/meta/foo?id=unresolved&id=precise/wordpress-23",
 	resolveURL: func(url *charm.Reference) error {
 		if url.Name == "unresolved" {
 			return params.ErrNotFound
@@ -619,7 +620,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta handler with id resolution error",
-	urlStr: "http://0.1.2.3/meta/foo?id=resolveerror&id=precise/wordpress-23",
+	urlStr: "/meta/foo?id=resolveerror&id=precise/wordpress-23",
 	resolveURL: func(url *charm.Reference) error {
 		if url.Name == "resolveerror" {
 			return errgo.Newf("an error")
@@ -637,7 +638,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta handler with some nil data",
-	urlStr: "http://0.1.2.3/meta/foo?id=bundle/something-24&id=precise/wordpress-23",
+	urlStr: "/meta/foo?id=bundle/something-24&id=precise/wordpress-23",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo": selectiveIdHandler(map[string]interface{}{
@@ -702,9 +703,15 @@ func (s *RouterSuite) TestRouterMethodsThatPassThroughUnresolvedId(c *gc.C) {
 		"POST":   false,
 		"PUT":    false,
 		"GET":    true,
-		"HEAD":   true,
 		"DELETE": true,
 	}
+
+	// Go 1.2 will not allow the form to be parsed unless
+	// the content type header is set.
+	header := http.Header{
+		"Content-Type": {"application/zip"},
+	}
+
 	for method, resolves := range alwaysResolves {
 		c.Logf("test %s", method)
 		// First try with a metadata handler. This should always resolve,
@@ -721,7 +728,9 @@ func (s *RouterSuite) TestRouterMethodsThatPassThroughUnresolvedId(c *gc.C) {
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 			Handler: router,
 			Method:  method,
-			URL:     "http://0.1.2.3/wordpress/meta/metahandler",
+			URL:     "/wordpress/meta/metahandler",
+			Body:    strings.NewReader(""),
+			Header:  header,
 			ExpectBody: &metaHandlerTestResp{
 				CharmURL: "cs:series/wordpress-1234",
 			},
@@ -738,7 +747,9 @@ func (s *RouterSuite) TestRouterMethodsThatPassThroughUnresolvedId(c *gc.C) {
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 			Handler:    router,
 			Method:     method,
-			URL:        "http://0.1.2.3/wordpress/idhandler",
+			Body:       strings.NewReader(""),
+			Header:     header,
+			URL:        "/wordpress/idhandler",
 			ExpectBody: resp,
 		})
 	}
@@ -967,12 +978,12 @@ func (s *RouterSuite) TestServeMux(c *gc.C) {
 	}))
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler:    mux,
-		URL:        "http://0.1.2.3/data",
+		URL:        "/data",
 		ExpectBody: Foo{"hello"},
 	})
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler:    mux,
-		URL:        "http://0.1.2.3/foo",
+		URL:        "/foo",
 		ExpectCode: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Message: "not found",
@@ -992,7 +1003,7 @@ var handlerTests = []struct {
 	handler: HandleErrors(func(http.ResponseWriter, *http.Request) error {
 		return errgo.Newf("an error")
 	}),
-	urlStr:     "http://0.1.2.3",
+	urlStr:     "",
 	expectCode: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "an error",
@@ -1005,7 +1016,7 @@ var handlerTests = []struct {
 			Code:    "snafu",
 		}
 	}),
-	urlStr:     "http://0.1.2.3",
+	urlStr:     "",
 	expectCode: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "something went wrong",
@@ -1099,7 +1110,7 @@ func (s *RouterSuite) TestHandlers(c *gc.C) {
 		c.Logf("test %d: %s", i, test.about)
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 			Handler:    test.handler,
-			URL:        "http://0.1.2.3",
+			URL:        "",
 			ExpectCode: test.expectCode,
 			ExpectBody: test.expectBody,
 		})

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -699,6 +699,12 @@ func (s *RouterSuite) TestRouterGet(c *gc.C) {
 }
 
 func (s *RouterSuite) TestRouterMethodsThatPassThroughUnresolvedId(c *gc.C) {
+	// We omit HEAD because net/http does not send back the body
+	// when doing a HEAD request. Given that there's no actual logic
+	// in the code that is HEAD specific, it seems reasonable to drop the this case.
+	// TODO(rog) Refactor the test to make the handler store the id in a local variable
+	// rather than relying on the returned body.
+
 	alwaysResolves := map[string]bool{
 		"POST":   false,
 		"PUT":    false,

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -428,7 +428,7 @@ func sizeChecker(c *gc.C, data interface{}) {
 func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.Reference, charm.Charm) {
 	url := mustParseReference(curl)
 	wordpress := charmtesting.Charms.CharmDir(charmName)
-	err := s.store.UploadCharm(url, wordpress)
+	err := s.store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
 	return url, wordpress
 }
@@ -436,7 +436,7 @@ func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.Reference, 
 func (s *APISuite) addBundle(c *gc.C, bundleName string, curl string) (*charm.Reference, charm.Bundle) {
 	url := mustParseReference(curl)
 	bundle := charmtesting.Charms.BundleDir(bundleName)
-	err := s.store.UploadBundle(url, bundle)
+	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
 	return url, bundle
 }

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -56,6 +56,7 @@ func (h *handler) serveArchive(charmId *charm.Reference, w http.ResponseWriter, 
 
 func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) (resp *params.ArchivePostResponse, err error) {
 	// Validate the request parameters.
+
 	if id.Series == "" {
 		return nil, badRequestf(nil, "series not specified")
 	}
@@ -72,6 +73,7 @@ func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 
 	// Upload the actual blob, and make sure that it is removed
 	// if we fail later.
+
 	err = h.store.BlobStore.PutUnchallenged(req.Body, req.ContentLength, hash)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot put archive blob")
@@ -89,6 +91,7 @@ func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 	}()
 
 	// Create the entry for the entity in charm store.
+
 	rev, err := h.nextRevisionForId(id)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot get next revision for id")

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -103,7 +103,7 @@ func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 		if err != nil {
 			return nil, errgo.Notef(err, "cannot read bundle archive")
 		}
-		if err := b.Data().Verify(func(string) error { return nil }); err != nil {
+		if err := b.Data().Verify(verifyConstraints); err != nil {
 			return nil, errgo.Notef(err, "bundle verification failed")
 		}
 		if err := h.store.AddBundle(id, b, hash, req.ContentLength); err != nil {
@@ -121,6 +121,11 @@ func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 	return &params.ArchivePostResponse{
 		Id: id,
 	}, nil
+}
+
+func verifyConstraints(s string) error {
+	// TODO(rog) provide some actual constraints checking here.
+	return nil
 }
 
 type readerAtSeeker struct {

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -1,0 +1,151 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/juju/errgo"
+	"gopkg.in/juju/charm.v3"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/charmstore/internal/mongodoc"
+	"github.com/juju/charmstore/internal/router"
+	"github.com/juju/charmstore/params"
+)
+
+// GET id/archive
+// http://tinyurl.com/qjrwq53
+//
+// POST id/archive?sha256=hash
+// http://tinyurl.com/lzrzrgb
+func (h *handler) serveArchive(charmId *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+	switch req.Method {
+	default:
+		// TODO(rog) params.ErrMethodNotAllowed
+		return errgo.Newf("method not allowed")
+	case "POST":
+		resp, err := h.servePostArchive(charmId, w, req)
+		if err != nil {
+			return err
+		}
+		return router.WriteJSON(w, http.StatusOK, resp)
+	case "GET":
+	}
+	var entity mongodoc.Entity
+	if err := h.store.DB.Entities().
+		FindId(charmId).
+		Select(bson.D{{"blobhash", 1}}).
+		One(&entity); err != nil {
+		if err == mgo.ErrNotFound {
+			return params.ErrNotFound
+		}
+		return errgo.Notef(err, "cannot get %s", charmId)
+	}
+	r, size, err := h.store.BlobStore.Open(entity.BlobHash)
+	if err != nil {
+		return errgo.Notef(err, "cannot open archive data for %s", charmId)
+	}
+	defer r.Close()
+	serveContent(w, req, size, r)
+	return nil
+}
+
+func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) (resp *params.ArchivePostResponse, err error) {
+	// Validate the request parameters.
+	if id.Series == "" {
+		return nil, badRequestf(nil, "series not specified")
+	}
+	if id.Revision != -1 {
+		return nil, badRequestf(nil, "revision specified, but should not be specified")
+	}
+	hash := req.Form.Get("hash")
+	if hash == "" {
+		return nil, badRequestf(nil, "hash parameter not specified")
+	}
+	if req.ContentLength == -1 {
+		return nil, badRequestf(nil, "Content-Length not specified")
+	}
+
+	// Upload the actual blob, and make sure that it is removed
+	// if we fail later.
+	err = h.store.BlobStore.PutUnchallenged(req.Body, req.ContentLength, hash)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot put archive blob")
+	}
+	r, _, err := h.store.BlobStore.Open(hash)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot open newly created blob")
+	}
+	defer r.Close()
+	defer func() {
+		if err != nil {
+			h.store.BlobStore.Remove(hash)
+			// TODO(rog) log if remove fails.
+		}
+	}()
+
+	// Create the entry for the entity in charm store.
+	rev, err := h.nextRevisionForId(id)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot get next revision for id")
+	}
+	id.Revision = rev
+	readerAt := &readerAtSeeker{r}
+	if id.Series == "bundle" {
+		b, err := charm.ReadBundleArchiveFromReader(readerAt, req.ContentLength)
+		if err != nil {
+			return nil, errgo.Notef(err, "cannot read bundle archive")
+		}
+		if err := b.Data().Verify(func(string) error { return nil }); err != nil {
+			return nil, errgo.Notef(err, "bundle verification failed")
+		}
+		if err := h.store.AddBundle(id, b, hash, req.ContentLength); err != nil {
+			return nil, errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload))
+		}
+	} else {
+		ch, err := charm.ReadCharmArchiveFromReader(readerAt, req.ContentLength)
+		if err != nil {
+			return nil, errgo.Notef(err, "cannot read charm archive")
+		}
+		if err := h.store.AddCharm(id, ch, hash, req.ContentLength); err != nil {
+			return nil, errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload))
+		}
+	}
+	return &params.ArchivePostResponse{
+		Id: id,
+	}, nil
+}
+
+type readerAtSeeker struct {
+	r io.ReadSeeker
+}
+
+func (r *readerAtSeeker) ReadAt(buf []byte, p int64) (int, error) {
+	if _, err := r.r.Seek(p, 0); err != nil {
+		return 0, errgo.Notef(err, "cannot seek")
+	}
+	return r.r.Read(buf)
+}
+
+func (h *handler) nextRevisionForId(id *charm.Reference) (int, error) {
+	id1 := *id
+	id1.Revision = -1
+	err := ResolveURL(h.store, &id1)
+	if err == nil {
+		return id1.Revision + 1, nil
+	}
+	if errgo.Cause(err) != params.ErrNotFound {
+		return 0, errgo.Notef(err, "cannot resolve id")
+	}
+	return 0, nil
+}
+
+// GET id/archive/…
+// http://tinyurl.com/lampm24
+func (h *handler) serveArchiveFile(charmId *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+	return errNotImplemented
+}

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1,0 +1,413 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+
+	jc "github.com/juju/testing/checkers"
+	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v3/testing"
+	charmtesting "gopkg.in/juju/charm.v3/testing"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/charmstore/internal/blobstore"
+	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/storetesting"
+	"github.com/juju/charmstore/params"
+)
+
+type ArchiveSuite struct {
+	storetesting.IsolatedMgoSuite
+	srv   http.Handler
+	store *charmstore.Store
+}
+
+var _ = gc.Suite(&ArchiveSuite{})
+
+func (s *ArchiveSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	s.srv, s.store = newServer(c, s.Session)
+}
+
+func (s *ArchiveSuite) TestArchiveGet(c *gc.C) {
+	wordpress := charmtesting.Charms.CharmArchive(c.MkDir(), "wordpress")
+	url := mustParseReference("cs:precise/wordpress-23")
+	err := s.store.UploadCharm(url, wordpress)
+	c.Assert(err, gc.IsNil)
+
+	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
+	c.Assert(err, gc.IsNil)
+
+	rec := storetesting.DoRequest(c, s.srv, "GET", storeURL("precise/wordpress-23/archive"), nil, 0, nil)
+	c.Assert(err, gc.IsNil)
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
+
+	// Check that the HTTP range logic is plugged in OK. If this
+	// is working, we assume that the whole thing is working OK,
+	// as net/http is well-tested.
+	rec = storetesting.DoRequest(c, s.srv, "GET", storeURL("precise/wordpress-23/archive"), nil, 0, http.Header{"Range": {"bytes=10-100"}})
+	c.Assert(err, gc.IsNil)
+	c.Assert(rec.Code, gc.Equals, http.StatusPartialContent, gc.Commentf("body: %q", rec.Body.Bytes()))
+	c.Assert(rec.Body.Bytes(), gc.HasLen, 100-10+1)
+	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes[10:101])
+}
+
+var archivePostErrorsTests = []struct {
+	about           string
+	path            string
+	noContentLength bool
+	expectStatus    int
+	expectMessage   string
+	expectCode      params.ErrorCode
+}{{
+	about:         "no series",
+	path:          "wordpress/archive",
+	expectStatus:  http.StatusBadRequest,
+	expectMessage: "series not specified",
+	expectCode:    params.ErrBadRequest,
+}, {
+	about:         "revision specified",
+	path:          "precise/wordpress-23/archive",
+	expectStatus:  http.StatusBadRequest,
+	expectMessage: "revision specified, but should not be specified",
+	expectCode:    params.ErrBadRequest,
+}, {
+	about:         "no hash given",
+	path:          "precise/wordpress/archive",
+	expectStatus:  http.StatusBadRequest,
+	expectMessage: "hash parameter not specified",
+	expectCode:    params.ErrBadRequest,
+}, {
+	about:           "no content length",
+	path:            "precise/wordpress/archive?hash=1234563",
+	noContentLength: true,
+	expectStatus:    http.StatusBadRequest,
+	expectMessage:   "Content-Length not specified",
+	expectCode:      params.ErrBadRequest,
+}}
+
+func (s *ArchiveSuite) TestArchivePostErrors(c *gc.C) {
+	type exoticReader struct {
+		io.Reader
+	}
+	for i, test := range archivePostErrorsTests {
+		c.Logf("test %d: %s", i, test.about)
+		var body io.Reader = strings.NewReader("bogus")
+		if test.noContentLength {
+			// net/http will automatically add a Content-Length header
+			// if it sees *strings.Reader, but not if it's a type it doesn't
+			// know about.
+			body = exoticReader{body}
+		}
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler: s.srv,
+			URL:     storeURL(test.path),
+			Method:  "POST",
+			Header: http.Header{
+				"Content-Type": {"application/zip"},
+			},
+			Body:       body,
+			ExpectCode: test.expectStatus,
+			ExpectBody: params.Error{
+				Message: test.expectMessage,
+				Code:    test.expectCode,
+			},
+		})
+	}
+}
+
+func (s *ArchiveSuite) TestConcurrentUploads(c *gc.C) {
+	wordpress := charmtesting.Charms.CharmArchive(c.MkDir(), "wordpress")
+	f, err := os.Open(wordpress.Path)
+	c.Assert(err, gc.IsNil)
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, f)
+	c.Assert(err, gc.IsNil)
+
+	hash, _ := hashOf(bytes.NewReader(buf.Bytes()))
+
+	srv := httptest.NewServer(s.srv)
+	defer srv.Close()
+
+	// Our strategy for testing concurrent uploads is as follows: We
+	// repeat uploading a bunch of simultaneous uploads to the same
+	// charm. Each upload should either succeed, or fail with an
+	// ErrDuplicateUpload error. We make sure that all replies are
+	// like this, and that at least one duplicate upload error is
+	// found, so that we know we've tested that error path.
+
+	errorBodies := make(chan io.ReadCloser)
+
+	// upload performs one upload of the testing charm.
+	// It sends the response body on the errorBodies channel when
+	// it finds an error response.
+	upload := func() {
+		c.Logf("uploading")
+		body := bytes.NewReader(buf.Bytes())
+		url := srv.URL + storeURL("precise/wordpress/archive?hash="+hash)
+		resp, err := http.Post(url, "application/zip", body)
+		if !c.Check(err, gc.IsNil) {
+			return
+		}
+		if resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return
+		}
+		errorBodies <- resp.Body
+	}
+
+	// The try loop continues concurrently uploading
+	// charms until it is told to stop (by closing the try
+	// channel). It then signals that it has terminated
+	// by closing errorBodies.
+	try := make(chan struct{})
+	go func() {
+		for {
+			for _ = range try {
+				var wg sync.WaitGroup
+				for p := 0; p < 5; p++ {
+					wg.Add(1)
+					go func() {
+						upload()
+						wg.Done()
+					}()
+				}
+				wg.Wait()
+			}
+			close(errorBodies)
+		}
+	}()
+
+	// We continue the loop until we have found an
+	// error (or the maximum iteration count has
+	// been exceeded).
+	foundError := false
+	count := 0
+loop:
+	for {
+		select {
+		case body, ok := <-errorBodies:
+			if !ok {
+				// The try loop has terminated,
+				// so we need to stop too.
+				break loop
+			}
+			dec := json.NewDecoder(body)
+			var errResp params.Error
+			err := dec.Decode(&errResp)
+			body.Close()
+			c.Assert(err, gc.IsNil)
+			c.Assert(errResp, jc.DeepEquals, params.Error{
+				Message: "duplicate upload",
+				Code:    params.ErrDuplicateUpload,
+			})
+			// We've found the error we're looking for,
+			// so we signal to the try loop that it can stop.
+			// We will process any outstanding error bodies,
+			// before seeing errorBodies closed and exiting
+			// the loop.
+			close(try)
+			try = nil
+			foundError = true
+		case try <- struct{}{}:
+			// In cases we've seen, the actual maximum value of
+			// count is 1, but let's allow for serious scheduler vagaries.
+			if count++; count > 200 {
+				c.Fatalf("200 tries with no duplicate error")
+			}
+		}
+	}
+	if !foundError {
+		c.Errorf("no duplicate-upload errors found")
+	}
+}
+
+func (s *ArchiveSuite) TestArchivePostCharm(c *gc.C) {
+	// A charm that did not exist before should get revision 0.
+	s.assertUploadCharm(c, mustParseReference("precise/wordpress-0"), "wordpress")
+
+	// Subsequent charm uploads should increment the
+	// revision by 1.
+	s.assertUploadCharm(c, mustParseReference("precise/wordpress-1"), "wordpress")
+}
+
+func (s *ArchiveSuite) TestArchivePostBundle(c *gc.C) {
+	// A bundle that did not exist before should get revision 0.
+	s.assertUploadBundle(c, mustParseReference("bundle/wordpress-0"), "wordpress")
+
+	// Subsequent bundle uploads should increment the
+	// revision by 1.
+	s.assertUploadBundle(c, mustParseReference("bundle/wordpress-1"), "wordpress")
+}
+
+func invalidZip() io.ReadSeeker {
+	return strings.NewReader("invalid zip content")
+}
+
+func (s *ArchiveSuite) TestPostInvalidCharmZip(c *gc.C) {
+	s.assertCannotUpload(c, "precise/wordpress", invalidZip(), "cannot read charm archive: zip: not a valid zip file")
+}
+
+func (s *ArchiveSuite) TestPostInvalidBundleZip(c *gc.C) {
+	s.assertCannotUpload(c, "bundle/wordpress", invalidZip(), "cannot read bundle archive: zip: not a valid zip file")
+}
+
+func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
+	path := testing.Charms.BundleArchivePath(c.MkDir(), "bad")
+	f, err := os.Open(path)
+	c.Assert(err, gc.IsNil)
+	defer f.Close()
+	expectErr := `bundle verification failed: relation ["foo:db" "mysql:server"] refers to service "foo" not defined in this bundle`
+	s.assertCannotUpload(c, "bundle/wordpress", f, expectErr)
+}
+
+func (s *ArchiveSuite) assertCannotUpload(c *gc.C, id string, content io.ReadSeeker, errorMessage string) {
+	hash, size := hashOf(content)
+	_, err := content.Seek(0, 0)
+	c.Assert(err, gc.IsNil)
+
+	path := fmt.Sprintf("%s/archive?hash=%s", id, hash)
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:       s.srv,
+		URL:           storeURL(path),
+		Method:        "POST",
+		ContentLength: size,
+		Header: http.Header{
+			"Content-Type": {"application/zip"},
+		},
+		Body:       content,
+		ExpectCode: http.StatusInternalServerError,
+
+		ExpectBody: params.Error{
+			Message: errorMessage,
+		},
+	})
+
+	// Check that the uploaded blob has been deleted.
+	_, _, err = s.store.BlobStore.Open(hash)
+	c.Assert(err, gc.ErrorMatches, "resource.*not found")
+}
+
+// assertUploadCharm uploads the testing charm with the given name
+// through the API. The URL must hold the expected revision
+// that the charm will be given when uploaded.
+func (s *ArchiveSuite) assertUploadCharm(c *gc.C, url *charm.Reference, charmName string) {
+	ch := testing.Charms.CharmArchive(c.MkDir(), charmName)
+	size := s.assertUpload(c, url, ch.Path)
+	s.assertEntityInfo(c, url, entityInfo{
+		Id: url,
+		Meta: entityMetaInfo{
+			ArchiveSize:  size,
+			CharmMeta:    ch.Meta(),
+			CharmConfig:  ch.Config(),
+			CharmActions: ch.Actions(),
+		},
+	},
+	)
+}
+
+// assertUploadBundle uploads the testing bundle with the given name
+// through the API. The URL must hold the expected revision
+// that the bundle will be given when uploaded.
+func (s *ArchiveSuite) assertUploadBundle(c *gc.C, url *charm.Reference, bundleName string) {
+	path := testing.Charms.BundleArchivePath(c.MkDir(), bundleName)
+	b, err := charm.ReadBundleArchive(path)
+	c.Assert(err, gc.IsNil)
+	size := s.assertUpload(c, url, path)
+	s.assertEntityInfo(c, url, entityInfo{
+		Id: url,
+		Meta: entityMetaInfo{
+			ArchiveSize: size,
+			BundleMeta:  b.Data(),
+		},
+	},
+	)
+}
+
+func (s *ArchiveSuite) assertUpload(c *gc.C, url *charm.Reference, fileName string) (size int64) {
+	f, err := os.Open(fileName)
+	c.Assert(err, gc.IsNil)
+	defer f.Close()
+	hash, size := hashOf(f)
+	_, err = f.Seek(0, 0)
+	c.Assert(err, gc.IsNil)
+
+	uploadURL := *url
+	uploadURL.Revision = -1
+
+	path := fmt.Sprintf("%s/archive?hash=%s", strings.TrimPrefix(uploadURL.String(), "cs:"), hash)
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:       s.srv,
+		URL:           storeURL(path),
+		Method:        "POST",
+		ContentLength: size,
+		Header: http.Header{
+			"Content-Type": {"application/zip"},
+		},
+		Body: f,
+		ExpectBody: params.ArchivePostResponse{
+			Id: url,
+		},
+	})
+
+	// Test that the expected entry has been created
+	// in the blob store.
+	r, _, err := s.store.BlobStore.Open(hash)
+	c.Assert(err, gc.IsNil)
+	r.Close()
+	return size
+}
+
+// entityInfo holds all the information we want to find
+// out about a charm or bundle uploaded to the store.
+type entityInfo struct {
+	Id   *charm.Reference
+	Meta entityMetaInfo
+}
+
+type entityMetaInfo struct {
+	// TODO(rog) change to params.ArchiveSizeResponse when archive-size endpoint
+	// is fixed.
+	ArchiveSize  int64             `json:"archive-size"`
+	CharmMeta    *charm.Meta       `json:"charm-metadata,omitempty"`
+	CharmConfig  *charm.Config     `json:"charm-config,omitempty"`
+	CharmActions *charm.Actions    `json:"charm-actions,omitempty"`
+	BundleMeta   *charm.BundleData `json:"bundle-metadata,omitempty"`
+}
+
+func (s *ArchiveSuite) assertEntityInfo(c *gc.C, url *charm.Reference, expect entityInfo) {
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler: s.srv,
+		URL: storeURL(
+			strings.TrimPrefix(url.String(), "cs:") + "/meta/any" +
+				"?include=archive-size" +
+				"&include=charm-metadata" +
+				"&include=charm-config" +
+				"&include=charm-actions" +
+				"&include=bundle-metadata",
+		),
+		ExpectBody: expect,
+	})
+}
+
+func hashOf(r io.Reader) (hashSum string, size int64) {
+	hash := blobstore.NewHash()
+	n, err := io.Copy(hash, r)
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), n
+}

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -33,7 +33,7 @@ func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (int
 	case "week":
 		by = charmstore.ByWeek
 	default:
-		return nil, errgo.WithCausef(nil, params.ErrBadRequest, "invalid 'by' value: %q", v)
+		return nil, badRequestf(nil, "invalid 'by' value %q", v)
 	}
 	req := charmstore.CounterRequest{
 		Key:  strings.Split(base, ":"),
@@ -44,14 +44,14 @@ func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (int
 		var err error
 		req.Start, err = time.Parse("2006-01-02", v)
 		if err != nil {
-			return nil, errgo.WithCausef(err, params.ErrBadRequest, "invalid 'start' value %q", v)
+			return nil, badRequestf(err, "invalid 'start' value %q", v)
 		}
 	}
 	if v := r.Form.Get("stop"); v != "" {
 		var err error
 		req.Stop, err = time.Parse("2006-01-02", v)
 		if err != nil {
-			return nil, errgo.WithCausef(err, params.ErrBadRequest, "invalid 'stop' value %q", v)
+			return nil, badRequestf(err, "invalid 'stop' value %q", v)
 		}
 		// Cover all timestamps within the stop day.
 		req.Stop = req.Stop.Add(24*time.Hour - 1*time.Second)

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -83,7 +83,7 @@ func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 	}, {
 		path:    "stats/counter/any?by=fortnight",
 		status:  http.StatusBadRequest,
-		message: `invalid 'by' value: "fortnight"`,
+		message: `invalid 'by' value "fortnight"`,
 		code:    params.ErrBadRequest,
 	}, {
 		path:    "stats/counter/any?start=tomorrow",

--- a/params/error.go
+++ b/params/error.go
@@ -16,6 +16,7 @@ const (
 	ErrMetadataNotFound ErrorCode = "metadata not found"
 	ErrForbidden        ErrorCode = "forbidden"
 	ErrBadRequest       ErrorCode = "bad request"
+	ErrDuplicateUpload  ErrorCode = "duplicate upload"
 )
 
 // Error represents an error - it is returned for any response

--- a/params/params.go
+++ b/params/params.go
@@ -24,3 +24,9 @@ type Statistic struct {
 	Date  string `json:",omitempty"`
 	Count int64
 }
+
+// ArchivePostResponse holds the result of
+// a post to /$id/archive. See http://tinyurl.com/lzrzrgb
+type ArchivePostResponse struct {
+	Id *charm.Reference
+}

--- a/server_test.go
+++ b/server_test.go
@@ -56,7 +56,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler:    h,
-		URL:        "http://0.1.2.3/v4/debug",
+		URL:        "/v4/debug",
 		ExpectCode: http.StatusInternalServerError,
 		ExpectBody: params.Error{
 			Message: "method not implemented",
@@ -68,7 +68,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 func assertServesVersion(c *gc.C, h http.Handler, vers string) {
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler: h,
-		URL:     "http://0.1.2.3/" + vers + "/some/path",
+		URL:     "/" + vers + "/some/path",
 		ExpectBody: versionResponse{
 			Version: vers,
 			Path:    "/some/path",
@@ -79,7 +79,7 @@ func assertServesVersion(c *gc.C, h http.Handler, vers string) {
 func assertDoesNotServeVersion(c *gc.C, h http.Handler, vers string) {
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler:    h,
-		URL:        "http://0.1.2.3/" + vers + "/debug",
+		URL:        "/" + vers + "/debug",
 		ExpectCode: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Message: "not found",


### PR DESCRIPTION
We don't yet verify bundles against charms in the store.

This required some refactoring of the testing code;
the most important change is AssertJSONCall actually
makes a real HTTP call through a socket, as that
allows us to correctly test the ContentLength logic.
It also gives us greater assurance that the logic
will work over a real HTTP connection. The overhead
seems to be negligible.
