### PR TITLE
Implement the archive delete API endpoint.

### DIFF
--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -577,6 +577,10 @@ var metaStatsTests = []struct {
 }}
 
 func (s *APISuite) TestMetaStats(c *gc.C) {
+	if !storetesting.MongoJSEnabled() {
+		c.Skip("MongoDB JavaScript not available")
+	}
+
 	// Add a bunch of entities in the database.
 	s.addCharm(c, "wordpress", "cs:trusty/mysql-0")
 	s.addCharm(c, "wordpress", "cs:utopic/django-42")

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -35,6 +35,8 @@ func (h *handler) serveArchive(id *charm.Reference, w http.ResponseWriter, req *
 	default:
 		// TODO(rog) params.ErrMethodNotAllowed
 		return errgo.Newf("method not allowed")
+	case "DELETE":
+		return h.serveDeleteArchive(id, w, req)
 	case "POST":
 		resp, err := h.servePostArchive(id, w, req)
 		if err != nil {
@@ -54,9 +56,27 @@ func (h *handler) serveArchive(id *charm.Reference, w http.ResponseWriter, req *
 	return nil
 }
 
+func (h *handler) serveDeleteArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+	// Retrieve the entity blob name from the database.
+	blobName, err := h.findBlobName(id)
+	if err != nil {
+		return err
+	}
+	// Remove the entity.
+	if err := h.store.DB.Entities().RemoveId(id); err != nil {
+		return errgo.Notef(err, "cannot remove %s", id)
+	}
+	// Remove the reference to the archive from the blob store.
+	if err := h.store.BlobStore.Remove(blobName); err != nil {
+		return errgo.Notef(err, "cannot remove blob %s", blobName)
+	}
+	// TODO frankban 2014-08-25: log possible IncCounter errors.
+	go h.store.IncCounter(entityStatsKey(id, params.StatsArchiveDelete))
+	return nil
+}
+
 func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) (resp *params.ArchivePostResponse, err error) {
 	// Validate the request parameters.
-
 	if id.Series == "" {
 		return nil, badRequestf(nil, "series not specified")
 	}
@@ -200,18 +220,26 @@ func (h *handler) nextRevisionForId(id *charm.Reference) (int, error) {
 	return 0, nil
 }
 
-func (h *handler) openBlob(id *charm.Reference) (blobstore.ReadSeekCloser, int64, error) {
+func (h *handler) findBlobName(id *charm.Reference) (string, error) {
 	var entity mongodoc.Entity
 	if err := h.store.DB.Entities().
 		FindId(id).
 		Select(bson.D{{"blobname", 1}}).
 		One(&entity); err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, 0, params.ErrNotFound
+			return "", params.ErrNotFound
 		}
-		return nil, 0, errgo.Notef(err, "cannot get %s", id)
+		return "", errgo.Notef(err, "cannot get %s", id)
 	}
-	r, size, err := h.store.BlobStore.Open(entity.BlobName)
+	return entity.BlobName, nil
+}
+
+func (h *handler) openBlob(id *charm.Reference) (blobstore.ReadSeekCloser, int64, error) {
+	blobName, err := h.findBlobName(id)
+	if err != nil {
+		return nil, 0, err
+	}
+	r, size, err := h.store.BlobStore.Open(blobName)
 	if err != nil {
 		return nil, 0, errgo.Notef(err, "cannot open archive data for %s", id)
 	}

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -30,6 +30,9 @@ import (
 //
 // POST id/archive?sha256=hash
 // http://tinyurl.com/lzrzrgb
+
+// DELETE id/archive
+// http://tinyurl.com/ojmlwos
 func (h *handler) serveArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	switch req.Method {
 	default:

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/juju/charm.v3"
 	"gopkg.in/juju/charm.v3/testing"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
+	"gopkg.in/mgo.v2/bson"
 	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/blobstore"
@@ -61,11 +62,27 @@ func (s *ArchiveSuite) TestGet(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusPartialContent, gc.Commentf("body: %q", rec.Body.Bytes()))
 	c.Assert(rec.Body.Bytes(), gc.HasLen, 100-10+1)
 	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes[10:101])
+}
+
+func (s *ArchiveSuite) TestGetCounters(c *gc.C) {
+	if !storetesting.MongoJSEnabled() {
+		c.Skip("MongoDB JavaScript not available")
+	}
+
+	// Add a charm to the database (including the archive).
+	id := "utopic/mysql-42"
+	err := s.store.AddCharmWithArchive(
+		mustParseReference(id),
+		charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"))
+	c.Assert(err, gc.IsNil)
+
+	// Download the charm archive using the API.
+	rec := storetesting.DoRequest(c, s.srv, "GET", storeURL(id+"/archive"), nil, 0, nil)
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 
 	// Check that the downloads count for the entity has been updated.
-	key := []string{params.StatsArchiveDownload, "precise", "wordpress", "0"}
-	checkCounterSum(c, s.store, key, false, 2)
-
+	key := []string{params.StatsArchiveDownload, "utopic", "mysql", "42"}
+	checkCounterSum(c, s.store, key, false, 1)
 }
 
 var archivePostErrorsTests = []struct {
@@ -599,6 +616,71 @@ func (s *ArchiveSuite) TestBundleCharms(c *gc.C) {
 			// the charm revision.
 		}
 	}
+}
+
+func (s *ArchiveSuite) TestDelete(c *gc.C) {
+	// Add a charm to the database (including the archive).
+	id := "utopic/mysql-42"
+	url := mustParseReference(id)
+	err := s.store.AddCharmWithArchive(url, charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"))
+	c.Assert(err, gc.IsNil)
+
+	// Retrieve the corresponding entity.
+	var entity mongodoc.Entity
+	err = s.store.DB.Entities().FindId(url).Select(bson.D{{"blobname", 1}}).One(&entity)
+	c.Assert(err, gc.IsNil)
+
+	// Delete the charm using the API.
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    s.srv,
+		URL:        storeURL(id + "/archive"),
+		Method:     "DELETE",
+		ExpectCode: http.StatusOK,
+	})
+
+	// The entity has been deleted.
+	count, err := s.store.DB.Entities().FindId(url).Count()
+	c.Assert(err, gc.IsNil)
+	c.Assert(count, gc.Equals, 0)
+
+	// The blob has been deleted.
+	_, _, err = s.store.BlobStore.Open(entity.BlobName)
+	c.Assert(err, gc.ErrorMatches, "resource.*not found")
+}
+
+func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
+	// Try to delete a non existing charm using the API.
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    s.srv,
+		URL:        storeURL("utopic/no-such-0/archive"),
+		Method:     "DELETE",
+		ExpectCode: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Message: params.ErrNotFound.Error(),
+			Code:    params.ErrNotFound,
+		},
+	})
+}
+
+func (s *ArchiveSuite) TestDeleteCounters(c *gc.C) {
+	if !storetesting.MongoJSEnabled() {
+		c.Skip("MongoDB JavaScript not available")
+	}
+
+	// Add a charm to the database (including the archive).
+	id := "utopic/mysql-42"
+	err := s.store.AddCharmWithArchive(
+		mustParseReference(id),
+		charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"))
+	c.Assert(err, gc.IsNil)
+
+	// Delete the charm using the API.
+	rec := storetesting.DoRequest(c, s.srv, "DELETE", storeURL(id+"/archive"), nil, 0, nil)
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+
+	// Check that the delete count for the entity has been updated.
+	key := []string{params.StatsArchiveDelete, "utopic", "mysql", "42"}
+	checkCounterSum(c, s.store, key, false, 1)
 }
 
 // entityInfo holds all the information we want to find

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -115,7 +115,7 @@ func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 
 func (s *StatsSuite) TestStatsCounter(c *gc.C) {
 	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB javascript not available")
+		c.Skip("MongoDB JavaScript not available")
 	}
 
 	for _, key := range [][]string{{"a", "b"}, {"a", "b"}, {"a", "c"}, {"a"}} {
@@ -153,7 +153,7 @@ func (s *StatsSuite) TestStatsCounter(c *gc.C) {
 
 func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
 	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB javascript not available")
+		c.Skip("MongoDB JavaScript not available")
 	}
 
 	incs := [][]string{
@@ -239,7 +239,7 @@ func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
 
 func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {
 	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB javascript not available")
+		c.Skip("MongoDB JavaScript not available")
 	}
 
 	incs := []struct {

--- a/params/stats.go
+++ b/params/stats.go
@@ -6,7 +6,7 @@ package params
 // Define the kinds to be included in stats keys.
 // TODO frankban 2014-08-22:
 //  increase the counters for the kinds below:
-//  the only hooked kind is archive-download for now.
+//  the only hooked kinds are archive-download and archive-delete for now.
 const (
 	StatsArchiveDownload     = "archive-download"
 	StatsArchiveDelete       = "archive-delete"


### PR DESCRIPTION
Also fixed tests not properly skipped in the case Mongo
has no JS support, and improved the test separation
when counters are exercised.
