### PR TITLE
HTTP test helpers refactoring.

### DIFF
--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -105,6 +105,9 @@ func assertServesVersion(c *gc.C, h http.Handler, vers string) {
 }
 
 func assertDoesNotServeVersion(c *gc.C, h http.Handler, vers string) {
-	rec := storetesting.DoRequest(c, h, "GET", "/"+vers+"/some/path", nil, 0, nil, "", "")
+	rec := storetesting.DoRequest(c, storetesting.DoRequestParams{
+		Handler: h,
+		URL:     "/" + vers + "/some/path",
+	})
 	c.Assert(rec.Code, gc.Equals, http.StatusNotFound)
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -36,7 +36,7 @@ var routerGetTests = []struct {
 	about            string
 	handlers         Handlers
 	urlStr           string
-	expectCode       int
+	expectStatus     int
 	expectBody       interface{}
 	expectQueryCount int32
 	resolveURL       func(*charm.Reference) error
@@ -52,8 +52,8 @@ var routerGetTests = []struct {
 			}),
 		},
 	},
-	urlStr:     "/foo",
-	expectCode: http.StatusOK,
+	urlStr:       "/foo",
+	expectStatus: http.StatusOK,
 	expectBody: ReqInfo{
 		Path: "",
 	},
@@ -69,8 +69,8 @@ var routerGetTests = []struct {
 			}),
 		},
 	},
-	urlStr:     "/foo/bar/a/b?a=1&b=two",
-	expectCode: http.StatusOK,
+	urlStr:       "/foo/bar/a/b?a=1&b=two",
+	expectStatus: http.StatusOK,
 	expectBody: ReqInfo{
 		Path: "/a/b",
 		Form: url.Values{
@@ -79,9 +79,9 @@ var routerGetTests = []struct {
 		},
 	},
 }, {
-	about:      "invalid form",
-	urlStr:     "/foo?a=%",
-	expectCode: http.StatusInternalServerError,
+	about:        "invalid form",
+	urlStr:       "/foo?a=%",
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: `cannot parse form: invalid URL escape "%"`,
 	},
@@ -92,8 +92,8 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "/precise/wordpress-34/foo",
-	expectCode: http.StatusOK,
+	urlStr:       "/precise/wordpress-34/foo",
+	expectStatus: http.StatusOK,
 	expectBody: idHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-34",
 	},
@@ -104,8 +104,8 @@ var routerGetTests = []struct {
 			"foo/": testIdHandler,
 		},
 	},
-	urlStr:     "/precise/wordpress-34/foo/blah/arble",
-	expectCode: http.StatusOK,
+	urlStr:       "/precise/wordpress-34/foo/blah/arble",
+	expectStatus: http.StatusOK,
 	expectBody: idHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-34",
 		Path:     "/blah/arble",
@@ -117,8 +117,8 @@ var routerGetTests = []struct {
 			"foo/": testIdHandler,
 		},
 	},
-	urlStr:     "/precise/wordpress-34/foo",
-	expectCode: http.StatusNotFound,
+	urlStr:       "/precise/wordpress-34/foo",
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
 		Message: "not found",
@@ -130,8 +130,8 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "/precise/wordpress-34/foo/blah",
-	expectCode: http.StatusNotFound,
+	urlStr:       "/precise/wordpress-34/foo/blah",
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
 		Message: "not found",
@@ -143,8 +143,8 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "/~joe/precise/wordpress-34/foo",
-	expectCode: http.StatusOK,
+	urlStr:       "/~joe/precise/wordpress-34/foo",
+	expectStatus: http.StatusOK,
 	expectBody: idHandlerTestResp{
 		CharmURL: "cs:~joe/precise/wordpress-34",
 	},
@@ -155,8 +155,8 @@ var routerGetTests = []struct {
 			"foo/": testIdHandler,
 		},
 	},
-	urlStr:     "/~joe/precise/wordpress-34/foo/blah/arble",
-	expectCode: http.StatusOK,
+	urlStr:       "/~joe/precise/wordpress-34/foo/blah/arble",
+	expectStatus: http.StatusOK,
 	expectBody: idHandlerTestResp{
 		CharmURL: "cs:~joe/precise/wordpress-34",
 		Path:     "/blah/arble",
@@ -168,8 +168,8 @@ var routerGetTests = []struct {
 			"foo/": errorIdHandler,
 		},
 	},
-	urlStr:     "/~joe/precise/wordpress-34/foo/blah/arble",
-	expectCode: http.StatusInternalServerError,
+	urlStr:       "/~joe/precise/wordpress-34/foo/blah/arble",
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "errorIdHandler error",
 	},
@@ -182,8 +182,8 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	urlStr:     "/~joe/precise/wordpress-34/foo",
-	expectCode: http.StatusNotFound,
+	urlStr:       "/~joe/precise/wordpress-34/foo",
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Message: "not found",
 		Code:    params.ErrNotFound,
@@ -197,8 +197,8 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	urlStr:     "/~joe/precise/wordpress-34/foo",
-	expectCode: http.StatusInternalServerError,
+	urlStr:       "/~joe/precise/wordpress-34/foo",
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "a message",
 		Code:    "foo",
