### PR TITLE
internal/v4: implement extra-info GET and PUT

### DIFF
--- a/internal/charmstore/stats.go
+++ b/internal/charmstore/stats.go
@@ -63,7 +63,7 @@ func (s *Store) statsKey(db StoreDatabase, key []string, write bool) (string, er
 			err = tokens.Find(bson.D{{"t", key[i]}}).One(&t)
 			if err == mgo.ErrNotFound {
 				if !write {
-					return "", params.ErrNotFound
+					return "", errgo.WithCausef(nil, params.ErrNotFound, "")
 				}
 				t.Id, err = tokens.Count()
 				if err != nil {

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -31,6 +31,10 @@ type Entity struct {
 
 	UploadTime time.Time
 
+	// ExtraInfo holds arbitrary extra metadata associated with
+	// the entity. The byte slices hold JSON-encoded data.
+	ExtraInfo map[string][]byte
+
 	// TODO(rog) verify that all these types marshal to the expected
 	// JSON form.
 	CharmMeta    *charm.Meta

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -183,7 +183,7 @@ func (r *Router) serveIds(w http.ResponseWriter, req *http.Request) error {
 	}
 	key, path := handlerKey(path)
 	if key == "" {
-		return params.ErrNotFound
+		return errgo.WithCausef(nil, params.ErrNotFound, "")
 	}
 	handler := r.handlers.Id[key]
 	if handler == nil || idHandlerNeedsResolveURL(req) {
@@ -203,7 +203,7 @@ func (r *Router) serveIds(w http.ResponseWriter, req *http.Request) error {
 		return errgo.Mask(err, errgo.Any)
 	}
 	if key != "meta/" && key != "meta" {
-		return params.ErrNotFound
+		return errgo.WithCausef(nil, params.ErrNotFound, "")
 	}
 	req.URL.Path = path
 	return r.serveMeta(url, w, req)
@@ -281,7 +281,7 @@ func (r *Router) serveMetaGet(id *charm.Reference, req *http.Request) (interface
 		}
 		return results[0], nil
 	}
-	return nil, params.ErrNotFound
+	return nil, errgo.WithCausef(nil, params.ErrNotFound, "")
 }
 
 const jsonContentType = "application/json"
@@ -343,7 +343,7 @@ func (r *Router) serveMetaPutBody(id *charm.Reference, req *http.Request, body *
 		}
 		return nil
 	}
-	return params.ErrNotFound
+	return errgo.WithCausef(nil, params.ErrNotFound, "")
 }
 
 // isNull reports whether the given value will encode to

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -130,7 +130,7 @@ func WriteJSON(w http.ResponseWriter, code int, val interface{}) error {
 // returns a JSON error response.
 func NotFoundHandler() http.Handler {
 	return HandleErrors(func(w http.ResponseWriter, req *http.Request) error {
-		return params.ErrNotFound
+		return errgo.WithCausef(nil, params.ErrNotFound, "")
 	})
 }
 
@@ -151,7 +151,7 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	h, pattern := mux.Handler(req)
 	if pattern == "" {
-		WriteError(w, params.ErrNotFound)
+		WriteError(w, errgo.WithCausef(nil, params.ErrNotFound, "no handler for %q", req.URL.Path))
 		return
 	}
 	h.ServeHTTP(w, req)

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -7,6 +7,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"reflect"
@@ -216,6 +217,28 @@ var metaEndpoints = []metaEndpoint{{
 	assertCheckData: func(c *gc.C, data interface{}) {
 		c.Assert(data, gc.FitsTypeOf, (*params.StatsResponse)(nil))
 	},
+}, {
+	name: "extra-info",
+	get: func(store *charmstore.Store, url *charm.Reference) (interface{}, error) {
+		return map[string]string{
+			"key": "value " + url.String(),
+		}, nil
+	},
+	checkURL: "cs:precise/wordpress-23",
+	assertCheckData: func(c *gc.C, data interface{}) {
+		c.Assert(data, gc.DeepEquals, map[string]string{
+			"key": "value cs:precise/wordpress-23",
+		})
+	},
+}, {
+	name: "extra-info/key",
+	get: func(store *charmstore.Store, url *charm.Reference) (interface{}, error) {
+		return "value " + url.String(), nil
+	},
+	checkURL: "cs:precise/wordpress-23",
+	assertCheckData: func(c *gc.C, data interface{}) {
+		c.Assert(data, gc.Equals, "value cs:precise/wordpress-23")
+	},
 }}
 
 // TestEndpointGet tries to ensure that the endpoint
@@ -248,6 +271,9 @@ func (s *APISuite) addTestEntities(c *gc.C) []*charm.Reference {
 		} else {
 			s.addCharm(c, url.Name, e)
 		}
+		// associate some extra-info data with the entity
+
+		s.assertPut(c, strings.TrimPrefix(e, "cs:")+"/meta/extra-info/key", "value "+e)
 		urls[i] = url
 	}
 	return urls
@@ -260,14 +286,14 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 		tested := false
 		for _, url := range urls {
 			charmId := strings.TrimPrefix(url.String(), "cs:")
-			storeURL := storeURL(charmId + "/meta/" + ep.name)
+			path := charmId + "/meta/" + ep.name
 			expectData, err := ep.get(s.store, url)
 			c.Assert(err, gc.IsNil)
 			c.Logf("	expected data for %q: %#v", url, expectData)
 			if isNull(expectData) {
 				storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 					Handler:      s.srv,
-					URL:          storeURL,
+					URL:          storeURL(path),
 					ExpectStatus: http.StatusNotFound,
 					ExpectBody: params.Error{
 						Message: params.ErrMetadataNotFound.Error(),
@@ -277,16 +303,155 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 				continue
 			}
 			tested = true
-			storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-				Handler:    s.srv,
-				URL:        storeURL,
-				ExpectBody: expectData,
-			})
-
+			s.assertGet(c, path, expectData)
 		}
 		if !tested {
 			c.Errorf("endpoint %q is null for all endpoints, so is not properly tested", ep.name)
 		}
