### PR TITLE
implement meta/revision-info

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -59,6 +59,9 @@ type Entity struct {
 
 type EntitiesByURLDesc []Entity
 
-func (s EntitiesByURLDesc) Len() int           { return len(s) }
-func (s EntitiesByURLDesc) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s EntitiesByURLDesc) Len() int      { return len(s) }
+func (s EntitiesByURLDesc) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+// Implement the Less method of the sort interface backward, with > so that
+// the sort order is descending.
 func (s EntitiesByURLDesc) Less(i, j int) bool { return s[i].URL.Revision > s[j].URL.Revision }

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -56,12 +56,3 @@ type Entity struct {
 	// TODO Add fields denormalized for search purposes
 	// and search ranking field(s).
 }
-
-type EntitiesByURLDesc []Entity
-
-func (s EntitiesByURLDesc) Len() int      { return len(s) }
-func (s EntitiesByURLDesc) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-
-// Implement the Less method of the sort interface backward, with > so that
-// the sort order is descending.
-func (s EntitiesByURLDesc) Less(i, j int) bool { return s[i].URL.Revision > s[j].URL.Revision }

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -56,3 +56,9 @@ type Entity struct {
 	// TODO Add fields denormalized for search purposes
 	// and search ranking field(s).
 }
+
+type EntitiesByURLDesc []Entity
+
+func (s EntitiesByURLDesc) Len() int           { return len(s) }
+func (s EntitiesByURLDesc) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s EntitiesByURLDesc) Less(i, j int) bool { return s[i].URL.Revision > s[j].URL.Revision }

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -325,7 +325,7 @@ func (h *handler) metaRevisionInfo(id *charm.Reference, path string, method stri
 	}
 
 	// Sort in descending order by revision.