@@ -210,9 +210,9 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "/~joe/wordpress/foo",
-	resolveURL: newResolveURL("precise", 34),
-	expectCode: http.StatusOK,
+	urlStr:       "/~joe/wordpress/foo",
+	resolveURL:   newResolveURL("precise", 34),
+	expectStatus: http.StatusOK,
 	expectBody: idHandlerTestResp{
 		CharmURL: "cs:~joe/precise/wordpress-34",
 	},
@@ -223,9 +223,9 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "/wordpress/meta",
-	resolveURL: resolveURLError(errgo.New("resolve URL error")),
-	expectCode: http.StatusInternalServerError,
+	urlStr:       "/wordpress/meta",
+	resolveURL:   resolveURLError(errgo.New("resolve URL error")),
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "resolve URL error",
 	},
@@ -236,9 +236,9 @@ var routerGetTests = []struct {
 			"foo": testIdHandler,
 		},
 	},
-	urlStr:     "/wordpress/meta",
-	resolveURL: resolveURLError(params.ErrNotFound),
-	expectCode: http.StatusNotFound,
+	urlStr:       "/wordpress/meta",
+	resolveURL:   resolveURLError(params.ErrNotFound),
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Message: "not found",
 		Code:    params.ErrNotFound,
@@ -251,9 +251,9 @@ var routerGetTests = []struct {
 			"bar": testMetaHandler,
 		},
 	},
-	urlStr:     "/precise/wordpress-42/meta",
-	expectCode: http.StatusOK,
-	expectBody: []string{"bar", "foo"},
+	urlStr:       "/precise/wordpress-42/meta",
+	expectStatus: http.StatusOK,
+	expectBody:   []string{"bar", "foo"},
 }, {
 	about: "meta handler",
 	handlers: Handlers{
@@ -261,8 +261,8 @@ var routerGetTests = []struct {
 			"foo": testMetaHandler,
 		},
 	},
-	urlStr:     "/precise/wordpress-42/meta/foo",
-	expectCode: http.StatusOK,
+	urlStr:       "/precise/wordpress-42/meta/foo",
+	expectStatus: http.StatusOK,
 	expectBody: &metaHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-42",
 		Method:   "GET",
@@ -274,8 +274,8 @@ var routerGetTests = []struct {
 			"foo/": testMetaHandler,
 		},
 	},
-	urlStr:     "/precise/wordpress-42/meta/foo/bar/baz",
-	expectCode: http.StatusOK,
+	urlStr:       "/precise/wordpress-42/meta/foo/bar/baz",
+	expectStatus: http.StatusOK,
 	expectBody: metaHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-42",
 		Method:   "GET",
@@ -288,8 +288,8 @@ var routerGetTests = []struct {
 			"foo": testMetaHandler,
 		},
 	},
-	urlStr:     "/precise/wordpress-42/meta/foo?one=a&two=b&one=c",
-	expectCode: http.StatusOK,
+	urlStr:       "/precise/wordpress-42/meta/foo?one=a&two=b&one=c",
+	expectStatus: http.StatusOK,
 	expectBody: metaHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-42",
 		Method:   "GET",
@@ -299,9 +299,9 @@ var routerGetTests = []struct {
 		},
 	},
 }, {
-	about:      "meta handler that's not found",
-	urlStr:     "/precise/wordpress-42/meta/foo",
-	expectCode: http.StatusNotFound,
+	about:        "meta handler that's not found",
+	urlStr:       "/precise/wordpress-42/meta/foo",
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
 		Message: "not found",
@@ -313,8 +313,8 @@ var routerGetTests = []struct {
 			"foo": constMetaHandler(nil),
 		},
 	},
-	urlStr:     "/precise/wordpress-42/meta/foo",
-	expectCode: http.StatusNotFound,
+	urlStr:       "/precise/wordpress-42/meta/foo",
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrMetadataNotFound,
 		Message: "metadata not found",
@@ -326,8 +326,8 @@ var routerGetTests = []struct {
 			"foo": constMetaHandler((*struct{})(nil)),
 		},
 	},
-	urlStr:     "/precise/wordpress-42/meta/foo",
-	expectCode: http.StatusNotFound,
+	urlStr:       "/precise/wordpress-42/meta/foo",
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrMetadataNotFound,
 		Message: "metadata not found",
@@ -340,7 +340,7 @@ var routerGetTests = []struct {
 			"foo": fieldSelectHandler("handler1", 0, "field1", "field2"),
 		},
 	},
-	expectCode:       http.StatusOK,
+	expectStatus:     http.StatusOK,
 	expectQueryCount: 1,
 	expectBody: fieldSelectHandleInfo{
 		HandlerId: "handler1",
@@ -359,15 +359,15 @@ var routerGetTests = []struct {
 			"foo": errorMetaHandler(errgo.WithCausef(nil, params.ErrorCode("arble"), "a message")),
 		},
 	},
-	expectCode: http.StatusInternalServerError,
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Code:    "arble",
 		Message: "a message",
 	},
 }, {
-	about:      "meta/any, no includes",
-	urlStr:     "/precise/wordpress-42/meta/any",
-	expectCode: http.StatusOK,
+	about:        "meta/any, no includes",
+	urlStr:       "/precise/wordpress-42/meta/any",
+	expectStatus: http.StatusOK,
 	expectBody: params.MetaAnyResponse{
 		Id: mustParseReference("cs:precise/wordpress-42"),
 	},
@@ -382,7 +382,7 @@ var routerGetTests = []struct {
 		},
 	},
 	expectQueryCount: 1,