+	}
+}
+
+func (s *APISuite) TestExtraInfo(c *gc.C) {
+	id := "precise/wordpress-23"
+	s.addCharm(c, "wordpress", "cs:"+id)
+
+	// Add one value and check that it's there.
+	s.assertPut(c, id+"/meta/extra-info/foo", "fooval")
+	s.assertGet(c, id+"/meta/extra-info/foo", "fooval")
+	s.assertGet(c, id+"/meta/extra-info", map[string]string{
+		"foo": "fooval",
+	})
+
+	// Add another value and check that both values are there.
+	s.assertPut(c, id+"/meta/extra-info/bar", "barval")
+	s.assertGet(c, id+"/meta/extra-info/bar", "barval")
+	s.assertGet(c, id+"/meta/extra-info", map[string]string{
+		"foo": "fooval",
+		"bar": "barval",
+	})
+
+	// Overwrite a value and check that it's changed.
+	s.assertPut(c, id+"/meta/extra-info/foo", "fooval2")
+	s.assertGet(c, id+"/meta/extra-info/foo", "fooval2")
+	s.assertGet(c, id+"/meta/extra-info", map[string]string{
+		"foo": "fooval2",
+		"bar": "barval",
+	})
+
+	// Write several values at once.
+	s.assertPut(c, id+"/meta/any", params.MetaAnyResponse{
+		Meta: map[string]interface{}{
+			"extra-info": map[string]string{
+				"foo": "fooval3",
+				"baz": "bazval",
+			},
+			"extra-info/frob": []int{1, 4, 6},
+		},
+	})
+	s.assertGet(c, id+"/meta/extra-info", map[string]interface{}{
+		"foo":  "fooval3",
+		"baz":  "bazval",
+		"bar":  "barval",
+		"frob": []int{1, 4, 6},
+	})
+}
+
+var extraInfoBadPutRequestsTests = []struct {
+	about        string
+	path         string
+	body         interface{}
+	contentType  string
+	expectStatus int
+	expectBody   params.Error
+}{{
+	about:        "key with extra element",
+	path:         "precise/wordpress-23/meta/extra-info/foo/bar",
+	body:         "hello",
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about:        "key with a dot",
+	path:         "precise/wordpress-23/meta/extra-info/foo.bar",
+	body:         "hello",
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about:        "key with a dollar",
+	path:         "precise/wordpress-23/meta/extra-info/foo$bar",
+	body:         "hello",
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about: "multi key with extra element",
+	path:  "precise/wordpress-23/meta/extra-info",
+	body: map[string]string{
+		"foo/bar": "value",
+	},
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about: "multi key with dot",
+	path:  "precise/wordpress-23/meta/extra-info",
+	body: map[string]string{
+		".bar": "value",
+	},
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about: "multi key with dollar",
+	path:  "precise/wordpress-23/meta/extra-info",
+	body: map[string]string{
+		"$bar": "value",
+	},
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about:        "multi key with bad map",
+	path:         "precise/wordpress-23/meta/extra-info",
+	body:         "bad",
+	expectStatus: http.StatusInternalServerError,
+	expectBody: params.Error{
+		Message: `cannot unmarshal extra info body: json: cannot unmarshal string into Go value of type map[string]*json.RawMessage`,
+	},
+}}
+
+func (s *APISuite) TestExtraInfoBadPutRequests(c *gc.C) {
+	s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
+	for i, test := range extraInfoBadPutRequestsTests {
+		c.Logf("test %d: %s", i, test.about)
+		contentType := test.contentType
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler: s.srv,
+			URL:     storeURL(test.path),
+			Method:  "PUT",
+			Header: http.Header{
+				"Content-Type": {contentType},
+			},
+			Body:         strings.NewReader(mustMarshalJSON(test.body)),
+			ExpectStatus: test.expectStatus,
+			ExpectBody:   test.expectBody,
+		})
 	}
 }
 
