### PR TITLE
use blob names instead of hashes

### DIFF
--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -60,8 +60,8 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm) {
 	c.Assert(blobName, gc.Matches, "[0-9a-z]+")
 	doc.BlobName = ""
 	c.Assert(doc, jc.DeepEquals, mongodoc.Entity{
-		URL:     url,
-		BaseURL: mustParseReference("cs:wordpress"),
+		URL:                     url,
+		BaseURL:                 mustParseReference("cs:wordpress"),
 		BlobHash:                hash,
 		Size:                    size,
 		CharmMeta:               ch.Meta(),

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -62,7 +62,6 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm) {
 	c.Assert(doc, jc.DeepEquals, mongodoc.Entity{
 		URL:     url,
 		BaseURL: mustParseReference("cs:wordpress"),
-
 		BlobHash:                hash,
 		Size:                    size,
 		CharmMeta:               ch.Meta(),
@@ -112,6 +111,8 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle) {
 	c.Assert(doc.UploadTime, jc.TimeBetween(beforeAdding, afterAdding))
 	doc.UploadTime = time.Time{}
 
+	// The blob name is random, but we check that it's
+	// in the correct format, and non-empty.
 	blobName := doc.BlobName
 	c.Assert(blobName, gc.Matches, "[0-9a-z]+")
 	doc.BlobName = ""

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -56,9 +56,13 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm) {
 
 	doc.UploadTime = time.Time{}
 
+	blobName := doc.BlobName
+	c.Assert(blobName, gc.Matches, "[0-9a-z]+")
+	doc.BlobName = ""
 	c.Assert(doc, jc.DeepEquals, mongodoc.Entity{
-		URL:                     url,
-		BaseURL:                 mustParseReference("cs:wordpress"),
+		URL:     url,
+		BaseURL: mustParseReference("cs:wordpress"),
+
 		BlobHash:                hash,
 		Size:                    size,
 		CharmMeta:               ch.Meta(),
@@ -69,7 +73,7 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm) {
 	})
 
 	// The charm archive has been properly added to the blob store.
-	r, obtainedSize, err := store.BlobStore.Open(hash)
+	r, obtainedSize, err := store.BlobStore.Open(blobName)
 	c.Assert(err, gc.IsNil)
 	c.Assert(obtainedSize, gc.Equals, size)
 	data, err := ioutil.ReadAll(r)
@@ -108,6 +112,10 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle) {
 	c.Assert(doc.UploadTime, jc.TimeBetween(beforeAdding, afterAdding))
 	doc.UploadTime = time.Time{}
 
+	blobName := doc.BlobName
+	c.Assert(blobName, gc.Matches, "[0-9a-z]+")
+	doc.BlobName = ""
+
 	// The entity doc has been correctly added to the mongo collection.
 	size, hash := mustGetSizeAndHash(bundle)
 	c.Assert(doc, jc.DeepEquals, mongodoc.Entity{
@@ -124,7 +132,7 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle) {
 	})
 
 	// The bundle archive has been properly added to the blob store.
-	r, obtainedSize, err := store.BlobStore.Open(hash)
+	r, obtainedSize, err := store.BlobStore.Open(blobName)
 	c.Assert(err, gc.IsNil)
 	c.Assert(obtainedSize, gc.Equals, size)
 	data, err := ioutil.ReadAll(r)

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -26,7 +26,7 @@ type Entity struct {
 	// TODO(rog) rename this to BlobSize.
 	Size int64
 
-	// BlobName holds the  name that the archive blob is given in the blob store.
+	// BlobName holds the name that the archive blob is given in the blob store.
 	BlobName string
 
 	UploadTime time.Time

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -18,8 +18,16 @@ type Entity struct {
 	// e.g. cs:wordpress, cs:~user/foo
 	BaseURL *charm.Reference
 
-	BlobHash string // This is also used as a blob reference.
-	Size     int64
+	// BlobHash holds the hash checksum of the blob, in hexadecimal format,
+	// as created by blobstore.NewHash.
+	BlobHash string
+
+	// Size holds the size of the archive blob.
+	// TODO(rog) rename this to BlobSize.
+	Size int64
+
+	// BlobName holds the  name that the archive blob is given in the blob store.
+	BlobName string
 
 	UploadTime time.Time
 

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -49,7 +49,7 @@ func New(store *charmstore.Store) http.Handler {
 			"charm-config":        h.entityHandler(h.metaCharmConfig, "charmconfig"),
 			"charm-actions":       h.entityHandler(h.metaCharmActions, "charmactions"),
 			"archive-size":        h.entityHandler(h.metaArchiveSize, "size"),
-			"manifest":            h.entityHandler(h.metaManifest, "blobhash"),
+			"manifest":            h.entityHandler(h.metaManifest, "blobname"),
 			"archive-upload-time": h.entityHandler(h.metaArchiveUploadTime, "uploadtime"),
 
 			// endpoints not yet implemented - use SingleIncludeHandler for the time being.
@@ -214,7 +214,7 @@ func (h *handler) metaBundleMetadata(entity *mongodoc.Entity, id *charm.Referenc
 // GET id/meta/manifest
 // http://tinyurl.com/p3xdcto
 func (h *handler) metaManifest(entity *mongodoc.Entity, id *charm.Reference, path, method string, flags url.Values) (interface{}, error) {
-	r, size, err := h.store.BlobStore.Open(entity.BlobHash)
+	r, size, err := h.store.BlobStore.Open(entity.BlobName)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot open archive data for %s", id)
 	}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -464,11 +464,11 @@ func zipGetter(get func(*zip.Reader) interface{}) metaEndpointExpectedValueGette
 		var doc mongodoc.Entity
 		if err := store.DB.Entities().
 			FindId(url).
-			Select(bson.D{{"blobhash", 1}}).
+			Select(bson.D{{"blobname", 1}}).
 			One(&doc); err != nil {
 			return nil, errgo.Mask(err)
 		}
-		blob, size, err := store.BlobStore.Open(doc.BlobHash)
+		blob, size, err := store.BlobStore.Open(doc.BlobName)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -89,16 +89,13 @@ func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 		}
 	}()
 
-	// Assign a new revision to the id, so that we know what name
-	// give the archive in the store.
+	// Create the entry for the entity in charm store.
+
 	rev, err := h.nextRevisionForId(id)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot get next revision for id")
 	}
 	id.Revision = rev
-
-	// Create the entry for the entity in charm store.
-
 	readerAt := &readerAtSeeker{r}
 	if id.Series == "bundle" {
 		b, err := charm.ReadBundleArchiveFromReader(readerAt, req.ContentLength)


### PR DESCRIPTION
We can't use content addressing with juju blob store,
as discussed ad nauseam online.

This is a redo of https://github.com/juju/charmstore/pull/71,
which had accidentally pulled in some code from another
branch.