-	expectCode:       http.StatusOK,
+	expectStatus:     http.StatusOK,
 	expectBody: params.MetaAnyResponse{
 		Id: mustParseReference("cs:precise/wordpress-42"),
 		Meta: map[string]interface{}{
@@ -426,7 +426,7 @@ var routerGetTests = []struct {
 		},
 	},
 	expectQueryCount: 1,
-	expectCode:       http.StatusOK,
+	expectStatus:     http.StatusOK,
 	expectBody: params.MetaAnyResponse{
 		Id: mustParseReference("cs:precise/wordpress-42"),
 		Meta: map[string]interface{}{
@@ -471,7 +471,7 @@ var routerGetTests = []struct {
 			"typednil": constMetaHandler((*struct{})(nil)),
 		},
 	},
-	expectCode: http.StatusOK,
+	expectStatus: http.StatusOK,
 	expectBody: params.MetaAnyResponse{
 		Id: mustParseReference("cs:precise/wordpress-42"),
 		Meta: map[string]interface{}{
@@ -489,7 +489,7 @@ var routerGetTests = []struct {
 			"error": errorMetaHandler(errgo.WithCausef(nil, params.ErrorCode("foo"), "a message")),
 		},
 	},
-	expectCode: http.StatusInternalServerError,
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Code:    "foo",
 		Message: "a message",
@@ -502,7 +502,7 @@ var routerGetTests = []struct {
 			"foo": testMetaHandler,
 		},
 	},
-	expectCode: http.StatusOK,
+	expectStatus: http.StatusOK,
 	expectBody: map[string]metaHandlerTestResp{
 		"precise/wordpress-42": {
 			CharmURL: "cs:precise/wordpress-42",
@@ -517,7 +517,7 @@ var routerGetTests = []struct {
 			"foo": testMetaHandler,
 		},
 	},
-	expectCode: http.StatusOK,
+	expectStatus: http.StatusOK,
 	expectBody: map[string]metaHandlerTestResp{
 		"precise/wordpress-42": {
 			CharmURL: "cs:precise/wordpress-42",
@@ -537,7 +537,7 @@ var routerGetTests = []struct {
 			"bar/": testMetaHandler,
 		},
 	},
-	expectCode: http.StatusOK,
+	expectStatus: http.StatusOK,
 	expectBody: map[string]params.MetaAnyResponse{
 		"precise/wordpress-42": {
 			Id: mustParseReference("cs:precise/wordpress-42"),
@@ -576,8 +576,8 @@ var routerGetTests = []struct {
 			"foo/": testMetaHandler,
 		},
 	},
-	resolveURL: newResolveURL("precise", 100),
-	expectCode: http.StatusOK,
+	resolveURL:   newResolveURL("precise", 100),
+	expectStatus: http.StatusOK,
 	expectBody: map[string]metaHandlerTestResp{
 		"wordpress": {
 			CharmURL: "cs:precise/wordpress-100",
@@ -593,8 +593,8 @@ var routerGetTests = []struct {
 			"foo/": testMetaHandler,
 		},
 	},
-	resolveURL: newResolveURL("precise", 100),
-	expectCode: http.StatusOK,
+	resolveURL:   newResolveURL("precise", 100),
+	expectStatus: http.StatusOK,
 	expectBody: map[string]metaHandlerTestResp{
 		"wordpress": {
 			CharmURL: "cs:precise/wordpress-100",
@@ -614,7 +614,7 @@ var routerGetTests = []struct {
 			"foo/": testMetaHandler,
 		},
 	},
-	expectCode: http.StatusInternalServerError,
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "no ids specified in meta request",
 	},
@@ -632,7 +632,7 @@ var routerGetTests = []struct {
 			"foo": testMetaHandler,
 		},
 	},
-	expectCode: http.StatusOK,
+	expectStatus: http.StatusOK,
 	expectBody: map[string]metaHandlerTestResp{
 		"precise/wordpress-23": {
 			CharmURL: "cs:precise/wordpress-23",
@@ -653,7 +653,7 @@ var routerGetTests = []struct {
 			"foo": testMetaHandler,
 		},
 	},
-	expectCode: http.StatusInternalServerError,
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "an error",
 	},
@@ -667,7 +667,7 @@ var routerGetTests = []struct {
 			}),
 		},
 	},
-	expectCode: http.StatusOK,
+	expectStatus: http.StatusOK,
 	expectBody: map[string]string{
 		"bundle/something-24": "bundlefoo",
 	},
@@ -710,10 +710,10 @@ func (s *RouterSuite) TestRouterGet(c *gc.C) {
 		// a query is made.
 		queryCount = 0
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    router,
-			URL:        test.urlStr,
-			ExpectCode: test.expectCode,
-			ExpectBody: test.expectBody,
+			Handler:      router,
+			URL:          test.urlStr,
+			ExpectStatus: test.expectStatus,
+			ExpectBody:   test.expectBody,
 		})
 		c.Assert(queryCount, gc.Equals, test.expectQueryCount)
 	}
@@ -1013,9 +1013,9 @@ func (s *RouterSuite) TestServeMux(c *gc.C) {
 		ExpectBody: Foo{"hello"},
 	})
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    mux,
-		URL:        "/foo",
-		ExpectCode: http.StatusNotFound,
+		Handler:      mux,
+		URL:          "/foo",
+		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Message: "not found",
 			Code:    params.ErrNotFound,
