### PR TITLE
Fix the meta archive-size response.

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -237,7 +237,9 @@ func (h *handler) metaColor(id *charm.Reference, path string, flags url.Values) 
 // GET id/meta/archive-size
 // http://tinyurl.com/m8b9geq
 func (h *handler) metaArchiveSize(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
-	return entity.Size, nil
+	return &params.ArchiveSizeResponse{
+		Size: entity.Size,
+	}, nil
 }
 
 // GET id/meta/stats/

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -106,14 +106,13 @@ var metaEndpoints = []metaEndpoint{{
 		c.Assert(data.(*charm.Actions).ActionSpecs["snapshot"].Description, gc.Equals, "Take a snapshot of the database.")
 	},
 }, {
-	name:            "archive-size", // Charm size.
-	get:             entityGetter(entitySizeGetter),
+	name: "archive-size",
+	get: entityGetter(func(entity *mongodoc.Entity) interface{} {
+		return &params.ArchiveSizeResponse{
+			Size: entity.Size,
+		}
+	}),
 	checkURL:        "cs:precise/wordpress-23",
-	assertCheckData: entitySizeChecker,
-}, {
-	name:            "archive-size", // Bundle size.
-	get:             entityGetter(entitySizeGetter),
-	checkURL:        "cs:bundle/wordpress-42",
 	assertCheckData: entitySizeChecker,
 }}
 
@@ -418,12 +417,6 @@ func entityGetter(get func(*mongodoc.Entity) interface{}) func(*charmstore.Store
 			return nil, errgo.Mask(err)
 		}
 		return get(&doc), nil
-	}
-}
-
-func entitySizeGetter(entity *mongodoc.Entity) interface{} {
-	return &params.ArchiveSizeResponse{
-		Size: entity.Size,
 	}
 }
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -107,14 +107,14 @@ var metaEndpoints = []metaEndpoint{{
 	},
 }, {
 	name:            "archive-size", // Charm size.
-	get:             entityFieldGetter("Size"),
+	get:             entityGetter(entitySizeGetter),
 	checkURL:        "cs:precise/wordpress-23",
-	assertCheckData: sizeChecker,
+	assertCheckData: entitySizeChecker,
 }, {
 	name:            "archive-size", // Bundle size.
-	get:             entityFieldGetter("Size"),
+	get:             entityGetter(entitySizeGetter),
 	checkURL:        "cs:bundle/wordpress-42",
-	assertCheckData: sizeChecker,
+	assertCheckData: entitySizeChecker,
 }}
 
 // TestEndpointGet tries to ensure that the endpoint
@@ -421,8 +421,15 @@ func entityGetter(get func(*mongodoc.Entity) interface{}) func(*charmstore.Store
 	}
 }
 
-func sizeChecker(c *gc.C, data interface{}) {
-	c.Assert(data.(int64), gc.Not(gc.Equals), int64(0))
+func entitySizeGetter(entity *mongodoc.Entity) interface{} {
+	return &params.ArchiveSizeResponse{
+		Size: entity.Size,
+	}
+}
+
+func entitySizeChecker(c *gc.C, data interface{}) {
+	response := data.(*params.ArchiveSizeResponse)
+	c.Assert(response.Size, gc.Not(gc.Equals), int64(0))
 }
 
 func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.Reference, charm.Charm) {

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -307,7 +307,7 @@ func (s *ArchiveSuite) assertUploadCharm(c *gc.C, url *charm.Reference, charmNam
 	s.assertEntityInfo(c, url, entityInfo{
 		Id: url,
 		Meta: entityMetaInfo{
-			ArchiveSize:  size,
+			ArchiveSize:  &params.ArchiveSizeResponse{Size: size},
 			CharmMeta:    ch.Meta(),
 			CharmConfig:  ch.Config(),
 			CharmActions: ch.Actions(),
@@ -327,7 +327,7 @@ func (s *ArchiveSuite) assertUploadBundle(c *gc.C, url *charm.Reference, bundleN
 	s.assertEntityInfo(c, url, entityInfo{
 		Id: url,
 		Meta: entityMetaInfo{
-			ArchiveSize: size,
+			ArchiveSize: &params.ArchiveSizeResponse{Size: size},
 			BundleMeta:  b.Data(),
 		},
 	},
@@ -376,13 +376,11 @@ type entityInfo struct {
 }
 
 type entityMetaInfo struct {
-	// TODO(rog) change to params.ArchiveSizeResponse when archive-size endpoint
-	// is fixed.
-	ArchiveSize  int64             `json:"archive-size"`
-	CharmMeta    *charm.Meta       `json:"charm-metadata,omitempty"`
-	CharmConfig  *charm.Config     `json:"charm-config,omitempty"`
-	CharmActions *charm.Actions    `json:"charm-actions,omitempty"`
-	BundleMeta   *charm.BundleData `json:"bundle-metadata,omitempty"`
+	ArchiveSize  *params.ArchiveSizeResponse `json:"archive-size,omitempty"`
+	CharmMeta    *charm.Meta                 `json:"charm-metadata,omitempty"`
+	CharmConfig  *charm.Config               `json:"charm-config,omitempty"`
+	CharmActions *charm.Actions              `json:"charm-actions,omitempty"`
+	BundleMeta   *charm.BundleData           `json:"bundle-metadata,omitempty"`
 }
 
 func (s *ArchiveSuite) assertEntityInfo(c *gc.C, url *charm.Reference, expect entityInfo) {

--- a/params/params.go
+++ b/params/params.go
@@ -30,3 +30,9 @@ type Statistic struct {
 type ArchivePostResponse struct {
 	Id *charm.Reference
 }
+
+// ArchiveSizeResponse holds the result of an
+// id/meta/archive-size GET request. See http://tinyurl.com/m8b9geq
+type ArchiveSizeResponse struct {
+	Size int64
+}


### PR DESCRIPTION
Now the size is wrapped in a struct as required by the spec.
