### PR TITLE
Implement extra-info GET and PUT API endpoints.

### DIFF
--- a/internal/charmstore/stats.go
+++ b/internal/charmstore/stats.go
@@ -63,7 +63,7 @@ func (s *Store) statsKey(db StoreDatabase, key []string, write bool) (string, er
 			err = tokens.Find(bson.D{{"t", key[i]}}).One(&t)
 			if err == mgo.ErrNotFound {
 				if !write {
-					return "", params.ErrNotFound
+					return "", errgo.WithCausef(nil, params.ErrNotFound, "")
 				}
 				t.Id, err = tokens.Count()
 				if err != nil {

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -33,7 +33,7 @@ type Entity struct {
 
 	// ExtraInfo holds arbitrary extra metadata associated with
 	// the entity. The byte slices hold JSON-encoded data.
-	ExtraInfo map[string][]byte
+	ExtraInfo map[string][]byte `bson:",omitempty"`
 
 	// TODO(rog) verify that all these types marshal to the expected
 	// JSON form.

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -31,6 +31,10 @@ type Entity struct {
 
 	UploadTime time.Time
 
+	// ExtraInfo holds arbitrary extra metadata associated with
+	// the entity. The byte slices hold JSON-encoded data.
+	ExtraInfo map[string][]byte
+
 	// TODO(rog) verify that all these types marshal to the expected
 	// JSON form.
 	CharmMeta    *charm.Meta

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -203,7 +203,7 @@ func (r *Router) serveIds(w http.ResponseWriter, req *http.Request) error {
 		return errgo.Mask(err, errgo.Any)
 	}
 	if key != "meta/" && key != "meta" {
-		return errgo.WithCausef(nil, params.ErrNotFound, "")
+		return errgo.WithCausef(nil, params.ErrNotFound, params.ErrNotFound.Error())
 	}
 	req.URL.Path = path
 	return r.serveMeta(url, w, req)
@@ -281,7 +281,7 @@ func (r *Router) serveMetaGet(id *charm.Reference, req *http.Request) (interface
 		}
 		return results[0], nil
 	}
-	return nil, errgo.WithCausef(nil, params.ErrNotFound, "")
+	return nil, errgo.WithCausef(nil, params.ErrNotFound, "unknown metadata %q", key)
 }
 
 const jsonContentType = "application/json"

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -183,7 +183,7 @@ func (r *Router) serveIds(w http.ResponseWriter, req *http.Request) error {
 	}
 	key, path := handlerKey(path)
 	if key == "" {
-		return params.ErrNotFound
+		return errgo.WithCausef(nil, params.ErrNotFound, "")
 	}
 	handler := r.handlers.Id[key]
 	if handler == nil || idHandlerNeedsResolveURL(req) {
@@ -203,7 +203,7 @@ func (r *Router) serveIds(w http.ResponseWriter, req *http.Request) error {
 		return errgo.Mask(err, errgo.Any)
 	}
 	if key != "meta/" && key != "meta" {
-		return params.ErrNotFound
+		return errgo.WithCausef(nil, params.ErrNotFound, "")
 	}
 	req.URL.Path = path
 	return r.serveMeta(url, w, req)
@@ -281,7 +281,7 @@ func (r *Router) serveMetaGet(id *charm.Reference, req *http.Request) (interface
 		}
 		return results[0], nil
 	}
-	return nil, params.ErrNotFound
+	return nil, errgo.WithCausef(nil, params.ErrNotFound, "")
 }
 
 const jsonContentType = "application/json"
@@ -343,7 +343,7 @@ func (r *Router) serveMetaPutBody(id *charm.Reference, req *http.Request, body *
 		}
 		return nil
 	}
-	return params.ErrNotFound
+	return errgo.WithCausef(nil, params.ErrNotFound, "")
 }
 
 // isNull reports whether the given value will encode to

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -314,7 +314,7 @@ var routerGetTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: "not found",
+		Message: `unknown metadata "foo"`,
 	},
 }, {
 	about: "meta handler with nil data",
@@ -1602,7 +1602,7 @@ func (s *RouterSuite) TestServeMux(c *gc.C) {
 		URL:          "/foo",
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
-			Message: "not found",
+			Message: `no handler for "/foo"`,
 			Code:    params.ErrNotFound,
 		},
 	})

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -130,7 +130,7 @@ func WriteJSON(w http.ResponseWriter, code int, val interface{}) error {
 // returns a JSON error response.
 func NotFoundHandler() http.Handler {
 	return HandleErrors(func(w http.ResponseWriter, req *http.Request) error {
-		return errgo.WithCausef(nil, params.ErrNotFound, "not found")
+		return errgo.WithCausef(nil, params.ErrNotFound, params.ErrNotFound.Error())
 	})
 }
 

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -130,7 +130,7 @@ func WriteJSON(w http.ResponseWriter, code int, val interface{}) error {
 // returns a JSON error response.
 func NotFoundHandler() http.Handler {
 	return HandleErrors(func(w http.ResponseWriter, req *http.Request) error {
-		return errgo.WithCausef(nil, params.ErrNotFound, "")
+		return errgo.WithCausef(nil, params.ErrNotFound, "not found")
 	})
 }
 

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -130,7 +130,7 @@ func WriteJSON(w http.ResponseWriter, code int, val interface{}) error {
 // returns a JSON error response.
 func NotFoundHandler() http.Handler {
 	return HandleErrors(func(w http.ResponseWriter, req *http.Request) error {
-		return params.ErrNotFound
+		return errgo.WithCausef(nil, params.ErrNotFound, "")
 	})
 }
 
@@ -151,7 +151,7 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	h, pattern := mux.Handler(req)
 	if pattern == "" {
-		WriteError(w, params.ErrNotFound)
+		WriteError(w, errgo.WithCausef(nil, params.ErrNotFound, "no handler for %q", req.URL.Path))
 		return
 	}
 	h.ServeHTTP(w, req)

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -148,7 +148,7 @@ func (h *handler) entityQuery(id *charm.Reference, selector map[string]int) (int
 		Select(selector).
 		One(&val)
 	if err == mgo.ErrNotFound {
-		return nil, errgo.WithCausef(nil, params.ErrNotFound, "")
+		return nil, errgo.WithCausef(nil, params.ErrNotFound, "no matching charm or bundle for %s", id)
 	}
 	if err != nil {
 		return nil, errgo.Mask(err)
@@ -366,7 +366,7 @@ func (h *handler) metaRevisionInfo(id *charm.Reference, path string, flags url.V
 	}
 
 	if len(docs) == 0 {
-		return "", errgo.WithCausef(nil, params.ErrNotFound, "")
+		return "", errgo.WithCausef(nil, params.ErrNotFound, "no matching charm or bundle for %s", id)
 	}
 
 	// Sort in descending order by revision.

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -116,7 +116,7 @@ func (h *handler) entityHandler(f entityHandlerFunc, fields ...string) router.Bu
 	return h.puttableEntityHandler(f, nil, fields...)
 }
 
-func (h *handler) puttableEntityHandler(get entityHandlerFunc, put router.FieldPutFunc, fields ...string) router.BulkIncludeHandler {
+func (h *handler) puttableEntityHandler(get entityHandlerFunc, handlePut router.FieldPutFunc, fields ...string) router.BulkIncludeHandler {
 	handleGet := func(doc interface{}, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 		edoc := doc.(*mongodoc.Entity)
 		val, err := get(edoc, id, path, flags)
@@ -128,7 +128,7 @@ func (h *handler) puttableEntityHandler(get entityHandlerFunc, put router.FieldP
 		Query:     h.entityQuery,
 		Fields:    fields,
 		HandleGet: handleGet,
-		HandlePut: put,
+		HandlePut: handlePut,
 		Update:    h.updateEntity,
 	})
 }

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -7,6 +7,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"reflect"
@@ -216,6 +217,28 @@ var metaEndpoints = []metaEndpoint{{
 	assertCheckData: func(c *gc.C, data interface{}) {
 		c.Assert(data, gc.FitsTypeOf, (*params.StatsResponse)(nil))
 	},
+}, {
+	name: "extra-info",
+	get: func(store *charmstore.Store, url *charm.Reference) (interface{}, error) {
+		return map[string]string{
+			"key": "value " + url.String(),
+		}, nil
+	},
+	checkURL: "cs:precise/wordpress-23",
+	assertCheckData: func(c *gc.C, data interface{}) {
+		c.Assert(data, gc.DeepEquals, map[string]string{
+			"key": "value cs:precise/wordpress-23",
+		})
+	},
+}, {
+	name: "extra-info/key",
+	get: func(store *charmstore.Store, url *charm.Reference) (interface{}, error) {
+		return "value " + url.String(), nil
+	},
+	checkURL: "cs:precise/wordpress-23",
+	assertCheckData: func(c *gc.C, data interface{}) {
+		c.Assert(data, gc.Equals, "value cs:precise/wordpress-23")
+	},
 }}
 
 // TestEndpointGet tries to ensure that the endpoint
@@ -248,6 +271,9 @@ func (s *APISuite) addTestEntities(c *gc.C) []*charm.Reference {
 		} else {
 			s.addCharm(c, url.Name, e)
 		}
+		// associate some extra-info data with the entity
+
+		s.assertPut(c, strings.TrimPrefix(e, "cs:")+"/meta/extra-info/key", "value "+e)
 		urls[i] = url
 	}
 	return urls
@@ -260,14 +286,14 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 		tested := false
 		for _, url := range urls {
 			charmId := strings.TrimPrefix(url.String(), "cs:")
-			storeURL := storeURL(charmId + "/meta/" + ep.name)
+			path := charmId + "/meta/" + ep.name
 			expectData, err := ep.get(s.store, url)
 			c.Assert(err, gc.IsNil)
 			c.Logf("	expected data for %q: %#v", url, expectData)
 			if isNull(expectData) {
 				storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 					Handler:      s.srv,
-					URL:          storeURL,
+					URL:          storeURL(path),
 					ExpectStatus: http.StatusNotFound,
 					ExpectBody: params.Error{
 						Message: params.ErrMetadataNotFound.Error(),
@@ -277,16 +303,155 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 				continue
 			}
 			tested = true
-			storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-				Handler:    s.srv,
-				URL:        storeURL,
-				ExpectBody: expectData,
-			})
-
+			s.assertGet(c, path, expectData)
 		}
 		if !tested {
 			c.Errorf("endpoint %q is null for all endpoints, so is not properly tested", ep.name)
 		}
+	}
+}
+
+func (s *APISuite) TestExtraInfo(c *gc.C) {
+	id := "precise/wordpress-23"
+	s.addCharm(c, "wordpress", "cs:"+id)
+
+	// Add one value and check that it's there.
+	s.assertPut(c, id+"/meta/extra-info/foo", "fooval")
+	s.assertGet(c, id+"/meta/extra-info/foo", "fooval")
+	s.assertGet(c, id+"/meta/extra-info", map[string]string{
+		"foo": "fooval",
+	})
+
+	// Add another value and check that both values are there.
+	s.assertPut(c, id+"/meta/extra-info/bar", "barval")
+	s.assertGet(c, id+"/meta/extra-info/bar", "barval")
+	s.assertGet(c, id+"/meta/extra-info", map[string]string{
+		"foo": "fooval",
+		"bar": "barval",
+	})
+
+	// Overwrite a value and check that it's changed.
+	s.assertPut(c, id+"/meta/extra-info/foo", "fooval2")
+	s.assertGet(c, id+"/meta/extra-info/foo", "fooval2")
+	s.assertGet(c, id+"/meta/extra-info", map[string]string{
+		"foo": "fooval2",
+		"bar": "barval",
+	})
+
+	// Write several values at once.
+	s.assertPut(c, id+"/meta/any", params.MetaAnyResponse{
+		Meta: map[string]interface{}{
+			"extra-info": map[string]string{
+				"foo": "fooval3",
+				"baz": "bazval",
+			},
+			"extra-info/frob": []int{1, 4, 6},
+		},
+	})
+	s.assertGet(c, id+"/meta/extra-info", map[string]interface{}{
+		"foo":  "fooval3",
+		"baz":  "bazval",
+		"bar":  "barval",
+		"frob": []int{1, 4, 6},
+	})
+}
+
+var extraInfoBadPutRequestsTests = []struct {
+	about        string
+	path         string
+	body         interface{}
+	contentType  string
+	expectStatus int
+	expectBody   params.Error
+}{{
+	about:        "key with extra element",
+	path:         "precise/wordpress-23/meta/extra-info/foo/bar",
+	body:         "hello",
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about:        "key with a dot",
+	path:         "precise/wordpress-23/meta/extra-info/foo.bar",
+	body:         "hello",
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about:        "key with a dollar",
+	path:         "precise/wordpress-23/meta/extra-info/foo$bar",
+	body:         "hello",
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about: "multi key with extra element",
+	path:  "precise/wordpress-23/meta/extra-info",
+	body: map[string]string{
+		"foo/bar": "value",
+	},
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about: "multi key with dot",
+	path:  "precise/wordpress-23/meta/extra-info",
+	body: map[string]string{
+		".bar": "value",
+	},
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about: "multi key with dollar",
+	path:  "precise/wordpress-23/meta/extra-info",
+	body: map[string]string{
+		"$bar": "value",
+	},
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: "bad key for extra-info",
+	},
+}, {
+	about:        "multi key with bad map",
+	path:         "precise/wordpress-23/meta/extra-info",
+	body:         "bad",
+	expectStatus: http.StatusInternalServerError,
+	expectBody: params.Error{
+		Message: `cannot unmarshal extra info body: json: cannot unmarshal string into Go value of type map[string]*json.RawMessage`,
+	},
+}}
+
+func (s *APISuite) TestExtraInfoBadPutRequests(c *gc.C) {
+	s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
+	for i, test := range extraInfoBadPutRequestsTests {
+		c.Logf("test %d: %s", i, test.about)
+		contentType := test.contentType
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler: s.srv,
+			URL:     storeURL(test.path),
+			Method:  "PUT",
+			Header: http.Header{
+				"Content-Type": {contentType},
+			},
+			Body:         strings.NewReader(mustMarshalJSON(test.body)),
+			ExpectStatus: test.expectStatus,
+			ExpectBody:   test.expectBody,
+		})
 	}
 }
 