@@ -1024,18 +1024,18 @@ func (s *RouterSuite) TestServeMux(c *gc.C) {
 }
 
 var handlerTests = []struct {
-	about      string
-	handler    http.Handler
-	urlStr     string
-	expectCode int
-	expectBody interface{}
+	about        string
+	handler      http.Handler
+	urlStr       string
+	expectStatus int
+	expectBody   interface{}
 }{{
 	about: "handleErrors, normal error",
 	handler: HandleErrors(func(http.ResponseWriter, *http.Request) error {
 		return errgo.Newf("an error")
 	}),
-	urlStr:     "",
-	expectCode: http.StatusInternalServerError,
+	urlStr:       "",
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "an error",
 	},
@@ -1047,8 +1047,8 @@ var handlerTests = []struct {
 			Code:    "snafu",
 		}
 	}),
-	urlStr:     "",
-	expectCode: http.StatusInternalServerError,
+	urlStr:       "",
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "something went wrong",
 		Code:    "snafu",
@@ -1059,13 +1059,13 @@ var handlerTests = []struct {
 		w.WriteHeader(http.StatusTeapot)
 		return nil
 	}),
-	expectCode: http.StatusTeapot,
+	expectStatus: http.StatusTeapot,
 }, {
 	about: "handleErrors, params error",
 	handler: HandleErrors(func(w http.ResponseWriter, req *http.Request) error {
 		return params.ErrMetadataNotFound
 	}),
-	expectCode: http.StatusNotFound,
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Message: "metadata not found",
 		Code:    params.ErrMetadataNotFound,
@@ -1076,7 +1076,7 @@ var handlerTests = []struct {
 		err := params.ErrMetadataNotFound
 		return errgo.NoteMask(err, "annotation", errgo.Is(params.ErrMetadataNotFound))
 	}),
-	expectCode: http.StatusNotFound,
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Message: "annotation: metadata not found",
 		Code:    params.ErrMetadataNotFound,
@@ -1086,7 +1086,7 @@ var handlerTests = []struct {
 	handler: HandleErrors(func(w http.ResponseWriter, req *http.Request) error {
 		return params.ErrBadRequest
 	}),
-	expectCode: http.StatusBadRequest,
+	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Message: "bad request",
 		Code:    params.ErrBadRequest,
@@ -1096,7 +1096,7 @@ var handlerTests = []struct {
 	handler: HandleErrors(func(w http.ResponseWriter, req *http.Request) error {
 		return params.ErrForbidden
 	}),
-	expectCode: http.StatusForbidden,
+	expectStatus: http.StatusForbidden,
 	expectBody: params.Error{
 		Message: "forbidden",
 		Code:    params.ErrForbidden,
@@ -1106,21 +1106,21 @@ var handlerTests = []struct {
 	handler: HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
 		return Foo{"hello"}, nil
 	}),
-	expectCode: http.StatusOK,
-	expectBody: Foo{"hello"},
+	expectStatus: http.StatusOK,
+	expectBody:   Foo{"hello"},
 }, {
 	about: "handleJSON, error case",
 	handler: HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
 		return nil, errgo.Newf("an error")
 	}),
-	expectCode: http.StatusInternalServerError,
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: "an error",
 	},
 }, {
-	about:      "NotFoundHandler",
-	handler:    NotFoundHandler(),
-	expectCode: http.StatusNotFound,
+	about:        "NotFoundHandler",
+	handler:      NotFoundHandler(),
+	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Message: "not found",
 		Code:    params.ErrNotFound,
@@ -1140,10 +1140,10 @@ func (s *RouterSuite) TestHandlers(c *gc.C) {
 	for i, test := range handlerTests {
 		c.Logf("test %d: %s", i, test.about)
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    test.handler,
-			URL:        "",
-			ExpectCode: test.expectCode,
-			ExpectBody: test.expectBody,
+			Handler:      test.handler,
+			URL:          "",
+			ExpectStatus: test.expectStatus,
+			ExpectBody:   test.expectBody,
 		})
 	}
 }

--- a/internal/storetesting/http.go
+++ b/internal/storetesting/http.go
@@ -71,10 +71,14 @@ func AssertJSONCall(c *gc.C, p JSONCallParams) {
 		Password:      p.Password,
 	})
 	c.Assert(rec.Code, gc.Equals, p.ExpectStatus, gc.Commentf("body: %s", rec.Body.Bytes()))
+
+	// Ensure the response includes the expected body.
 	if p.ExpectBody == nil {
 		c.Assert(rec.Body.Bytes(), gc.HasLen, 0)
 		return
 	}
+	c.Assert(rec.Header().Get("Content-Type"), gc.Equals, "application/json")
+
 	// Rather than unmarshaling into something of the expected
 	// body type, we reform the expected body in JSON and
 	// back to interface{}, so we can check the whole content.
@@ -88,7 +92,6 @@ func AssertJSONCall(c *gc.C, p JSONCallParams) {
 	var gotBodyVal interface{}
 	err = json.Unmarshal(rec.Body.Bytes(), &gotBodyVal)
 	c.Assert(err, gc.IsNil, gc.Commentf("json body: %q", rec.Body.Bytes()))
-	// TODO(rog) check that content type is application/json
 	c.Assert(gotBodyVal, jc.DeepEquals, expectBodyVal)
 }
 