-	sort.Sort(mongodoc.EntitiesByURLDesc(docs))
+	sort.Sort(entitiesByRevision(docs))
 	response := make([]params.ExpandedId, 0, len(docs))
 	for _, doc := range docs {
 		if doc.URL.Series == id.Series {
@@ -340,6 +340,15 @@ func (h *handler) metaRevisionInfo(id *charm.Reference, path string, method stri
 	// Write the response in JSON format.
 	return response, nil
 }
+
+type entitiesByRevision []mongodoc.Entity
+
+func (s entitiesByRevision) Len() int      { return len(s) }
+func (s entitiesByRevision) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+// Implement the Less method of the sort interface backward, with > so that
+// the sort order is descending.
+func (s entitiesByRevision) Less(i, j int) bool { return s[i].URL.Revision > s[j].URL.Revision }
 
 // GET id/meta/extra-info
 // http://tinyurl.com/keos7wd

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -326,14 +326,14 @@ func (h *handler) metaRevisionInfo(id *charm.Reference, path string, method stri
 
 	// Sort in descending order by revision.
 	sort.Sort(entitiesByRevision(docs))
-	response := make([]params.ExpandedId, 0, len(docs))
+	response := &params.RevisionInfoResponse{}
 	for _, doc := range docs {
 		if doc.URL.Series == id.Series {
-			response = append(response, params.ExpandedId{Id: doc.URL.String()})
+			response.Revisions = append(response.Revisions, doc.URL)
 		}
 	}
 
-	if len(response) == 0 {
+	if len(response.Revisions) == 0 {
 		return "", noMatchingURLError(&baseURL)
 	}
 

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -5,9 +5,9 @@ package v4
 
 import (
 	"archive/zip"
-	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 
 	"github.com/juju/errgo"
 	"gopkg.in/juju/charm.v3"
@@ -309,25 +309,29 @@ func (h *handler) metaBundlesContaining(id *charm.Reference, path string, method
 // GET id/meta/revision-info
 // http://tinyurl.com/q6xos7f
 func (h *handler) metaRevisionInfo(id *charm.Reference, path string, method string, flags url.Values) (interface{}, error) {
-	// Mutate the given id so that it represents a base URL.
-	id.Revision = -1
+	baseURL := *id
+	baseURL.Revision = -1
+	baseURL.Series = ""
 
 	var docs []mongodoc.Entity
-	if err := h.store.DB.Entities().Find(bson.D{{"_id", bson.RegEx{fmt.Sprintf(`%s-\d+`, id), ""}}}).Select(bson.D{{"_id", 1}}).Sort("-_id").All(&docs); err != nil {
+	if err := h.store.DB.Entities().Find(
+		bson.D{{"baseurl", baseURL.String()}}).Select(
+		bson.D{{"_id", 1}}).All(&docs); err != nil {
 		return "", errgo.Notef(err, "cannot get ids")
 	}
 
-	// A not found error should have been already returned by the router in the
-	// case a partial id is provided. Here we do the same for the case when
-	// a fully qualified URL is provided, but no matching entities are found.
-	if len(docs) == 0 {
-		return "", noMatchingURLError(id)
-	}
-
-	// Collect all the expanded identifiers for each entity.
+	sort.Sort(mongodoc.EntitiesByURLDesc(docs))
 	response := make([]params.ExpandedId, 0, len(docs))
 	for _, doc := range docs {
-		response = append(response, params.ExpandedId{Id: doc.URL.String()})
+		if doc.URL.Series == id.Series {
+			response = append(response, params.ExpandedId{Id: doc.URL.String()})
+		}
+	}
+
+	if len(response) == 0 {
+		errorURL := *id
+		errorURL.Revision = -1
+		return "", noMatchingURLError(&errorURL)
 	}
 
 	// Write the response in JSON format.

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -324,6 +324,7 @@ func (h *handler) metaRevisionInfo(id *charm.Reference, path string, method stri
 		return "", params.ErrNotFound
 	}
 
+	// Sort in descending order by revision.
 	sort.Sort(mongodoc.EntitiesByURLDesc(docs))
 	response := make([]params.ExpandedId, 0, len(docs))
 	for _, doc := range docs {

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -315,7 +315,7 @@ func (h *handler) metaRevisionInfo(id *charm.Reference, path string, method stri
 
 	var docs []mongodoc.Entity
 	if err := h.store.DB.Entities().Find(
-		bson.D{{"baseurl", baseURL.String()}}).Select(
+		bson.D{{"baseurl", &baseURL}}).Select(
 		bson.D{{"_id", 1}}).All(&docs); err != nil {
 		return "", errgo.Notef(err, "cannot get ids")
 	}

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -320,6 +320,10 @@ func (h *handler) metaRevisionInfo(id *charm.Reference, path string, method stri
 		return "", errgo.Notef(err, "cannot get ids")
 	}
 
+	if len(docs) == 0 {
+		return "", params.ErrNotFound
+	}
+
 	sort.Sort(mongodoc.EntitiesByURLDesc(docs))
 	response := make([]params.ExpandedId, 0, len(docs))
 	for _, doc := range docs {
@@ -329,9 +333,7 @@ func (h *handler) metaRevisionInfo(id *charm.Reference, path string, method stri
 	}
 
 	if len(response) == 0 {
-		errorURL := *id
-		errorURL.Revision = -1
-		return "", noMatchingURLError(&errorURL)
+		return "", noMatchingURLError(&baseURL)
 	}
 
 	// Write the response in JSON format.

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -147,6 +147,19 @@ var metaEndpoints = []metaEndpoint{{
 		c.Assert(response.UploadTime, gc.Not(jc.Satisfies), time.Time.IsZero)
 		c.Assert(response.UploadTime.Location(), gc.Equals, time.UTC)
 	},
+}, {
+	name: "revision-info",
+	get: func(store *charmstore.Store, id *charm.Reference) (interface{}, error) {
+		return []params.ExpandedId{
+			params.ExpandedId{Id: id.String()},
+		}, nil
+	},
+	checkURL: "cs:precise/wordpress-99",
+	assertCheckData: func(c *gc.C, data interface{}) {
+		ids := data.([]params.ExpandedId)
+		c.Assert(ids[0].Id, gc.Equals, "cs:precise/wordpress-99")
+		c.Assert(len(ids), gc.Equals, 1)
+	},
 }}
 
 // TestEndpointGet tries to ensure that the endpoint
@@ -532,7 +545,7 @@ func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
 	}, {
 		about: "no entities found",
 		url:   "precise/no-such-33",
-		err:   `no matching charm or bundle for "cs:precise/no-such"`,
+		err:   "not found",
 	}}
 
 	for i, test := range serveMetaRevisionInfoTests {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -503,9 +503,9 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 
 func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
 	s.addCharm(c, "wordpress", "cs:trusty/wordpress-43")
-	s.addCharm(c, "wordpress", "cs:trusty/wordpress-42")
 	s.addCharm(c, "wordpress", "cs:trusty/wordpress-41")
-	s.addCharm(c, "wordpress", "cs:trusty/wordpress-39")
+	s.addCharm(c, "wordpress", "cs:trusty/wordpress-9")
+	s.addCharm(c, "wordpress", "cs:trusty/wordpress-42")
 	var serveMetaRevisionInfoTests = []struct {
 		about  string
 		url    string
@@ -518,7 +518,7 @@ func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
 			{Id: "cs:trusty/wordpress-43"},
 			{Id: "cs:trusty/wordpress-42"},
 			{Id: "cs:trusty/wordpress-41"},
-			{Id: "cs:trusty/wordpress-39"},
+			{Id: "cs:trusty/wordpress-9"},
 		},
 	}, {
 		about: "partial url uses a default series",
@@ -527,7 +527,7 @@ func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
 			{Id: "cs:trusty/wordpress-43"},
 			{Id: "cs:trusty/wordpress-42"},
 			{Id: "cs:trusty/wordpress-41"},
-			{Id: "cs:trusty/wordpress-39"},
+			{Id: "cs:trusty/wordpress-9"},
 		},
 	}, {
 		about: "no entities found",

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -164,9 +164,10 @@ var metaEndpoints = []metaEndpoint{{
 	},
 	checkURL: "cs:precise/wordpress-99",
 	assertCheckData: func(c *gc.C, data interface{}) {
-		ids := data.(params.RevisionInfoResponse)
-		c.Assert(ids.Revisions[0].String(), gc.Equals, "cs:precise/wordpress-99")
-		c.Assert(len(ids.Revisions), gc.Equals, 1)
+		c.Assert(data, gc.DeepEquals, params.RevisionInfoResponse{
+			[]*charm.Reference{
+				mustParseReference("cs:precise/wordpress-99"),
+			}})
 	},
 }, {
 	name:      "charm-related",

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -515,6 +515,9 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 }
 
 func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
+	s.addCharm(c, "wordpress", "cs:trusty/mysql-42")
+	s.addCharm(c, "wordpress", "cs:trusty/mysql-41")
+	s.addCharm(c, "wordpress", "cs:precise/wordpress-42")
 	s.addCharm(c, "wordpress", "cs:trusty/wordpress-43")
 	s.addCharm(c, "wordpress", "cs:trusty/wordpress-41")
 	s.addCharm(c, "wordpress", "cs:trusty/wordpress-9")

--- a/params/params.go
+++ b/params/params.go
@@ -71,3 +71,9 @@ type RelatedResponse struct {
 	// the charm, containing all charms that provide that interface.
 	Provides map[string][]MetaAnyResponse `json:",omitempty"`
 }
+
+// RevisionInfoResponse holds the result of an
+// id/meta/revision-info GET request. See http://tinyurl.com/q6xos7f
+type RevisionInfoResponse struct {
+	Revisions []*charm.Reference
+}


### PR DESCRIPTION
This is very close to the same as ExtendId which was just implemented.

The revision-info path returns information about other available revisions of the charm id that the charmstore knows about. It will include both older and newer revisions. The fully qualified ids of those charms will be returned in an ordered list from newest to oldest revision. Note that the current revision will be included in the list as it is also an available revision.