@@ -320,12 +485,7 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 				expectData.Meta[ep.name] = val
 			}
 		}
-		storeURL := storeURL(charmId + "/meta/any?" + strings.Join(flags, "&"))
-		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:    s.srv,
-			URL:        storeURL,
-			ExpectBody: expectData,
-		})
+		s.assertGet(c, charmId+"/meta/any?"+strings.Join(flags, "&"), expectData)
 	}
 }
 
@@ -333,21 +493,15 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 // dummy charm that has actions included.
 func (s *APISuite) TestMetaCharmActions(c *gc.C) {
 	url, dummy := s.addCharm(c, "dummy", "cs:precise/dummy-10")
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    s.srv,
-		URL:        storeURL("precise/dummy-10/meta/charm-actions"),
-		ExpectBody: dummy.Actions(),
-	})
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler: s.srv,
-		URL:     storeURL("precise/dummy-10/meta/any?include=charm-actions"),
-		ExpectBody: params.MetaAnyResponse{
+	s.assertGet(c, "precise/dummy-10/meta/charm-actions", dummy.Actions())
+	s.assertGet(c, "precise/dummy-10/meta/any?include=charm-actions",
+		params.MetaAnyResponse{
 			Id: url,
 			Meta: map[string]interface{}{
 				"charm-actions": dummy.Actions(),
 			},
 		},
-	})
+	)
 }
 
 func (s *APISuite) TestBulkMeta(c *gc.C) {
@@ -357,14 +511,13 @@ func (s *APISuite) TestBulkMeta(c *gc.C) {
 
 	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	_, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler: s.srv,
-		URL:     storeURL("meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10"),
-		ExpectBody: map[string]*charm.Meta{
+	s.assertGet(c,
+		"meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10",
+		map[string]*charm.Meta{
 			"precise/wordpress-23": wordpress.Meta(),
 			"precise/mysql-10":     mysql.Meta(),
 		},
-	})
+	)
 }
 
 func (s *APISuite) TestBulkMetaAny(c *gc.C) {
@@ -374,10 +527,9 @@ func (s *APISuite) TestBulkMetaAny(c *gc.C) {
 
 	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
 	mysqlURL, mysql := s.addCharm(c, "mysql", "cs:precise/mysql-10")
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler: s.srv,
-		URL:     storeURL("meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10"),
-		ExpectBody: map[string]params.MetaAnyResponse{
+	s.assertGet(c,
+		"meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10",
+		map[string]params.MetaAnyResponse{
 			"precise/wordpress-23": {
 				Id: wordpressURL,
 				Meta: map[string]interface{}{
@@ -393,7 +545,7 @@ func (s *APISuite) TestBulkMetaAny(c *gc.C) {
 				},
 			},
 		},
-	})
+	)
 }
 
 func (s *APISuite) TestIdsAreResolved(c *gc.C) {
@@ -402,11 +554,7 @@ func (s *APISuite) TestIdsAreResolved(c *gc.C) {
 	// defined, and the ResolveURL tests, this should
 	// be sufficient to "join the dots".
 	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
-	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-		Handler:    s.srv,
-		URL:        storeURL("wordpress/meta/charm-metadata"),
-		ExpectBody: wordpress.Meta(),
-	})
+	s.assertGet(c, "wordpress/meta/charm-metadata", wordpress.Meta())
 }
 
 func (s *APISuite) TestMetaCharmNotFound(c *gc.C) {
@@ -693,14 +841,8 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 		checkCounterSum(c, s.store, key, false, test.downloads)
 
 		// Ensure the meta/stats response reports the correct downloads count.
-		statsURL := storeURL(test.url + "/meta/stats")
-		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
-			Handler:      s.srv,
-			URL:          statsURL,
-			ExpectStatus: http.StatusOK,
-			ExpectBody: params.StatsResponse{
-				ArchiveDownloadCount: test.downloads,
-			},
+		s.assertGet(c, test.url+"/meta/stats", params.StatsResponse{
+			ArchiveDownloadCount: test.downloads,
 		})
 	}
 }
