### PR TITLE
implement get/put on meta/color

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -53,6 +53,10 @@ type Entity struct {
 	// not already included.
 	BundleCharms []*charm.Reference
 
+	// IconBackgroundColor is the predominant background color of the icons of
+	// charm or bundle
+	IconBackgroundColor string
+
 	// TODO Add fields denormalized for search purposes
 	// and search ranking field(s).
 }

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -57,10 +57,13 @@ func New(store *charmstore.Store, config charmstore.ServerParams) http.Handler {
 			"charm-config":        h.entityHandler(h.metaCharmConfig, "charmconfig"),
 			"charm-metadata":      h.entityHandler(h.metaCharmMetadata, "charmmeta"),
 			"charm-related":       h.entityHandler(h.metaCharmRelated, "charmprovidedinterfaces", "charmrequiredinterfaces"),
-			"color":               h.entityHandler(h.metaColor, "iconbackgroundcolor"),
-			"manifest":            h.entityHandler(h.metaManifest, "blobname"),
-			"revision-info":       router.SingleIncludeHandler(h.metaRevisionInfo),
-			"stats":               h.entityHandler(h.metaStats),
+			"color": h.puttableEntityHandler(
+				h.metaColor,
+				h.putMetaColor,
+				"iconbackgroundcolor"),
+			"manifest":      h.entityHandler(h.metaManifest, "blobname"),
+			"revision-info": router.SingleIncludeHandler(h.metaRevisionInfo),
+			"stats":         h.entityHandler(h.metaStats),
 			"extra-info": h.puttableEntityHandler(
 				h.metaExtraInfo,
 				h.putMetaExtraInfo,
@@ -321,6 +324,17 @@ func (h *handler) metaCharmConfig(entity *mongodoc.Entity, id *charm.Reference, 
 // http://tinyurl.com/o2t3j4p
 func (h *handler) metaColor(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return &params.ColorResponse{entity.IconBackgroundColor}, nil
+}
+
+// PUT id/meta/color
+func (h *handler) putMetaColor(id *charm.Reference, path string, val *json.RawMessage, updater *router.FieldUpdater) error {
+	var message params.ColorResponse
+	if err := json.Unmarshal(*val, &message); err != nil {
+		return err
+	} else {
+		updater.UpdateField("iconbackgroundcolor", message.RGB)
+	}
+	return nil
 }
 
 // GET id/meta/archive-size

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -55,12 +55,12 @@ func New(store *charmstore.Store, config charmstore.ServerParams) http.Handler {
 			"charm-config":        h.entityHandler(h.metaCharmConfig, "charmconfig"),
 			"charm-metadata":      h.entityHandler(h.metaCharmMetadata, "charmmeta"),
 			"charm-related":       h.entityHandler(h.metaCharmRelated, "charmprovidedinterfaces", "charmrequiredinterfaces"),
+			"color":               h.entityHandler(h.metaColor, "iconbackgroundcolor"),
 			"manifest":            h.entityHandler(h.metaManifest, "blobname"),
 			"revision-info":       router.SingleIncludeHandler(h.metaRevisionInfo),
 			"stats":               h.entityHandler(h.metaStats),
 
 			// endpoints not yet implemented - use SingleIncludeHandler for the time being.
-			"color":       router.SingleIncludeHandler(h.metaColor),
 			"extra-info":  router.SingleIncludeHandler(h.metaExtraInfo),
 			"extra-info/": router.SingleIncludeHandler(h.metaExtraInfoWithKey),
 		},
@@ -297,8 +297,8 @@ func (h *handler) metaCharmConfig(entity *mongodoc.Entity, id *charm.Reference, 
 
 // GET id/meta/color
 // http://tinyurl.com/o2t3j4p
-func (h *handler) metaColor(id *charm.Reference, path string, flags url.Values) (interface{}, error) {
-	return nil, errNotImplemented
+func (h *handler) metaColor(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+	return &params.ColorResponse{entity.IconBackgroundColor}, nil
 }
 
 // GET id/meta/archive-size

--- a/params/params.go
+++ b/params/params.go
@@ -69,3 +69,9 @@ type RelatedResponse struct {
 type RevisionInfoResponse struct {
 	Revisions []*charm.Reference
 }
+
+// ColorResponse holds the result of an
+// id/meta/color GET request. See http://tinyurl.com/o2t3j4p
+type ColorResponse struct {
+	RGB string
+}


### PR DESCRIPTION
This is just the get/put implementation. The UX algorithm to extract a color on archive post is separate. 