@@ -320,12 +485,7 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 				expectData.Meta[ep.name] = val
 			}
 		}
-		storeURL := storeURL(charmId + "/meta/any?" + strings.Join(flags, "&"))
-		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL,
-			ExpectBody: expectData,
-		})
+		s.assertGet(c, charmId+"/meta/any?"+strings.Join(flags, "&"), expectData)
 	}
 }
 
@@ -333,21 +493,15 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 // dummy charm that has actions included.
 func (s *APISuite) TestMetaCharmActions(c *gc.C) {
 	url, dummy := s.addCharm(c, "dummy", "cs:precise/dummy-10")
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    s.srv,
-		URL:        storeURL("precise/dummy-10/meta/charm-actions"),
-		ExpectBody: dummy.Actions(),
-	})
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler: s.srv,
-		URL:     storeURL("precise/dummy-10/meta/any?include=charm-actions"),
-		ExpectBody: params.MetaAnyResponse{
+	s.assertGet(c, "precise/dummy-10/meta/charm-actions", dummy.Actions())
+	s.assertGet(c, "precise/dummy-10/meta/any?include=charm-actions",
+		params.MetaAnyResponse{
 			Id: url,
 			Meta: map[string]interface{}{
 				"charm-actions": dummy.Actions(),
 			},
 		},
-	})
+	)
 }
 
 func (s *APISuite) TestBulkMeta(c *gc.C) {
@@ -357,14 +511,13 @@ func (s *APISuite) TestBulkMeta(c *gc.C) {
 
 	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	_, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler: s.srv,
-		URL:     storeURL("meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10"),
-		ExpectBody: map[string]*charm.Meta{
+	s.assertGet(c,
+		"meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10",
+		map[string]*charm.Meta{
 			"precise/wordpress-23": wordpress.Meta(),
 			"precise/mysql-10":     mysql.Meta(),
 		},
-	})
+	)
 }
 
 func (s *APISuite) TestBulkMetaAny(c *gc.C) {
@@ -374,10 +527,9 @@ func (s *APISuite) TestBulkMetaAny(c *gc.C) {
 
 	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	mysqlURL, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler: s.srv,
-		URL:     storeURL("meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10"),
-		ExpectBody: map[string]params.MetaAnyResponse{
+	s.assertGet(c,
+		"meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10",
+		map[string]params.MetaAnyResponse{
 			"precise/wordpress-23": {
 				Id: wordpressURL,
 				Meta: map[string]interface{}{
@@ -393,7 +545,7 @@ func (s *APISuite) TestBulkMetaAny(c *gc.C) {
 				},
 			},
 		},
-	})
+	)
 }
 
 func (s *APISuite) TestIdsAreResolved(c *gc.C) {
@@ -402,11 +554,7 @@ func (s *APISuite) TestIdsAreResolved(c *gc.C) {
 	// defined, and the ResolveURL tests, this should
 	// be sufficient to "join the dots".
 	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    s.srv,
-		URL:        storeURL("wordpress/meta/charm-metadata"),
-		ExpectBody: wordpress.Meta(),
-	})
+	s.assertGet(c, "wordpress/meta/charm-metadata", wordpress.Meta())
 }
 
 func (s *APISuite) TestMetaCharmNotFound(c *gc.C) {
@@ -693,14 +841,8 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 		checkCounterSum(c, s.store, key, false, test.downloads)
 
 		// Ensure the meta/stats response reports the correct downloads count.
-		statsURL := storeURL(test.url + "/meta/stats")
-		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:      s.srv,
-			URL:          statsURL,
-			ExpectStatus: http.StatusOK,
-			ExpectBody: params.StatsResponse{
-				ArchiveDownloadCount: test.downloads,
-			},
+		s.assertGet(c, test.url+"/meta/stats", params.StatsResponse{
+			ArchiveDownloadCount: test.downloads,
 		})
 	}
 }