@@ -782,6 +924,38 @@ func (s *APISuite) addBundle(c *gc.C, bundleName string, curl string) (*charm.Re
 	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
 	return url, bundle
+}
+
+func (s *APISuite) assertPut(c *gc.C, url string, val interface{}) {
+	body, err := json.Marshal(val)
+	c.Assert(err, gc.IsNil)
+	rec := storetesting.DoRequest(c, storetesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL(url),
+		Method:  "PUT",
+		Header: http.Header{
+			"Content-Type": {"application/json"},
+		},
+		Body: bytes.NewReader(body),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %s", rec.Body.String()))
+	c.Assert(rec.Body.String(), gc.HasLen, 0)
+}
+
+func (s *APISuite) assertGet(c *gc.C, url string, expectVal interface{}) {
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:    s.srv,
+		URL:        storeURL(url),
+		ExpectBody: expectVal,
+	})
+}
+
+func mustMarshalJSON(val interface{}) string {
+	data, err := json.Marshal(val)
+	if err != nil {
+		panic(fmt.Errorf("cannot marshal %#v: %v", val, err))
+	}
+	return string(data)
 }
 
 func mustParseReference(url string) *charm.Reference {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -271,9 +271,9 @@ func (s *APISuite) addTestEntities(c *gc.C) []*charm.Reference {
 		} else {
 			s.addCharm(c, url.Name, e)
 		}
-		// associate some extra-info data with the entity
-
-		s.assertPut(c, strings.TrimPrefix(e, "cs:")+"/meta/extra-info/key", "value "+e)
+		// Associate some extra-info data with the entity.
+		key := strings.TrimPrefix(e, "cs:") + "/meta/extra-info/key"
+		s.assertPut(c, key, "value "+e)
 		urls[i] = url
 	}
 	return urls
