### PR TITLE
Fix intermittent test failures due to results ordering issues.

### DIFF
--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -324,6 +325,7 @@ func verificationError(err error) error {
 	for i, err := range verr.Errors {
 		messages[i] = err.Error()
 	}
+	sort.Strings(messages)
 	encodedMessages, err := json.Marshal(messages)
 	if err != nil {
 		// This should never happen.

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -134,6 +134,7 @@ func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 			return errgo.Notef(err, "cannot retrieve bundle charms")
 		}
 		if err := bundleData.VerifyWithCharms(verifyConstraints, charms); err != nil {
+			// TODO frankban: use multiError (defined in internal/router).
 			return errgo.Notef(verificationError(err), "bundle verification failed")
 		}
 		if err := h.store.AddBundle(id, b, name, hash, req.ContentLength); err != nil {

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -348,9 +348,9 @@ func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
 	expectErr := `bundle verification failed: [` +
-		`"service \"wordpress\" refers to non-existent charm \"wordpress\"",` +
+		`"relation [\"foo:db\" \"mysql:server\"] refers to service \"foo\" not defined in this bundle",` +
 		`"service \"mysql\" refers to non-existent charm \"mysql\"",` +
-		`"relation [\"foo:db\" \"mysql:server\"] refers to service \"foo\" not defined in this bundle"]`
+		`"service \"wordpress\" refers to non-existent charm \"wordpress\""]`
 	s.assertCannotUpload(c, "bundle/wordpress", f, expectErr)
 }
 

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -188,14 +188,14 @@ func (h *handler) metaBundlesContaining(entity *mongodoc.Entity, id *charm.Refer
 	}
 
 	// Prepare and return the response.
-	response := make([]params.MetaAnyResponse, 0, len(entities))
+	response := make([]*params.MetaAnyResponse, 0, len(entities))
 	includes := flags["include"]
 	for _, e := range entities {
 		meta, err := h.GetMetadata(e.URL, includes)
 		if err != nil {
 			return nil, errgo.Notef(err, "cannot retrieve bundle metadata")
 		}
-		response = append(response, params.MetaAnyResponse{
+		response = append(response, &params.MetaAnyResponse{
 			Id:   e.URL,
 			Meta: meta,
 		})

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -5,6 +5,7 @@ package v4
 
 import (
 	"net/url"
+	"sort"
 
 	"github.com/juju/errgo"
 	"gopkg.in/juju/charm.v3"
@@ -134,6 +135,7 @@ func (h *handler) getRelatedIfaceResponses(
 			}
 		}
 	}
+	sort.Sort(byId(responses))
 	return responses, nil
 }
 
@@ -187,18 +189,19 @@ func (h *handler) metaBundlesContaining(entity *mongodoc.Entity, id *charm.Refer
 	}
 
 	// Prepare and return the response.
-	response := make([]*params.MetaAnyResponse, 0, len(entities))
+	response := make([]params.MetaAnyResponse, 0, len(entities))
 	includes := flags["include"]
 	for _, e := range entities {
 		meta, err := h.GetMetadata(e.URL, includes)
 		if err != nil {
 			return nil, errgo.Notef(err, "cannot retrieve bundle metadata")
 		}
-		response = append(response, &params.MetaAnyResponse{
+		response = append(response, params.MetaAnyResponse{
 			Id:   e.URL,
 			Meta: meta,
 		})
 	}
+	sort.Sort(byId(response))
 	return response, nil
 }
 
@@ -212,4 +215,29 @@ func filterEntities(entities []mongodoc.Entity, predicate func(*mongodoc.Entity)
 		}
 	}
 	return results
+}
+
+// byId implements sort.Interface for []params.MetaAnyResponse based on the Id
+// field. For the same base charm, the most recent revisions come first.
+type byId []params.MetaAnyResponse
+
+func (s byId) Len() int           { return len(s) }
+func (s byId) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s byId) Less(i, j int) bool { return referenceLess(s[i].Id, s[j].Id) }
+
+// referenceLess reports whether ref1 should sort before ref2.
+// Alphabetical order of the reference string representation
+// (without the revision) is considered. If ref1 and ref2 have the same base
+// string representation, the most recent revision comes first.
+// This function can be used when implementing sort.Interface in data
+// structures requiring reference sorting.
+func referenceLess(ref1, ref2 *charm.Reference) bool {
+	base1, base2 := *ref1, *ref2
+	base1.Revision = -1
+	base2.Revision = -1
+	str1, str2 := base1.String(), base2.String()
+	if str1 != str2 {
+		return str1 < str2
+	}
+	return ref1.Revision > ref2.Revision
 }

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -126,9 +126,9 @@ var metaCharmRelatedTests = []struct {
 		},
 		Requires: map[string][]params.MetaAnyResponse{
 			"http": []params.MetaAnyResponse{{
-				Id: mustParseReference("trusty/haproxy-47"),
-			}, {
 				Id: mustParseReference("precise/haproxy-48"),
+			}, {
+				Id: mustParseReference("trusty/haproxy-47"),
 			}},
 		},
 	},
