### PR TITLE
internal/blobstore: check content hash when uploading

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,5 @@
 code.google.com/p/go.crypto	hg	aa2644fe4aa50e3b38d75187b4799b1f0c9ddcef	212
-github.com/juju/blobstore	git	cb12cc93f02a9b83d4f8cc635b505d8423be4181	
+github.com/juju/blobstore	git	cd6cafb4214d1d23a7e3efbe3f20738fb912ee4f	
 github.com/juju/errgo	git	2cf7b553faddc588f903020c33e71c527d5e0838	
 github.com/juju/errors	git	11f260fcce20d158a2c68d6d2a7fb6b98e83b658	
 github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -54,6 +54,46 @@ func (s *BlobStoreSuite) TestPutOpen(c *gc.C) {
 	c.Assert(chal, gc.IsNil)
 }
 
+func (s *BlobStoreSuite) TestPutInvalidHash(c *gc.C) {
+	store := blobstore.New(s.Session.DB("db"), "blobstore")
+	content := "some data"
+	chal, err := store.Put(strings.NewReader(content), int64(len(content)), hashOf("wrong"), nil)
+	c.Assert(err, gc.ErrorMatches, "hash mismatch")
+	c.Assert(chal, gc.IsNil)
+
+	rc, length, err := store.Open(hashOf(content))
+	c.Assert(err, gc.ErrorMatches, "resource.*not found")
+	c.Assert(rc, gc.Equals, nil)
+	c.Assert(length, gc.Equals, int64(0))
+}
+
+func (s *BlobStoreSuite) TestPutUnchallenged(c *gc.C) {
+	store := blobstore.New(s.Session.DB("db"), "blobstore")
+
+	content := "some data"
+	err := store.PutUnchallenged(strings.NewReader(content), int64(len(content)), hashOf(content))
+	c.Assert(err, gc.IsNil)
+
+	rc, length, err := store.Open(hashOf(content))
+	c.Assert(err, gc.IsNil)
+	defer rc.Close()
+	c.Assert(length, gc.Equals, int64(len(content)))
+
+	data, err := ioutil.ReadAll(rc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Equals, content)
+
+	err = store.PutUnchallenged(strings.NewReader(content), int64(len(content)), hashOf(content))
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *BlobStoreSuite) TestPutUnchallengedInvalidHash(c *gc.C) {
+	store := blobstore.New(s.Session.DB("db"), "blobstore")
+	content := "some data"
+	err := store.PutUnchallenged(strings.NewReader(content), int64(len(content)), hashOf("wrong"))
+	c.Assert(err, gc.ErrorMatches, "hash mismatch")
+}
+
 func (s *BlobStoreSuite) TestRemove(c *gc.C) {
 	store := blobstore.New(s.Session.DB("db"), "blobstore")
 	content := "some data"


### PR DESCRIPTION
We can now check the content hash with the new method implemented in juju/blobstore.
