### PR TITLE
Implement the charm-related API.

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -51,6 +51,7 @@ func New(store *charmstore.Store) http.Handler {
 			"archive-size":        h.entityHandler(h.metaArchiveSize, "size"),
 			"manifest":            h.entityHandler(h.metaManifest, "blobname"),
 			"archive-upload-time": h.entityHandler(h.metaArchiveUploadTime, "uploadtime"),
+			"charm-related":       h.entityHandler(h.metaCharmRelated, "charmprovidedinterfaces", "charmrequiredinterfaces"),
 
 			// endpoints not yet implemented - use SingleIncludeHandler for the time being.
 			"color":              router.SingleIncludeHandler(h.metaColor),
@@ -58,7 +59,6 @@ func New(store *charmstore.Store) http.Handler {
 			"revision-info":      router.SingleIncludeHandler(h.metaRevisionInfo),
 			"extra-info":         router.SingleIncludeHandler(h.metaExtraInfo),
 			"extra-info/":        router.SingleIncludeHandler(h.metaExtraInfoWithKey),
-			"charm-related":      router.SingleIncludeHandler(h.metaCharmRelated),
 		},
 	}, h.resolveURL)
 	return h
@@ -292,12 +292,6 @@ func (h *handler) metaExtraInfo(id *charm.Reference, path string, method string,
 // GET id/meta/extra-info/key
 // http://tinyurl.com/polrbn7
 func (h *handler) metaExtraInfoWithKey(id *charm.Reference, path string, method string, flags url.Values) (interface{}, error) {
-	return nil, errNotImplemented
-}
-
-// GET id/meta/charm-related[?include=meta[&include=meta…]]
-// http://tinyurl.com/q7vdmzl
-func (h *handler) metaCharmRelated(id *charm.Reference, path string, method string, flags url.Values) (interface{}, error) {
 	return nil, errNotImplemented
 }
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -11,11 +11,9 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/juju/errgo"
-	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
@@ -29,10 +27,6 @@ import (
 	"github.com/juju/charmstore/internal/v4"
 	"github.com/juju/charmstore/params"
 )
-
-func TestPackage(t *testing.T) {
-	jujutesting.MgoTestPackage(t, nil)
-}
 
 type APISuite struct {
 	storetesting.IsolatedMgoSuite

--- a/internal/v4/package_test.go
+++ b/internal/v4/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4_test
+
+import (
+	"testing"
+
+	jujutesting "github.com/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	jujutesting.MgoTestPackage(t, nil)
+}

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -1,0 +1,134 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4
+
+import (
+	"net/url"
+
+	"github.com/juju/errgo"
+	"gopkg.in/juju/charm.v3"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/charmstore/internal/mongodoc"
+	"github.com/juju/charmstore/params"
+)
+
+// GET id/meta/charm-related[?include=meta[&include=meta…]]
+// http://tinyurl.com/q7vdmzl
+func (h *handler) metaCharmRelated(entity *mongodoc.Entity, id *charm.Reference, path, method string, flags url.Values) (interface{}, error) {
+	// If the charm does not define any relation we can just return without
+	// hitting the db.
+	if len(entity.CharmProvidedInterfaces)+len(entity.CharmRequiredInterfaces) == 0 {
+		return &params.RelatedResponse{}, nil
+	}
+
+	// Build the query to retrieve the related entities.
+	query := bson.M{
+		"$or": []bson.M{
+			bson.M{"charmrequiredinterfaces": bson.M{
+				"$elemMatch": bson.M{"$in": entity.CharmProvidedInterfaces},
+			}},
+			bson.M{"charmprovidedinterfaces": bson.M{
+				"$elemMatch": bson.M{"$in": entity.CharmRequiredInterfaces},
+			}},
+		},
+	}
+	fields := bson.D{
+		{"_id", 1},
+		{"charmrequiredinterfaces", 1},
+		{"charmprovidedinterfaces", 1},
+	}
+
+	// Retrieve the entities from the database.
+	var entities []mongodoc.Entity
+	if err := h.store.DB.Entities().Find(query).Select(fields).All(&entities); err != nil {
+		return nil, errgo.Notef(err, "cannot retrieve the related charms")
+	}
+
+	// If no entities are found there is no need for further processing the
+	// results.
+	if len(entities) == 0 {
+		return &params.RelatedResponse{}, nil
+	}
+
+	// Build the results, by grouping entities based on their relations' roles
+	// and interfaces.
+	includes := flags["include"]
+	requires, err := h.getRelatedCharmsResponse(entity.CharmProvidedInterfaces, entities, func(e mongodoc.Entity) []string {
+		return e.CharmRequiredInterfaces
+	}, includes)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot retrieve the charm requires")
+	}
+	provides, err := h.getRelatedCharmsResponse(entity.CharmRequiredInterfaces, entities, func(e mongodoc.Entity) []string {
+		return e.CharmProvidedInterfaces
+	}, includes)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot retrieve the charm provides")
+	}
+
+	// Return the response.
+	return &params.RelatedResponse{
+		Requires: requires,
+		Provides: provides,
+	}, nil
+}
+
+type entityRelatedInterfacesGetter func(mongodoc.Entity) []string
+
+// getRelatedCharmsResponse returns a response mapping interfaces to related
+// charms. For instance:
+//   map[string][]params.MetaAnyResponse{
+//       "http": []params.MetaAnyResponse{
+//           {Id: "cs:utopic/django-42", Meta: ...},
+//           {Id: "cs:trusty/wordpress-47", Meta: ...},
+//       },
+//       "memcache": []params.MetaAnyResponse{
+//           {Id: "cs:utopic/memcached-0", Meta: ...},
+//       },
+//   }
+func (h *handler) getRelatedCharmsResponse(
+	ifaces []string,
+	entities []mongodoc.Entity,
+	getInterfaces entityRelatedInterfacesGetter,
+	includes []string) (map[string][]params.MetaAnyResponse, error) {
+	results := make(map[string][]params.MetaAnyResponse, len(ifaces))
+	for _, iface := range ifaces {
+		responses, err := h.getRelatedIfaceResponses(iface, entities, getInterfaces, includes)
+		if err != nil {
+			return nil, err
+		}
+		if len(responses) > 0 {
+			results[iface] = responses
+		}
+	}
+	return results, nil
+}
+
+func (h *handler) getRelatedIfaceResponses(
+	iface string,
+	entities []mongodoc.Entity,
+	getInterfaces entityRelatedInterfacesGetter,
+	includes []string) ([]params.MetaAnyResponse, error) {
+	// Build a list of responses including entities which are related
+	// to the given interface.
+	responses := make([]params.MetaAnyResponse, 0, len(entities))
+	for _, entity := range entities {
+		for _, entityIface := range getInterfaces(entity) {
+			if entityIface == iface {
+				// Retrieve the requested metadata for the entity.
+				meta, err := h.GetMetadata(entity.URL, includes)
+				if err != nil {
+					return nil, err
+				}
+				// Build the response.
+				responses = append(responses, params.MetaAnyResponse{
+					Id:   entity.URL,
+					Meta: meta,
+				})
+			}
+		}
+	}
+	return responses, nil
+}

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -90,7 +90,7 @@ var metaCharmRelatedCharms = map[string]charm.Charm{
 }
 
 var metaCharmRelatedTests = []struct {
-	// About the test.
+	// Description of the test.
 	about string
 	// Charms to be stored in the store before the test is run.
 	charms map[string]charm.Charm

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -1,0 +1,341 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4_test
+
+import (
+	"net/http"
+
+	"gopkg.in/juju/charm.v3"
+	gc "launchpad.net/gocheck"
+
+	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/storetesting"
+	"github.com/juju/charmstore/params"
+)
+
+type RelationsSuite struct {
+	storetesting.IsolatedMgoSuite
+	srv   http.Handler
+	store *charmstore.Store
+}
+
+var _ = gc.Suite(&RelationsSuite{})
+
+func (s *RelationsSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	s.srv, s.store = newServer(c, s.Session)
+}
+
+// metaCharmRelatedCharms defines a bunch of charms to be used in
+// the relation tests.
+var metaCharmRelatedCharms = map[string]charm.Charm{
+	"utopic/wordpress-0": &relationTestingCharm{
+		provides: map[string]charm.Relation{
+			"website": {
+				Name:      "website",
+				Role:      "provider",
+				Interface: "http",
+			},
+		},
+		requires: map[string]charm.Relation{
+			"cache": {
+				Name:      "cache",
+				Role:      "requirer",
+				Interface: "memcache",
+			},
+			"nfs": {
+				Name:      "nfs",
+				Role:      "requirer",
+				Interface: "mount",
+			},
+		},
+	},
+	"utopic/memcached-42": &relationTestingCharm{
+		provides: map[string]charm.Relation{
+			"cache": {
+				Name:      "cache",
+				Role:      "provider",
+				Interface: "memcache",
+			},
+		},
+	},
+	"precise/nfs-1": &relationTestingCharm{
+		provides: map[string]charm.Relation{
+			"nfs": {
+				Name:      "nfs",
+				Role:      "provider",
+				Interface: "mount",
+			},
+		},
+	},
+	"trusty/haproxy-47": &relationTestingCharm{
+		requires: map[string]charm.Relation{
+			"reverseproxy": {
+				Name:      "reverseproxy",
+				Role:      "requirer",
+				Interface: "http",
+			},
+		},
+	},
+	"precise/haproxy-48": &relationTestingCharm{
+		requires: map[string]charm.Relation{
+			"reverseproxy": {
+				Name:      "reverseproxy",
+				Role:      "requirer",
+				Interface: "http",
+			},
+		},
+	},
+}
+
+var metaCharmRelatedTests = []struct {
+	// About the test.
+	about string
+	// Charms to be stored in the store before the test is run.
+	charms map[string]charm.Charm
+	// The id of the charm for which related charms are returned.
+	id string
+	// The querystring to append to the resulting charmstore URL.
+	querystring string
+	// The expected response body.
+	expectBody params.RelatedResponse
+}{{
+	about:  "provides and requires",
+	charms: metaCharmRelatedCharms,
+	id:     "utopic/wordpress-0",
+	expectBody: params.RelatedResponse{
+		Provides: map[string][]params.MetaAnyResponse{
+			"memcache": []params.MetaAnyResponse{{
+				Id: mustParseReference("utopic/memcached-42"),
+			}},
+			"mount": []params.MetaAnyResponse{{
+				Id: mustParseReference("precise/nfs-1"),
+			}},
+		},
+		Requires: map[string][]params.MetaAnyResponse{
+			"http": []params.MetaAnyResponse{{
+				Id: mustParseReference("trusty/haproxy-47"),
+			}, {
+				Id: mustParseReference("precise/haproxy-48"),
+			}},
+		},
+	},
+}, {
+	about:  "only provides",
+	charms: metaCharmRelatedCharms,
+	id:     "trusty/haproxy-47",
+	expectBody: params.RelatedResponse{
+		Provides: map[string][]params.MetaAnyResponse{
+			"http": []params.MetaAnyResponse{{
+				Id: mustParseReference("utopic/wordpress-0"),
+			}},
+		},
+	},
+}, {
+	about:  "only requires",
+	charms: metaCharmRelatedCharms,
+	id:     "utopic/memcached-42",
+	expectBody: params.RelatedResponse{
+		Requires: map[string][]params.MetaAnyResponse{
+			"memcache": []params.MetaAnyResponse{{
+				Id: mustParseReference("utopic/wordpress-0"),
+			}},
+		},
+	},
+}, {
+	about: "no relations found",
+	charms: map[string]charm.Charm{
+		"utopic/wordpress-0": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"website": {
+					Name:      "website",
+					Role:      "provider",
+					Interface: "http",
+				},
+			},
+			requires: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "requirer",
+					Interface: "memcache",
+				},
+				"nfs": {
+					Name:      "nfs",
+					Role:      "requirer",
+					Interface: "mount",
+				},
+			},
+		},
+	},
+	id: "utopic/wordpress-0",
+}, {
+	about: "no relations defined",
+	charms: map[string]charm.Charm{
+		"utopic/django-42": &relationTestingCharm{},
+	},
+	id: "utopic/django-42",
+}, {
+	about: "multiple revisions of the same related charm",
+	charms: map[string]charm.Charm{
+		"trusty/wordpress-0": &relationTestingCharm{
+			requires: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "requirer",
+					Interface: "memcache",
+				},
+			},
+		},
+		"utopic/memcached-1": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "provider",
+					Interface: "memcache",
+				},
+			},
+		},
+		"utopic/memcached-2": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "provider",
+					Interface: "memcache",
+				},
+			},
+		},
+		"utopic/memcached-3": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "provider",
+					Interface: "memcache",
+				},
+			},
+		},
+	},
+	id: "trusty/wordpress-0",
+	expectBody: params.RelatedResponse{
+		Provides: map[string][]params.MetaAnyResponse{
+			"memcache": []params.MetaAnyResponse{{
+				Id: mustParseReference("utopic/memcached-1"),
+			}, {
+				Id: mustParseReference("utopic/memcached-2"),
+			}, {
+				Id: mustParseReference("utopic/memcached-3"),
+			}},
+		},
+	},
+}, {
+	about:       "includes",
+	charms:      metaCharmRelatedCharms,
+	id:          "precise/nfs-1",
+	querystring: "?include=archive-size&include=charm-metadata",
+	expectBody: params.RelatedResponse{
+		Requires: map[string][]params.MetaAnyResponse{
+			"mount": []params.MetaAnyResponse{{
+				Id: mustParseReference("utopic/wordpress-0"),
+				Meta: map[string]interface{}{
+					"archive-size": params.ArchiveSizeResponse{Size: 42},
+					"charm-metadata": &charm.Meta{
+						Provides: map[string]charm.Relation{
+							"website": {
+								Name:      "website",
+								Role:      "provider",
+								Interface: "http",
+							},
+						},
+						Requires: map[string]charm.Relation{
+							"cache": {
+								Name:      "cache",
+								Role:      "requirer",
+								Interface: "memcache",
+							},
+							"nfs": {
+								Name:      "nfs",
+								Role:      "requirer",
+								Interface: "mount",
+							},
+						},
+					},
+				},
+			}},
+		},
+	},
+}}
+
+func (s *RelationsSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
+	blobSize := int64(42)
+	for id, ch := range charms {
+		url := mustParseReference(id)
+		// The blob related info are not used in these tests.
+		// The related charms are retrieved from the entities collection,
+		// without accessing the blob store.
+		err := s.store.AddCharm(url, ch, "blobName", "blobHash", blobSize)
+		c.Assert(err, gc.IsNil)
+	}
+}
+
+func (s *RelationsSuite) TestMetaCharmRelated(c *gc.C) {
+	for i, test := range metaCharmRelatedTests {
+		c.Logf("test %d: %s", i, test.about)
+		s.addCharms(c, test.charms)
+		storeURL := storeURL(test.id + "/meta/charm-related" + test.querystring)
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:    s.srv,
+			URL:        storeURL,
+			ExpectCode: http.StatusOK,
+			ExpectBody: test.expectBody,
+		})
+		// Clean up the entities in the store.
+		_, err := s.store.DB.Entities().RemoveAll(nil)
+		c.Assert(err, gc.IsNil)
+	}
+}
+
+func (s *RelationsSuite) TestMetaCharmRelatedIncludeError(c *gc.C) {
+	s.addCharms(c, metaCharmRelatedCharms)
+	storeURL := storeURL("utopic/wordpress-0/meta/charm-related?include=no-such")
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    s.srv,
+		URL:        storeURL,
+		ExpectCode: http.StatusInternalServerError,
+		ExpectBody: params.Error{
+			Message: `cannot retrieve the charm requires: unrecognized metadata name "no-such"`,
+		},
+	})
+}
+
+// relationTestingCharm implements charm.Charm, and it is used for testing
+// charm relations.
+type relationTestingCharm struct {
+	provides map[string]charm.Relation
+	requires map[string]charm.Relation
+}
+
+func (ch *relationTestingCharm) Meta() *charm.Meta {
+	// The only metadata we are interested in is the relation data.
+	return &charm.Meta{
+		Provides: ch.provides,
+		Requires: ch.requires,
+	}
+}
+
+func (ch *relationTestingCharm) Config() *charm.Config {
+	// For the purposes of this implementation, the charm configuration is not
+	// relevant.
+	return nil
+}
+
+func (ch *relationTestingCharm) Actions() *charm.Actions {
+	// For the purposes of this implementation, the charm actions are not
+	// relevant.
+	return nil
+}
+
+func (ch *relationTestingCharm) Revision() int {
+	// For the purposes of this implementation, the charm revision is not
+	// relevant.
+	return 0
+}

--- a/params/params.go
+++ b/params/params.go
@@ -52,3 +52,15 @@ type ManifestFile struct {
 type ArchiveUploadTimeResponse struct {
 	UploadTime time.Time
 }
+
+// RelatedResponse holds the result of an
+// id/meta/charm-related GET request. See http://tinyurl.com/q7vdmzl
+type RelatedResponse struct {
+	// Requires holds an entry for each interface provided by
+	// the charm, containing all charms that require that interface.
+	Requires map[string][]MetaAnyResponse `json:",omitempty"`
+
+	// Provides holds an entry for each interface required by the
+	// the charm, containing all charms that provide that interface.
+	Provides map[string][]MetaAnyResponse `json:",omitempty"`
+}


### PR DESCRIPTION
Also move MgoTestPackage suite registration out from api_test to its
own package_test.go.