@@ -230,11 +230,102 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"memcache": []params.MetaAnyResponse{{
-				Id: mustParseReference("utopic/memcached-1"),
+				Id: mustParseReference("utopic/memcached-3"),
 			}, {
 				Id: mustParseReference("utopic/memcached-2"),
 			}, {
-				Id: mustParseReference("utopic/memcached-3"),
+				Id: mustParseReference("utopic/memcached-1"),
+			}},
+		},
+	},
+}, {
+	about: "reference ordering",
+	charms: map[string]charm.Charm{
+		"trusty/wordpress-0": &relationTestingCharm{
+			requires: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "requirer",
+					Interface: "memcache",
+				},
+				"nfs": {
+					Name:      "nfs",
+					Role:      "requirer",
+					Interface: "mount",
+				},
+			},
+		},
+		"utopic/memcached-1": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "provider",
+					Interface: "memcache",
+				},
+			},
+		},
+		"utopic/memcached-2": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "provider",
+					Interface: "memcache",
+				},
+			},
+		},
+		"utopic/redis-90": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "provider",
+					Interface: "memcache",
+				},
+			},
+		},
+		"trusty/nfs-47": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"nfs": {
+					Name:      "nfs",
+					Role:      "provider",
+					Interface: "mount",
+				},
+			},
+		},
+		"precise/nfs-42": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"nfs": {
+					Name:      "nfs",
+					Role:      "provider",
+					Interface: "mount",
+				},
+			},
+		},
+		"precise/nfs-47": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"nfs": {
+					Name:      "nfs",
+					Role:      "provider",
+					Interface: "mount",
+				},
+			},
+		},
+	},
+	id: "trusty/wordpress-0",
+	expectBody: params.RelatedResponse{
+		Provides: map[string][]params.MetaAnyResponse{
+			"memcache": []params.MetaAnyResponse{{
+				Id: mustParseReference("utopic/memcached-2"),
+			}, {
+				Id: mustParseReference("utopic/memcached-1"),
+			}, {
+				Id: mustParseReference("utopic/redis-90"),
+			}},
+			"mount": []params.MetaAnyResponse{{
+				Id: mustParseReference("precise/nfs-47"),
+			}, {
+				Id: mustParseReference("precise/nfs-42"),
+			}, {
+				Id: mustParseReference("trusty/nfs-47"),
 			}},
 		},
 	},
@@ -359,6 +450,12 @@ var metaBundlesContainingBundles = map[string]charm.Bundle{
 			"cs:utopic/mysql-0",
 		},
 	},