@@ -313,7 +313,7 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 
 func (s *APISuite) TestExtraInfo(c *gc.C) {
 	id := "precise/wordpress-23"
-	s.addCharm(c, "wordpress", "cs:"+id)
+	s.addCharm(c, "wordpress", id)
 
 	// Add one value and check that it's there.
 	s.assertPut(c, id+"/meta/extra-info/foo", "fooval")
@@ -561,7 +561,7 @@ func (s *APISuite) TestMetaCharmNotFound(c *gc.C) {
 	for i, ep := range metaEndpoints {
 		c.Logf("test %d: %s", i, ep.name)
 		expected := params.Error{
-			Message: params.ErrNotFound.Error(),
+			Message: "no matching charm or bundle for cs:precise/wordpress-23",
 			Code:    params.ErrNotFound,
 		}
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
@@ -746,7 +746,7 @@ var serveMetaRevisionInfoTests = []struct {
 }, {
 	about: "no entities found",
 	url:   "precise/no-such-33",
-	err:   "not found",
+	err:   "no matching charm or bundle for cs:precise/no-such-33",
 }}
 
 func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -232,7 +232,7 @@ func (h *handler) findBlobName(id *charm.Reference) (string, error) {
 		Select(bson.D{{"blobname", 1}}).
 		One(&entity); err != nil {
 		if err == mgo.ErrNotFound {
-			return "", params.ErrNotFound
+			return "", errgo.WithCausef(nil, params.ErrNotFound, "")
 		}
 		return "", errgo.Notef(err, "cannot get %s", id)
 	}

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -232,7 +232,7 @@ func (h *handler) findBlobName(id *charm.Reference) (string, error) {
 		Select(bson.D{{"blobname", 1}}).
 		One(&entity); err != nil {
 		if err == mgo.ErrNotFound {
-			return "", errgo.WithCausef(nil, params.ErrNotFound, "")
+			return "", errgo.WithCausef(nil, params.ErrNotFound, "entity not found")
 		}
 		return "", errgo.Notef(err, "cannot get %s", id)
 	}

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -466,7 +466,7 @@ var archiveFileErrorsTests = []struct {
 	about:         "entity not found",
 	path:          "trusty/no-such-42/archive/icon.svg",
 	expectStatus:  http.StatusNotFound,
-	expectMessage: "not found",
+	expectMessage: "entity not found",
 	expectCode:    params.ErrNotFound,
 }, {
 	about:         "directory listing",
@@ -717,7 +717,7 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 		Password:     serverParams.AuthPassword,
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
-			Message: params.ErrNotFound.Error(),
+			Message: "entity not found",
 			Code:    params.ErrNotFound,
 		},
 	})

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -38,7 +38,7 @@ func entityStatsKey(url *charm.Reference, kind string) []string {
 func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	base := strings.TrimPrefix(r.URL.Path, "/")
 	if strings.Index(base, "/") > 0 {
-		return nil, params.ErrNotFound
+		return nil, errgo.WithCausef(nil, params.ErrNotFound, "")
 	}
 	if base == "" {
 		return nil, params.ErrForbidden

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -38,7 +38,7 @@ func entityStatsKey(url *charm.Reference, kind string) []string {
 func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	base := strings.TrimPrefix(r.URL.Path, "/")
 	if strings.Index(base, "/") > 0 {
-		return nil, errgo.WithCausef(nil, params.ErrNotFound, "")
+		return nil, errgo.WithCausef(nil, params.ErrNotFound, "invalid key")
 	}
 	if base == "" {
 		return nil, params.ErrForbidden

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -71,7 +71,7 @@ func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 	}, {
 		path:    "stats/counter/any/",
 		status:  http.StatusNotFound,
-		message: "not found",
+		message: "invalid key",
 		code:    params.ErrNotFound,
 	}, {
 		path:    "stats/",

--- a/server_test.go
+++ b/server_test.go
@@ -4,6 +4,7 @@
 package charmstore_test
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -86,12 +87,13 @@ func assertServesVersion(c *gc.C, h http.Handler, vers string) {
 }
 
 func assertDoesNotServeVersion(c *gc.C, h http.Handler, vers string) {
+	url := "/" + vers + "/debug"
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler:      h,
-		URL:          "/" + vers + "/debug",
+		URL:          url,
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
-			Message: "not found",
+			Message: fmt.Sprintf("no handler for %q", url),
 			Code:    params.ErrNotFound,
 		},
 	})


### PR DESCRIPTION
This includes both extra-info and extra-info with key.
Also improve how not found errors are handled by the router and the endpoints.

This is mostly based on Roger's work. I just fixed the failing tests and other minors.