@@ -782,6 +924,38 @@ func (s *APISuite) addBundle(c *gc.C, bundleName string, curl string) (*charm.Re
 	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
 	return url, bundle
+}
+
+func (s *APISuite) assertPut(c *gc.C, url string, val interface{}) {
+	body, err := json.Marshal(val)
+	c.Assert(err, gc.IsNil)
+	rec := storetesting.DoRequest(c, storetesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL(url),
+		Method:  "PUT",
+		Header: http.Header{
+			"Content-Type": {"application/json"},
+		},
+		Body: bytes.NewReader(body),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %s", rec.Body.String()))
+	c.Assert(rec.Body.String(), gc.HasLen, 0)
+}
+
+func (s *APISuite) assertGet(c *gc.C, url string, expectVal interface{}) {
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    s.srv,
+		URL:        storeURL(url),
+		ExpectBody: expectVal,
+	})
+}
+
+func mustMarshalJSON(val interface{}) string {
+	data, err := json.Marshal(val)
+	if err != nil {
+		panic(fmt.Errorf("cannot marshal %#v: %v", val, err))
+	}
+	return string(data)
 }
 
 func mustParseReference(url string) *charm.Reference {

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -324,6 +325,7 @@ func verificationError(err error) error {
 	for i, err := range verr.Errors {
 		messages[i] = err.Error()
 	}
+	sort.Strings(messages)
 	encodedMessages, err := json.Marshal(messages)
 	if err != nil {
 		// This should never happen.

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -134,6 +134,7 @@ func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 			return errgo.Notef(err, "cannot retrieve bundle charms")
 		}
 		if err := bundleData.VerifyWithCharms(verifyConstraints, charms); err != nil {
+			// TODO frankban: use multiError (defined in internal/router).
 			return errgo.Notef(verificationError(err), "bundle verification failed")
 		}
 		if err := h.store.AddBundle(id, b, name, hash, req.ContentLength); err != nil {

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -232,7 +232,7 @@ func (h *handler) findBlobName(id *charm.Reference) (string, error) {
 		Select(bson.D{{"blobname", 1}}).
 		One(&entity); err != nil {
 		if err == mgo.ErrNotFound {
-			return "", params.ErrNotFound
+			return "", errgo.WithCausef(nil, params.ErrNotFound, "")
 		}
 		return "", errgo.Notef(err, "cannot get %s", id)
 	}

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -348,9 +348,9 @@ func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
 	expectErr := `bundle verification failed: [` +
-		`"service \"wordpress\" refers to non-existent charm \"wordpress\"",` +
+		`"relation [\"foo:db\" \"mysql:server\"] refers to service \"foo\" not defined in this bundle",` +
 		`"service \"mysql\" refers to non-existent charm \"mysql\"",` +
-		`"relation [\"foo:db\" \"mysql:server\"] refers to service \"foo\" not defined in this bundle"]`
+		`"service \"wordpress\" refers to non-existent charm \"wordpress\""]`
 	s.assertCannotUpload(c, "bundle/wordpress", f, expectErr)
 }
 

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -188,14 +188,14 @@ func (h *handler) metaBundlesContaining(entity *mongodoc.Entity, id *charm.Refer
 	}
 
 	// Prepare and return the response.
-	response := make([]params.MetaAnyResponse, 0, len(entities))
+	response := make([]*params.MetaAnyResponse, 0, len(entities))
 	includes := flags["include"]
 	for _, e := range entities {
 		meta, err := h.GetMetadata(e.URL, includes)
 		if err != nil {
 			return nil, errgo.Notef(err, "cannot retrieve bundle metadata")
 		}
-		response = append(response, params.MetaAnyResponse{
+		response = append(response, &params.MetaAnyResponse{
 			Id:   e.URL,
 			Meta: meta,
 		})

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -5,6 +5,7 @@ package v4
 
 import (
 	"net/url"
+	"sort"
 
 	"github.com/juju/errgo"
 	"gopkg.in/juju/charm.v3"
@@ -134,6 +135,7 @@ func (h *handler) getRelatedIfaceResponses(
 			}
 		}
 	}
+	sort.Sort(byId(responses))
 	return responses, nil
 }
 
@@ -187,18 +189,19 @@ func (h *handler) metaBundlesContaining(entity *mongodoc.Entity, id *charm.Refer
 	}
 
 	// Prepare and return the response.
-	response := make([]*params.MetaAnyResponse, 0, len(entities))
+	response := make([]params.MetaAnyResponse, 0, len(entities))
 	includes := flags["include"]
 	for _, e := range entities {
 		meta, err := h.GetMetadata(e.URL, includes)
 		if err != nil {
 			return nil, errgo.Notef(err, "cannot retrieve bundle metadata")
 		}
-		response = append(response, &params.MetaAnyResponse{
+		response = append(response, params.MetaAnyResponse{
 			Id:   e.URL,
 			Meta: meta,
 		})
 	}
+	sort.Sort(byId(response))
 	return response, nil
 }
 
@@ -212,4 +215,29 @@ func filterEntities(entities []mongodoc.Entity, predicate func(*mongodoc.Entity)
 		}
 	}
 	return results
+}
+
+// byId implements sort.Interface for []params.MetaAnyResponse based on the Id
+// field. For the same base charm, the most recent revisions come first.
+type byId []params.MetaAnyResponse
+
+func (s byId) Len() int           { return len(s) }
+func (s byId) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s byId) Less(i, j int) bool { return referenceLess(s[i].Id, s[j].Id) }
+
+// referenceLess reports whether ref1 should sort before ref2.
+// Alphabetical order of the reference string representation
+// (without the revision) is considered. If ref1 and ref2 have the same base
+// string representation, the most recent revision comes first.
+// This function can be used when implementing sort.Interface in data
+// structures requiring reference sorting.
+func referenceLess(ref1, ref2 *charm.Reference) bool {
+	base1, base2 := *ref1, *ref2
+	base1.Revision = -1
+	base2.Revision = -1
+	str1, str2 := base1.String(), base2.String()
+	if str1 != str2 {
+		return str1 < str2
+	}
+	return ref1.Revision > ref2.Revision
 }

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -126,9 +126,9 @@ var metaCharmRelatedTests = []struct {
 		},
 		Requires: map[string][]params.MetaAnyResponse{
 			"http": []params.MetaAnyResponse{{
-				Id: mustParseReference("trusty/haproxy-47"),
-			}, {
 				Id: mustParseReference("precise/haproxy-48"),
+			}, {
+				Id: mustParseReference("trusty/haproxy-47"),
 			}},
 		},
 	},
@@ -230,11 +230,102 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"memcache": []params.MetaAnyResponse{{
-				Id: mustParseReference("utopic/memcached-1"),
+				Id: mustParseReference("utopic/memcached-3"),
 			}, {
 				Id: mustParseReference("utopic/memcached-2"),
 			}, {
-				Id: mustParseReference("utopic/memcached-3"),
+				Id: mustParseReference("utopic/memcached-1"),
+			}},
+		},
+	},
+}, {
+	about: "reference ordering",
+	charms: map[string]charm.Charm{
+		"trusty/wordpress-0": &relationTestingCharm{
+			requires: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "requirer",
+					Interface: "memcache",
+				},
+				"nfs": {
+					Name:      "nfs",
+					Role:      "requirer",
+					Interface: "mount",
+				},
+			},
+		},
+		"utopic/memcached-1": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "provider",
+					Interface: "memcache",
+				},
+			},
+		},
+		"utopic/memcached-2": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "provider",
+					Interface: "memcache",
+				},
+			},
+		},
+		"utopic/redis-90": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"cache": {
+					Name:      "cache",
+					Role:      "provider",
+					Interface: "memcache",
+				},
+			},
+		},
+		"trusty/nfs-47": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"nfs": {
+					Name:      "nfs",
+					Role:      "provider",
+					Interface: "mount",
+				},
+			},
+		},
+		"precise/nfs-42": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"nfs": {
+					Name:      "nfs",
+					Role:      "provider",
+					Interface: "mount",
+				},
+			},
+		},
+		"precise/nfs-47": &relationTestingCharm{
+			provides: map[string]charm.Relation{
+				"nfs": {
+					Name:      "nfs",
+					Role:      "provider",
+					Interface: "mount",
+				},
+			},
+		},
+	},
+	id: "trusty/wordpress-0",
+	expectBody: params.RelatedResponse{
+		Provides: map[string][]params.MetaAnyResponse{
+			"memcache": []params.MetaAnyResponse{{
+				Id: mustParseReference("utopic/memcached-2"),
+			}, {
+				Id: mustParseReference("utopic/memcached-1"),
+			}, {
+				Id: mustParseReference("utopic/redis-90"),
+			}},
+			"mount": []params.MetaAnyResponse{{
+				Id: mustParseReference("precise/nfs-47"),
+			}, {
+				Id: mustParseReference("precise/nfs-42"),
+			}, {
+				Id: mustParseReference("trusty/nfs-47"),
 			}},
 		},
 	},
