### PR TITLE
cmd/charmd: update to use gopkg.in/yaml.v1

### DIFF
--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 
 	"gopkg.in/mgo.v2"
-	"launchpad.net/goyaml"
+	"gopkg.in/yaml.v1"
 
 	"github.com/juju/charmstore"
 )
@@ -70,7 +70,7 @@ func readConfig(path string) (*config, error) {
 		return nil, fmt.Errorf("reading config file: %v", err)
 	}
 	var conf config
-	err = goyaml.Unmarshal(data, &conf)
+	err = yaml.Unmarshal(data, &conf)
 	if err != nil {
 		return nil, fmt.Errorf("processing config file: %v", err)
 	}

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,8 +10,8 @@ github.com/juju/names	git	93fc8cbf8111c11d4ff47e603f668a0e29fb7cec
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	
 github.com/juju/testing	git	8bdbb45d87dd9724c254eb6afeacd84b127d7e76	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
-github.com/juju/utils	git	7f3110a0b4f01e5800e72b50cc92c8e9de4ea658	
-gopkg.in/juju/charm.v3	git	0b5cc48fc4aceac821c7810fe54001fa05dcb781	
+github.com/juju/utils	git	68554773385c32c354bf6357f8b6edd8a4742682	
+gopkg.in/juju/charm.v3	git	eb7dae8ed9dfa44b89e4e8eee6e21f80e31a3b69	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
+gopkg.in/yaml.v1	git	1b9791953ba4027efaeb728c7355e542a203be5e	
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
-launchpad.net/goyaml	bzr	gustavo@niemeyer.net-20131114120802-abe042syx64z2m7s	50


### PR DESCRIPTION
This brings us into line with juju-core, which has just changed to
do the same.