--- a/internal/storetesting/http.go
+++ b/internal/storetesting/http.go
@@ -45,10 +45,9 @@ type JSONCallParams struct {
 	// Password, if specified, is used for HTTP basic authentication.
 	Password string
 
-	// ExpectCode holds the expected HTTP status code.
+	// ExpectStatus holds the expected HTTP status code.
 	// http.StatusOK is assumed if this is zero.
-	// TODO(rog) change this to ExpectStatus
-	ExpectCode int
+	ExpectStatus int
 
 	// ExpectBody holds the expected JSON body.
 	ExpectBody interface{}
@@ -58,8 +57,8 @@ type JSONCallParams struct {
 // the given parameters, the result is as specified.
 func AssertJSONCall(c *gc.C, p JSONCallParams) {
 	c.Logf("JSON call, url %q", p.URL)
-	if p.ExpectCode == 0 {
-		p.ExpectCode = http.StatusOK
+	if p.ExpectStatus == 0 {
+		p.ExpectStatus = http.StatusOK
 	}
 	rec := DoRequest(c, DoRequestParams{
 		Handler:       p.Handler,
@@ -71,7 +70,7 @@ func AssertJSONCall(c *gc.C, p JSONCallParams) {
 		Username:      p.Username,
 		Password:      p.Password,
 	})
-	c.Assert(rec.Code, gc.Equals, p.ExpectCode, gc.Commentf("body: %s", rec.Body.Bytes()))
+	c.Assert(rec.Code, gc.Equals, p.ExpectStatus, gc.Commentf("body: %s", rec.Body.Bytes()))
 	if p.ExpectBody == nil {
 		c.Assert(rec.Body.Bytes(), gc.HasLen, 0)
 		return

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -266,9 +266,9 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 			c.Logf("	expected data for %q: %#v", url, expectData)
 			if isNull(expectData) {
 				storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-					Handler:    s.srv,
-					URL:        storeURL,
-					ExpectCode: http.StatusNotFound,
+					Handler:      s.srv,
+					URL:          storeURL,
+					ExpectStatus: http.StatusNotFound,
 					ExpectBody: params.Error{
 						Message: params.ErrMetadataNotFound.Error(),
 						Code:    params.ErrMetadataNotFound,
@@ -417,17 +417,17 @@ func (s *APISuite) TestMetaCharmNotFound(c *gc.C) {
 			Code:    params.ErrNotFound,
 		}
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL("precise/wordpress-23/meta/" + ep.name),
-			ExpectCode: http.StatusNotFound,
-			ExpectBody: expected,
+			Handler:      s.srv,
+			URL:          storeURL("precise/wordpress-23/meta/" + ep.name),
+			ExpectStatus: http.StatusNotFound,
+			ExpectBody:   expected,
 		})
 		expected.Message = `no matching charm or bundle for "cs:wordpress"`
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL("wordpress/meta/" + ep.name),
-			ExpectCode: http.StatusNotFound,
-			ExpectBody: expected,
+			Handler:      s.srv,
+			URL:          storeURL("wordpress/meta/" + ep.name),
+			ExpectStatus: http.StatusNotFound,
+			ExpectBody:   expected,
 		})
 	}
 }
@@ -549,23 +549,23 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	for i, test := range serveExpandIdTests {
 		c.Logf("test %d: %s", i, test.about)
 		storeURL := storeURL(test.url + "/expand-id")
-		var expectCode int
+		var expectStatus int
 		var expectBody interface{}
 		if test.err == "" {
-			expectCode = http.StatusOK
+			expectStatus = http.StatusOK
 			expectBody = test.expect
 		} else {
-			expectCode = http.StatusNotFound
+			expectStatus = http.StatusNotFound
 			expectBody = params.Error{
 				Code:    params.ErrNotFound,
 				Message: test.err,
 			}
 		}
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL,
-			ExpectCode: expectCode,
-			ExpectBody: expectBody,
+			Handler:      s.srv,
+			URL:          storeURL,
+			ExpectStatus: expectStatus,
+			ExpectBody:   expectBody,
 		})
 	}
 }
@@ -613,23 +613,23 @@ func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
 	for i, test := range serveMetaRevisionInfoTests {
 		c.Logf("test %d: %s", i, test.about)
 		storeURL := storeURL(test.url + "/meta/revision-info")
-		var expectCode int
+		var expectStatus int
 		var expectBody interface{}
 		if test.err == "" {
-			expectCode = http.StatusOK
+			expectStatus = http.StatusOK
 			expectBody = test.expect
 		} else {
-			expectCode = http.StatusNotFound
+			expectStatus = http.StatusNotFound
 			expectBody = params.Error{
 				Code:    params.ErrNotFound,
 				Message: test.err,
 			}
 		}
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL,
-			ExpectCode: expectCode,
-			ExpectBody: expectBody,
+			Handler:      s.srv,
+			URL:          storeURL,
+			ExpectStatus: expectStatus,
+			ExpectBody:   expectBody,
 		})
 	}
 }