@@ -359,6 +450,12 @@ var metaBundlesContainingBundles = map[string]charm.Bundle{
 			"cs:utopic/mysql-0",
 		},
 	},
+	"bundle/wordpress-simple-1": &relationTestingBundle{
+		urls: []string{
+			"cs:utopic/wordpress-47",
+			"cs:utopic/mysql-1",
+		},
+	},
 	"bundle/wordpress-complex-1": &relationTestingBundle{
 		urls: []string{
 			"cs:utopic/wordpress-42",
@@ -403,11 +500,11 @@ var metaBundlesContainingTests = []struct {
 	id:           "utopic/wordpress-42",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Id: mustParseReference("bundle/useless-0"),
 	}, {
 		Id: mustParseReference("bundle/wordpress-complex-1"),
 	}, {
-		Id: mustParseReference("bundle/useless-0"),
+		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
 	about:        "specific charm present in one bundle",
@@ -446,9 +543,9 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-series=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-simple-0"),
-	}, {
 		Id: mustParseReference("bundle/wordpress-complex-1"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
 	about:        "invalid any series",
@@ -465,9 +562,9 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-revision=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-complex-1"),
-	}, {
 		Id: mustParseReference("bundle/django-generic-42"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-complex-1"),
 	}},
 }, {
 	about:        "invalid any revision",
@@ -484,13 +581,15 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-series=1&any-revision=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-simple-0"),
-	}, {
-		Id: mustParseReference("bundle/wordpress-complex-1"),
-	}, {
 		Id: mustParseReference("bundle/django-generic-42"),
 	}, {
 		Id: mustParseReference("bundle/mediawiki-47"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-complex-1"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-1"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
 	about:        "any series and revision with includes",
@@ -498,10 +597,10 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-series=1&any-revision=1&include=archive-size&include=bundle-metadata",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Id: mustParseReference("bundle/useless-0"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
-			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-0"].Data(),
+			"bundle-metadata": metaBundlesContainingBundles["bundle/useless-0"].Data(),
 		},
 	}, {
 		Id: mustParseReference("bundle/wordpress-complex-1"),
@@ -510,10 +609,16 @@ var metaBundlesContainingTests = []struct {
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-complex-1"].Data(),
 		},
 	}, {
-		Id: mustParseReference("bundle/useless-0"),
+		Id: mustParseReference("bundle/wordpress-simple-1"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
-			"bundle-metadata": metaBundlesContainingBundles["bundle/useless-0"].Data(),
+			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-1"].Data(),
+		},
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Meta: map[string]interface{}{
+			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
+			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-0"].Data(),
 		},
 	}},
 }, {

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -230,11 +230,11 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"memcache": []params.MetaAnyResponse{{
-				Id: mustParseReference("utopic/memcached-3"),
+				Id: mustParseReference("utopic/memcached-1"),
 			}, {
 				Id: mustParseReference("utopic/memcached-2"),
 			}, {
-				Id: mustParseReference("utopic/memcached-1"),
+				Id: mustParseReference("utopic/memcached-3"),
 			}},
 		},
 	},