+	"bundle/wordpress-simple-1": &relationTestingBundle{
+		urls: []string{
+			"cs:utopic/wordpress-47",
+			"cs:utopic/mysql-1",
+		},
+	},
 	"bundle/wordpress-complex-1": &relationTestingBundle{
 		urls: []string{
 			"cs:utopic/wordpress-42",
@@ -403,11 +500,11 @@ var metaBundlesContainingTests = []struct {
 	id:           "utopic/wordpress-42",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Id: mustParseReference("bundle/useless-0"),
 	}, {
 		Id: mustParseReference("bundle/wordpress-complex-1"),
 	}, {
-		Id: mustParseReference("bundle/useless-0"),
+		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
 	about:        "specific charm present in one bundle",
@@ -446,9 +543,9 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-series=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-simple-0"),
-	}, {
 		Id: mustParseReference("bundle/wordpress-complex-1"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
 	about:        "invalid any series",
@@ -465,9 +562,9 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-revision=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-complex-1"),
-	}, {
 		Id: mustParseReference("bundle/django-generic-42"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-complex-1"),
 	}},
 }, {
 	about:        "invalid any revision",
@@ -484,13 +581,15 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-series=1&any-revision=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-simple-0"),
-	}, {
-		Id: mustParseReference("bundle/wordpress-complex-1"),
-	}, {
 		Id: mustParseReference("bundle/django-generic-42"),
 	}, {
 		Id: mustParseReference("bundle/mediawiki-47"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-complex-1"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-1"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
 	about:        "any series and revision with includes",
@@ -498,10 +597,10 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-series=1&any-revision=1&include=archive-size&include=bundle-metadata",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Id: mustParseReference("bundle/useless-0"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
-			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-0"].Data(),
+			"bundle-metadata": metaBundlesContainingBundles["bundle/useless-0"].Data(),
 		},
 	}, {
 		Id: mustParseReference("bundle/wordpress-complex-1"),
@@ -510,10 +609,16 @@ var metaBundlesContainingTests = []struct {
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-complex-1"].Data(),
 		},
 	}, {
-		Id: mustParseReference("bundle/useless-0"),
+		Id: mustParseReference("bundle/wordpress-simple-1"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
-			"bundle-metadata": metaBundlesContainingBundles["bundle/useless-0"].Data(),
+			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-1"].Data(),
+		},
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Meta: map[string]interface{}{
+			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
+			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-0"].Data(),
 		},
 	}},
 }, {

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -230,11 +230,11 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"memcache": []params.MetaAnyResponse{{
-				Id: mustParseReference("utopic/memcached-3"),
+				Id: mustParseReference("utopic/memcached-1"),
 			}, {
 				Id: mustParseReference("utopic/memcached-2"),
 			}, {
-				Id: mustParseReference("utopic/memcached-1"),
+				Id: mustParseReference("utopic/memcached-3"),
 			}},
 		},
 	},
@@ -314,16 +314,16 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"memcache": []params.MetaAnyResponse{{
-				Id: mustParseReference("utopic/memcached-2"),
-			}, {
 				Id: mustParseReference("utopic/memcached-1"),
+			}, {
+				Id: mustParseReference("utopic/memcached-2"),
 			}, {
 				Id: mustParseReference("utopic/redis-90"),
 			}},
 			"mount": []params.MetaAnyResponse{{
-				Id: mustParseReference("precise/nfs-47"),
-			}, {
 				Id: mustParseReference("precise/nfs-42"),
+			}, {
+				Id: mustParseReference("precise/nfs-47"),
 			}, {
 				Id: mustParseReference("trusty/nfs-47"),
 			}},
@@ -587,9 +587,9 @@ var metaBundlesContainingTests = []struct {
 	}, {
 		Id: mustParseReference("bundle/wordpress-complex-1"),
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-1"),
-	}, {
 		Id: mustParseReference("bundle/wordpress-simple-0"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-1"),
 	}},
 }, {
 	about:        "any series and revision with includes",
@@ -609,16 +609,16 @@ var metaBundlesContainingTests = []struct {
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-complex-1"].Data(),
 		},
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-1"),
-		Meta: map[string]interface{}{
-			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
-			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-1"].Data(),
-		},
-	}, {
 		Id: mustParseReference("bundle/wordpress-simple-0"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-0"].Data(),
+		},
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-1"),
+		Meta: map[string]interface{}{
+			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
+			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-1"].Data(),
 		},
 	}},
 }, {


### PR DESCRIPTION
Make bundles-containing and charm-related API
endpoints return results in a specific order.