@@ -695,9 +695,9 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 		// Ensure the meta/stats response reports the correct downloads count.
 		statsURL := storeURL(test.url + "/meta/stats")
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        statsURL,
-			ExpectCode: http.StatusOK,
+			Handler:      s.srv,
+			URL:          statsURL,
+			ExpectStatus: http.StatusOK,
 			ExpectBody: params.StatsResponse{
 				ArchiveDownloadCount: test.downloads,
 			},
@@ -707,9 +707,9 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 
 func assertNotImplemented(c *gc.C, h http.Handler, path string) {
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    h,
-		URL:        storeURL(path),
-		ExpectCode: http.StatusInternalServerError,
+		Handler:      h,
+		URL:          storeURL(path),
+		ExpectStatus: http.StatusInternalServerError,
 		ExpectBody: params.Error{
 			Message: "method not implemented",
 		},

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -677,7 +677,10 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 		// Download the entity archive for the requested number of times.
 		archiveUrl := storeURL(test.url + "/archive")
 		for i := 0; i < int(test.downloads); i++ {
-			rec := storetesting.DoRequest(c, s.srv, "GET", archiveUrl, nil, 0, nil, "", "")
+			rec := storetesting.DoRequest(c, storetesting.DoRequestParams{
+				Handler: s.srv,
+				URL:     archiveUrl,
+			})
 			c.Assert(rec.Code, gc.Equals, http.StatusOK)
 		}
 

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -151,10 +151,10 @@ func (s *ArchiveSuite) TestPostErrors(c *gc.C) {
 			Header: http.Header{
 				"Content-Type": {"application/zip"},
 			},
-			Body:       body,
-			Username:   serverParams.AuthUsername,
-			Password:   serverParams.AuthPassword,
-			ExpectCode: test.expectStatus,
+			Body:         body,
+			Username:     serverParams.AuthUsername,
+			Password:     serverParams.AuthPassword,
+			ExpectStatus: test.expectStatus,
 			ExpectBody: params.Error{
 				Message: test.expectMessage,
 				Code:    test.expectCode,
@@ -318,10 +318,10 @@ func (s *ArchiveSuite) TestPostHashMismatch(c *gc.C) {
 		Header: http.Header{
 			"Content-Type": {"application/zip"},
 		},
-		Body:       bytes.NewReader(content),
-		Username:   serverParams.AuthUsername,
-		Password:   serverParams.AuthPassword,
-		ExpectCode: http.StatusInternalServerError,
+		Body:         bytes.NewReader(content),
+		Username:     serverParams.AuthUsername,
+		Password:     serverParams.AuthPassword,
+		ExpectStatus: http.StatusInternalServerError,
 		ExpectBody: params.Error{
 			Message: "cannot put archive blob: hash mismatch",
 		},
@@ -368,10 +368,10 @@ func (s *ArchiveSuite) assertCannotUpload(c *gc.C, id string, content io.ReadSee
 		Header: http.Header{
 			"Content-Type": {"application/zip"},
 		},
-		Body:       content,
-		Username:   serverParams.AuthUsername,
-		Password:   serverParams.AuthPassword,
-		ExpectCode: http.StatusInternalServerError,
+		Body:         content,
+		Username:     serverParams.AuthUsername,
+		Password:     serverParams.AuthPassword,
+		ExpectStatus: http.StatusInternalServerError,
 		ExpectBody: params.Error{
 			Message: errorMessage,
 		},
@@ -490,10 +490,10 @@ func (s *ArchiveSuite) TestArchiveFileErrors(c *gc.C) {
 	for i, test := range archiveFileErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL(test.path),
-			Method:     "GET",
-			ExpectCode: test.expectStatus,
+			Handler:      s.srv,
+			URL:          storeURL(test.path),
+			Method:       "GET",
+			ExpectStatus: test.expectStatus,
 			ExpectBody: params.Error{
 				Message: test.expectMessage,
 				Code:    test.expectCode,
@@ -658,12 +658,12 @@ func (s *ArchiveSuite) TestDelete(c *gc.C) {
 
 	// Delete the charm using the API.
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    s.srv,
-		URL:        storeURL(id + "/archive"),
-		Method:     "DELETE",
-		Username:   serverParams.AuthUsername,
-		Password:   serverParams.AuthPassword,
-		ExpectCode: http.StatusOK,
+		Handler:      s.srv,
+		URL:          storeURL(id + "/archive"),
+		Method:       "DELETE",
+		Username:     serverParams.AuthUsername,
+		Password:     serverParams.AuthPassword,
+		ExpectStatus: http.StatusOK,
 	})
 
 	// The entity has been deleted.
@@ -687,12 +687,12 @@ func (s *ArchiveSuite) TestDeleteSpecificCharm(c *gc.C) {
 
 	// Delete the second charm using the API.
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    s.srv,
-		URL:        storeURL("utopic/mysql-42/archive"),
-		Method:     "DELETE",
-		Username:   serverParams.AuthUsername,
-		Password:   serverParams.AuthPassword,
-		ExpectCode: http.StatusOK,
+		Handler:      s.srv,
+		URL:          storeURL("utopic/mysql-42/archive"),
+		Method:       "DELETE",
+		Username:     serverParams.AuthUsername,
+		Password:     serverParams.AuthPassword,
+		ExpectStatus: http.StatusOK,
 	})
 
 	// The other two charms are still present in the database.
@@ -710,12 +710,12 @@ func (s *ArchiveSuite) TestDeleteSpecificCharm(c *gc.C) {
 func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 	// Try to delete a non existing charm using the API.
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    s.srv,
-		URL:        storeURL("utopic/no-such-0/archive"),
-		Method:     "DELETE",
-		Username:   serverParams.AuthUsername,
-		Password:   serverParams.AuthPassword,
-		ExpectCode: http.StatusNotFound,
+		Handler:      s.srv,
+		URL:          storeURL("utopic/no-such-0/archive"),
+		Method:       "DELETE",
+		Username:     serverParams.AuthUsername,
+		Password:     serverParams.AuthPassword,
+		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Message: params.ErrNotFound.Error(),
 			Code:    params.ErrNotFound,
@@ -732,12 +732,12 @@ func (s *ArchiveSuite) TestDeleteError(c *gc.C) {
 
 	// Try to delete the charm using the API.
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    s.srv,
-		URL:        storeURL(id + "/archive"),
-		Method:     "DELETE",
-		Username:   serverParams.AuthUsername,
-		Password:   serverParams.AuthPassword,
-		ExpectCode: http.StatusInternalServerError,
+		Handler:      s.srv,
+		URL:          storeURL(id + "/archive"),
+		Method:       "DELETE",
+		Username:     serverParams.AuthUsername,
+		Password:     serverParams.AuthPassword,
+		ExpectStatus: http.StatusInternalServerError,
 		ExpectBody: params.Error{
 			Message: `cannot remove blob no-such-name: resource at path "global/no-such-name" not found`,
 		},
@@ -818,13 +818,13 @@ func checkAuthErrors(c *gc.C, handler http.Handler, method, url string) {
 			test.header.Add("Content-Type", "application/zip")
 		}
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    handler,
-			URL:        archiveURL,
-			Method:     method,
-			Header:     test.header,
-			Username:   test.username,
-			Password:   test.password,
-			ExpectCode: http.StatusUnauthorized,
+			Handler:      handler,
+			URL:          archiveURL,
+			Method:       method,
+			Header:       test.header,
+			Username:     test.username,
+			Password:     test.password,
+			ExpectStatus: http.StatusUnauthorized,
 			ExpectBody: params.Error{
 				Message: test.expectMessage,
 				Code:    params.ErrUnauthorized,

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -293,10 +293,10 @@ func (s *RelationsSuite) TestMetaCharmRelated(c *gc.C) {
 		s.addCharms(c, test.charms)
 		storeURL := storeURL(test.id + "/meta/charm-related" + test.querystring)
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL,
-			ExpectCode: http.StatusOK,
-			ExpectBody: test.expectBody,
+			Handler:      s.srv,
+			URL:          storeURL,
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   test.expectBody,
 		})
 		// Clean up the entities in the store.
 		_, err := s.store.DB.Entities().RemoveAll(nil)
@@ -308,9 +308,9 @@ func (s *RelationsSuite) TestMetaCharmRelatedIncludeError(c *gc.C) {
 	s.addCharms(c, metaCharmRelatedCharms)
 	storeURL := storeURL("utopic/wordpress-0/meta/charm-related?include=no-such")
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    s.srv,
-		URL:        storeURL,
-		ExpectCode: http.StatusInternalServerError,
+		Handler:      s.srv,
+		URL:          storeURL,
+		ExpectStatus: http.StatusInternalServerError,
 		ExpectBody: params.Error{
 			Message: `cannot retrieve the charm requires: unrecognized metadata name "no-such"`,
 		},
@@ -395,13 +395,13 @@ var metaBundlesContainingTests = []struct {
 	// The querystring to append to the resulting charmstore URL.
 	querystring string
 	// The expected status code of the response.
-	expectCode int
+	expectStatus int
 	// The expected response body.
 	expectBody interface{}
 }{{
-	about:      "specific charm present in several bundles",
-	id:         "utopic/wordpress-42",
-	expectCode: http.StatusOK,
+	about:        "specific charm present in several bundles",
+	id:           "utopic/wordpress-42",
+	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}, {
@@ -410,22 +410,22 @@ var metaBundlesContainingTests = []struct {
 		Id: mustParseReference("bundle/useless-0"),
 	}},
 }, {
-	about:      "specific charm present in one bundle",
-	id:         "trusty/memcached-2",
-	expectCode: http.StatusOK,
+	about:        "specific charm present in one bundle",
+	id:           "trusty/memcached-2",
+	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: mustParseReference("bundle/wordpress-complex-1"),
 	}},
 }, {
-	about:      "specific charm not present in any bundle",
-	id:         "trusty/django-42",
-	expectCode: http.StatusOK,
-	expectBody: []*params.MetaAnyResponse{},
+	about:        "specific charm not present in any bundle",
+	id:           "trusty/django-42",
+	expectStatus: http.StatusOK,
+	expectBody:   []*params.MetaAnyResponse{},
 }, {
-	about:       "specific charm with includes",
-	id:          "trusty/mysql-1",
-	querystring: "?include=archive-size&include=bundle-metadata",
-	expectCode:  http.StatusOK,
+	about:        "specific charm with includes",
+	id:           "trusty/mysql-1",
+	querystring:  "?include=archive-size&include=bundle-metadata",
+	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: mustParseReference("bundle/wordpress-complex-1"),
 		Meta: map[string]interface{}{
@@ -434,55 +434,55 @@ var metaBundlesContainingTests = []struct {
 		},
 	}},
 }, {
-	about:      "partial charm id",
-	id:         "mysql", // The test will add cs:utopic/mysql-0.
-	expectCode: http.StatusOK,
+	about:        "partial charm id",
+	id:           "mysql", // The test will add cs:utopic/mysql-0.
+	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
-	about:       "any series set to true",
-	id:          "trusty/mysql-0",
-	querystring: "?any-series=1",
-	expectCode:  http.StatusOK,
+	about:        "any series set to true",
+	id:           "trusty/mysql-0",
+	querystring:  "?any-series=1",
+	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}, {
 		Id: mustParseReference("bundle/wordpress-complex-1"),
 	}},
 }, {
-	about:       "invalid any series",
-	id:          "utopic/mysql-0",
-	querystring: "?any-series=true",
-	expectCode:  http.StatusBadRequest,
+	about:        "invalid any series",
+	id:           "utopic/mysql-0",
+	querystring:  "?any-series=true",
+	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
 		Message: `invalid value for any-series: unexpected bool value "true" (must be "0" or "1")`,
 	},
 }, {
-	about:       "any revision set to true",
-	id:          "trusty/memcached-99",
-	querystring: "?any-revision=1",
-	expectCode:  http.StatusOK,
+	about:        "any revision set to true",
+	id:           "trusty/memcached-99",
+	querystring:  "?any-revision=1",
+	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: mustParseReference("bundle/wordpress-complex-1"),
 	}, {
 		Id: mustParseReference("bundle/django-generic-42"),
 	}},
 }, {
-	about:       "invalid any revision",
-	id:          "trusty/memcached-99",
-	querystring: "?any-revision=why-not",
-	expectCode:  http.StatusBadRequest,
+	about:        "invalid any revision",
+	id:           "trusty/memcached-99",
+	querystring:  "?any-revision=why-not",
+	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
 		Message: `invalid value for any-revision: unexpected bool value "why-not" (must be "0" or "1")`,
 	},
 }, {
-	about:       "any series and revision",
-	id:          "saucy/mysql-99",
-	querystring: "?any-series=1&any-revision=1",
-	expectCode:  http.StatusOK,
+	about:        "any series and revision",
+	id:           "saucy/mysql-99",
+	querystring:  "?any-series=1&any-revision=1",
+	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}, {
@@ -493,10 +493,10 @@ var metaBundlesContainingTests = []struct {
 		Id: mustParseReference("bundle/mediawiki-47"),
 	}},
 }, {
-	about:       "any series and revision with includes",
-	id:          "saucy/wordpress-99",
-	querystring: "?any-series=1&any-revision=1&include=archive-size&include=bundle-metadata",
-	expectCode:  http.StatusOK,
+	about:        "any series and revision with includes",
+	id:           "saucy/wordpress-99",
+	querystring:  "?any-series=1&any-revision=1&include=archive-size&include=bundle-metadata",
+	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: mustParseReference("bundle/wordpress-simple-0"),
 		Meta: map[string]interface{}{
@@ -517,10 +517,10 @@ var metaBundlesContainingTests = []struct {
 		},
 	}},
 }, {
-	about:       "include-error",
-	id:          "utopic/wordpress-42",
-	querystring: "?include=no-such",
-	expectCode:  http.StatusInternalServerError,
+	about:        "include-error",
+	id:           "utopic/wordpress-42",
+	querystring:  "?include=no-such",
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
 		Message: `cannot retrieve bundle metadata: unrecognized metadata name "no-such"`,
 	},