@@ -314,16 +314,16 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"memcache": []params.MetaAnyResponse{{
-				Id: mustParseReference("utopic/memcached-2"),
-			}, {
 				Id: mustParseReference("utopic/memcached-1"),
+			}, {
+				Id: mustParseReference("utopic/memcached-2"),
 			}, {
 				Id: mustParseReference("utopic/redis-90"),
 			}},
 			"mount": []params.MetaAnyResponse{{
-				Id: mustParseReference("precise/nfs-47"),
-			}, {
 				Id: mustParseReference("precise/nfs-42"),
+			}, {
+				Id: mustParseReference("precise/nfs-47"),
 			}, {
 				Id: mustParseReference("trusty/nfs-47"),
 			}},
@@ -587,9 +587,9 @@ var metaBundlesContainingTests = []struct {
 	}, {
 		Id: mustParseReference("bundle/wordpress-complex-1"),
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-1"),
-	}, {
 		Id: mustParseReference("bundle/wordpress-simple-0"),
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-1"),
 	}},
 }, {
 	about:        "any series and revision with includes",
@@ -609,16 +609,16 @@ var metaBundlesContainingTests = []struct {
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-complex-1"].Data(),
 		},
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-1"),
-		Meta: map[string]interface{}{
-			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
-			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-1"].Data(),
-		},
-	}, {
 		Id: mustParseReference("bundle/wordpress-simple-0"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-0"].Data(),
+		},
+	}, {
+		Id: mustParseReference("bundle/wordpress-simple-1"),
+		Meta: map[string]interface{}{
+			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
+			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-1"].Data(),
 		},
 	}},
 }, {

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -38,7 +38,7 @@ func entityStatsKey(url *charm.Reference, kind string) []string {
 func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	base := strings.TrimPrefix(r.URL.Path, "/")
 	if strings.Index(base, "/") > 0 {
-		return nil, params.ErrNotFound
+		return nil, errgo.WithCausef(nil, params.ErrNotFound, "")
 	}
 	if base == "" {
 		return nil, params.ErrForbidden


### PR DESCRIPTION
We also change a bunch of ErrNotFound returns to use WithCausef
to aid error diagnosis.

We store the extra-info values as raw JSON, so that we're guaranteed
a correct round trip through mongo.

There are a bunch of changes to internal/v4/relations_test.go that
I didn't make and don't expect to see. Weird.