@@ -557,10 +557,10 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 		// Perform the request and ensure the response is what we expect.
 		storeURL := storeURL(test.id + "/meta/bundles-containing" + test.querystring)
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL,
-			ExpectCode: test.expectCode,
-			ExpectBody: test.expectBody,
+			Handler:      s.srv,
+			URL:          storeURL,
+			ExpectStatus: test.expectStatus,
+			ExpectBody:   test.expectBody,
 		})
 
 		// Clean up the charm entity in the store.

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -102,9 +102,9 @@ func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("test %d. %s", i, test.path)
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL(test.path),
-			ExpectCode: test.status,
+			Handler:      s.srv,
+			URL:          storeURL(test.path),
+			ExpectStatus: test.status,
 			ExpectBody: params.Error{
 				Message: test.message,
 				Code:    test.code,

--- a/server_test.go
+++ b/server_test.go
@@ -64,9 +64,9 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    h,
-		URL:        "/v4/debug",
-		ExpectCode: http.StatusInternalServerError,
+		Handler:      h,
+		URL:          "/v4/debug",
+		ExpectStatus: http.StatusInternalServerError,
 		ExpectBody: params.Error{
 			Message: "method not implemented",
 		},
@@ -87,9 +87,9 @@ func assertServesVersion(c *gc.C, h http.Handler, vers string) {
 
 func assertDoesNotServeVersion(c *gc.C, h http.Handler, vers string) {
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    h,
-		URL:        "/" + vers + "/debug",
-		ExpectCode: http.StatusNotFound,
+		Handler:      h,
+		URL:          "/" + vers + "/debug",
+		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Message: "not found",
 			Code:    params.ErrNotFound,


### PR DESCRIPTION
Mostly mechanical.
Introduce DoRequest params.
s/expectCode/expectStatus/ in tests.
Make AssertJSONCall also check the response content type.
