### PR TITLE
internal/v4: export Handler

### DIFF
--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -15,8 +15,9 @@ import (
 	"github.com/juju/charmstore/internal/router"
 )
 
-// NewAPIHandler returns a new API handler that uses the given Store.
-type NewAPIHandler func(*Store, ServerParams) http.Handler
+// NewAPIHandlerFunc is a function that returns a new API handler that uses
+// the given Store.
+type NewAPIHandlerFunc func(*Store, ServerParams) http.Handler
 
 // ServerParams holds configuration for a new internal API server.
 type ServerParams struct {
@@ -28,7 +29,7 @@ type ServerParams struct {
 // versions using db to store that charm store data.
 // The key of the versions map is the version name.
 // The handler configuration is provided to all version handlers.
-func NewServer(db *mgo.Database, config ServerParams, versions map[string]NewAPIHandler) (http.Handler, error) {
+func NewServer(db *mgo.Database, config ServerParams, versions map[string]NewAPIHandlerFunc) (http.Handler, error) {
 	if len(versions) == 0 {
 		return nil, errgo.Newf("charm store server must serve at least one version of the API")
 	}

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -36,7 +36,7 @@ type versionResponse struct {
 
 func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	db := s.Session.DB("foo")
-	serveVersion := func(vers string) NewAPIHandler {
+	serveVersion := func(vers string) NewAPIHandlerFunc {
 		return func(store *Store, config ServerParams) http.Handler {
 			c.Assert(store.DB.Database, gc.Equals, db)
 			return router.HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -48,7 +48,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 		}
 	}
 
-	h, err := NewServer(db, serverParams, map[string]NewAPIHandler{
+	h, err := NewServer(db, serverParams, map[string]NewAPIHandlerFunc{
 		"version1": serveVersion("version1"),
 	})
 	c.Assert(err, gc.IsNil)
@@ -56,7 +56,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	assertDoesNotServeVersion(c, h, "version2")
 	assertDoesNotServeVersion(c, h, "version3")
 
-	h, err = NewServer(db, serverParams, map[string]NewAPIHandler{
+	h, err = NewServer(db, serverParams, map[string]NewAPIHandlerFunc{
 		"version1": serveVersion("version1"),
 		"version2": serveVersion("version2"),
 	})
@@ -65,7 +65,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	assertServesVersion(c, h, "version2")
 	assertDoesNotServeVersion(c, h, "version3")
 
-	h, err = NewServer(db, serverParams, map[string]NewAPIHandler{
+	h, err = NewServer(db, serverParams, map[string]NewAPIHandlerFunc{
 		"version1": serveVersion("version1"),
 		"version2": serveVersion("version2"),
 		"version3": serveVersion("version3"),
@@ -82,7 +82,7 @@ func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
 			return config, nil
 		})
 	}
-	h, err := NewServer(s.Session.DB("foo"), serverParams, map[string]NewAPIHandler{
+	h, err := NewServer(s.Session.DB("foo"), serverParams, map[string]NewAPIHandlerFunc{
 		"version1": serveConfig,
 	})
 	c.Assert(err, gc.IsNil)

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -22,15 +22,15 @@ import (
 	"github.com/juju/charmstore/params"
 )
 
-type handler struct {
+type Handler struct {
 	*router.Router
 	store  *charmstore.Store
 	config charmstore.ServerParams
 }
 
 // New returns a new instance of the v4 API handler.
-func New(store *charmstore.Store, config charmstore.ServerParams) http.Handler {
-	h := &handler{
+func New(store *charmstore.Store, config charmstore.ServerParams) *Handler {
+	h := &Handler{
 		store:  store,
 		config: config,
 	}
@@ -80,7 +80,14 @@ func New(store *charmstore.Store, config charmstore.ServerParams) http.Handler {
 	return h
 }
 
-func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+// NewHTTPHandler returns a new Handler as an http Handler.
+// It is defined for the convenience of callers that require a
+// function with this signature.
+func NewHTTPHandler(store *charmstore.Store, config charmstore.ServerParams) http.Handler {
+	return New(store, config)
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h.Router.ServeHTTP(w, req)
 }
 
@@ -106,19 +113,19 @@ func noMatchingURLError(url *charm.Reference) error {
 	return errgo.WithCausef(nil, params.ErrNotFound, "no matching charm or bundle for %q", url)
 }
 
-func (h *handler) resolveURL(url *charm.Reference) error {
+func (h *Handler) resolveURL(url *charm.Reference) error {
 	return ResolveURL(h.store, url)
 }
 
 type entityHandlerFunc func(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error)
 
-// entityHandler returns a handler that calls f with a *mongodoc.Entity that
+// entityHandler returns a Handler that calls f with a *mongodoc.Entity that
 // contains at least the given fields. It allows only GET requests.
-func (h *handler) entityHandler(f entityHandlerFunc, fields ...string) router.BulkIncludeHandler {
+func (h *Handler) entityHandler(f entityHandlerFunc, fields ...string) router.BulkIncludeHandler {
 	return h.puttableEntityHandler(f, nil, fields...)
 }
 
-func (h *handler) puttableEntityHandler(get entityHandlerFunc, handlePut router.FieldPutFunc, fields ...string) router.BulkIncludeHandler {
+func (h *Handler) puttableEntityHandler(get entityHandlerFunc, handlePut router.FieldPutFunc, fields ...string) router.BulkIncludeHandler {
 	handleGet := func(doc interface{}, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 		edoc := doc.(*mongodoc.Entity)
 		val, err := get(edoc, id, path, flags)
@@ -135,7 +142,7 @@ func (h *handler) puttableEntityHandler(get entityHandlerFunc, handlePut router.
 	})
 }
 
-func (h *handler) updateEntity(id *charm.Reference, fields map[string]interface{}) error {
+func (h *Handler) updateEntity(id *charm.Reference, fields map[string]interface{}) error {
 	err := h.store.DB.Entities().UpdateId(id, bson.D{{"$set", fields}})
 	if err != nil {
 		return errgo.Notef(err, "cannot update %q", id)
@@ -143,7 +150,7 @@ func (h *handler) updateEntity(id *charm.Reference, fields map[string]interface{
 	return nil
 }
 
-func (h *handler) entityQuery(id *charm.Reference, selector map[string]int) (interface{}, error) {
+func (h *Handler) entityQuery(id *charm.Reference, selector map[string]int) (interface{}, error) {
 	var val mongodoc.Entity
 	err := h.store.DB.Entities().
 		Find(bson.D{{"_id", id}}).
@@ -206,19 +213,19 @@ var errNotImplemented = errgo.Newf("method not implemented")
 
 // GET search[?text=text][&autocomplete=1][&filter=value…][&limit=limit][&include=meta]
 // http://tinyurl.com/qzobc69
-func (h *handler) serveSearch(w http.ResponseWriter, req *http.Request) {
+func (h *Handler) serveSearch(w http.ResponseWriter, req *http.Request) {
 	router.WriteError(w, errNotImplemented)
 }
 
 // GET search/interesting[?limit=limit][&include=meta]
 // http://tinyurl.com/ntmdrg8
-func (h *handler) serveSearchInteresting(w http.ResponseWriter, req *http.Request) {
+func (h *Handler) serveSearchInteresting(w http.ResponseWriter, req *http.Request) {
 	router.WriteError(w, errNotImplemented)
 }
 
 // GET /debug
 // http://tinyurl.com/m63xhz8
-func (h *handler) serveDebug(w http.ResponseWriter, req *http.Request) {
+func (h *Handler) serveDebug(w http.ResponseWriter, req *http.Request) {
 	router.WriteError(w, errNotImplemented)
 }
 
@@ -230,13 +237,13 @@ func (h *handler) serveDebug(w http.ResponseWriter, req *http.Request) {
 //
 // PUT id/resources/[~user/]series/name.stream-revision/arch?sha256=hash
 // http://tinyurl.com/k8l8kdg
-func (h *handler) serveResources(charmId *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveResources(charmId *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	return errNotImplemented
 }
 
 // GET id/expand-id
 // https://docs.google.com/a/canonical.com/document/d/1TgRA7jW_mmXoKH3JiwBbtPvQu7WiM6XMrz1wSrhTMXw/edit#bookmark=id.4xdnvxphb2si
-func (h *handler) serveExpandId(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveExpandId(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	// Mutate the given id so that it represents a base URL.
 	id.Revision = -1
 	id.Series = ""
@@ -272,25 +279,25 @@ func badRequestf(underlying error, f string, a ...interface{}) error {
 
 // GET id/meta/charm-metadata
 // http://tinyurl.com/poeoulw
-func (h *handler) metaCharmMetadata(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaCharmMetadata(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return entity.CharmMeta, nil
 }
 
 // GET id/meta/bundle-metadata
 // http://tinyurl.com/ozshbtb
-func (h *handler) metaBundleMetadata(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaBundleMetadata(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return entity.BundleData, nil
 }
 
 // GET id/meta/bundle-unit-count
 // http://tinyurl.com/mkvowub
-func (h *handler) metaBundleUnitCount(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaBundleUnitCount(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return bundleCount(entity.BundleUnitCount), nil
 }
 
 // GET id/meta/bundle-machine-count
 // http://tinyurl.com/qfuubrv
-func (h *handler) metaBundleMachineCount(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaBundleMachineCount(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return bundleCount(entity.BundleMachineCount), nil
 }
 
@@ -305,7 +312,7 @@ func bundleCount(x *int) interface{} {
 
 // GET id/meta/manifest
 // http://tinyurl.com/p3xdcto
-func (h *handler) metaManifest(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaManifest(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	r, size, err := h.store.BlobStore.Open(entity.BlobName)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot open archive data for %s", id)
@@ -332,25 +339,25 @@ func (h *handler) metaManifest(entity *mongodoc.Entity, id *charm.Reference, pat
 
 // GET id/meta/charm-actions
 // http://tinyurl.com/kfd2h34
-func (h *handler) metaCharmActions(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaCharmActions(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return entity.CharmActions, nil
 }
 
 // GET id/meta/charm-config
 // http://tinyurl.com/oxxyujx
-func (h *handler) metaCharmConfig(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaCharmConfig(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return entity.CharmConfig, nil
 }
 
 // GET id/meta/color
 // http://tinyurl.com/o2t3j4p
-func (h *handler) metaColor(id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaColor(id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return nil, errNotImplemented
 }
 
 // GET id/meta/archive-size
 // http://tinyurl.com/m8b9geq
-func (h *handler) metaArchiveSize(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaArchiveSize(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return &params.ArchiveSizeResponse{
 		Size: entity.Size,
 	}, nil
@@ -358,7 +365,7 @@ func (h *handler) metaArchiveSize(entity *mongodoc.Entity, id *charm.Reference, 
 
 // GET id/meta/stats/
 // http://tinyurl.com/lvyp2l5
-func (h *handler) metaStats(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaStats(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	req := charmstore.CounterRequest{
 		Key: entityStatsKey(id, params.StatsArchiveDownload),
 	}
@@ -376,7 +383,7 @@ func (h *handler) metaStats(entity *mongodoc.Entity, id *charm.Reference, path s
 
 // GET id/meta/revision-info
 // http://tinyurl.com/q6xos7f
-func (h *handler) metaRevisionInfo(id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaRevisionInfo(id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	baseURL := *id
 	baseURL.Revision = -1
 	baseURL.Series = ""
@@ -420,7 +427,7 @@ func (s entitiesByRevision) Less(i, j int) bool { return s[i].URL.Revision > s[j
 
 // GET id/meta/extra-info
 // http://tinyurl.com/keos7wd
-func (h *handler) metaExtraInfo(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaExtraInfo(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	// The extra-info is stored in mongo as simple byte
 	// slices, so convert the values to json.RawMessages
 	// so that the client will see the original JSON.
@@ -434,7 +441,7 @@ func (h *handler) metaExtraInfo(entity *mongodoc.Entity, id *charm.Reference, pa
 
 // GET id/meta/extra-info/key
 // http://tinyurl.com/polrbn7
-func (h *handler) metaExtraInfoWithKey(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaExtraInfoWithKey(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	path = strings.TrimPrefix(path, "/")
 	var data json.RawMessage = entity.ExtraInfo[path]
 	if len(data) == 0 {
@@ -443,7 +450,7 @@ func (h *handler) metaExtraInfoWithKey(entity *mongodoc.Entity, id *charm.Refere
 	return &data, nil
 }
 
-func (h *handler) putMetaExtraInfo(id *charm.Reference, path string, val *json.RawMessage, updater *router.FieldUpdater) error {
+func (h *Handler) putMetaExtraInfo(id *charm.Reference, path string, val *json.RawMessage, updater *router.FieldUpdater) error {
 	var fields map[string]*json.RawMessage
 	if err := json.Unmarshal(*val, &fields); err != nil {
 		return errgo.Notef(err, "cannot unmarshal extra info body")
@@ -460,7 +467,7 @@ func (h *handler) putMetaExtraInfo(id *charm.Reference, path string, val *json.R
 	return nil
 }
 
-func (h *handler) putMetaExtraInfoWithKey(id *charm.Reference, path string, val *json.RawMessage, updater *router.FieldUpdater) error {
+func (h *Handler) putMetaExtraInfoWithKey(id *charm.Reference, path string, val *json.RawMessage, updater *router.FieldUpdater) error {
 	key := strings.TrimPrefix(path, "/")
 	if err := checkExtraInfoKey(key); err != nil {
 		return err
@@ -478,7 +485,7 @@ func checkExtraInfoKey(key string) error {
 
 // GET id/meta/archive-upload-time
 // http://tinyurl.com/nmujuqk
-func (h *handler) metaArchiveUploadTime(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaArchiveUploadTime(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	return &params.ArchiveUploadTimeResponse{
 		UploadTime: entity.UploadTime.UTC(),
 	}, nil

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -80,10 +80,10 @@ func New(store *charmstore.Store, config charmstore.ServerParams) *Handler {
 	return h
 }
 
-// NewHTTPHandler returns a new Handler as an http Handler.
+// NewAPIHandler returns a new Handler as an http Handler.
 // It is defined for the convenience of callers that require a
-// function with this signature.
-func NewHTTPHandler(store *charmstore.Store, config charmstore.ServerParams) http.Handler {
+// charmstore.NewAPIHandlerFunc.
+func NewAPIHandler(store *charmstore.Store, config charmstore.ServerParams) http.Handler {
 	return New(store, config)
 }
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -52,7 +52,7 @@ func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (h
 	db := session.DB("charmstore")
 	store, err := charmstore.NewStore(db)
 	c.Assert(err, gc.IsNil)
-	srv, err := charmstore.NewServer(db, config, map[string]charmstore.NewAPIHandler{"v4": v4.New})
+	srv, err := charmstore.NewServer(db, config, map[string]charmstore.NewAPIHandler{"v4": v4.NewHTTPHandler})
 	c.Assert(err, gc.IsNil)
 	return srv, store
 }
@@ -298,7 +298,7 @@ func (s *APISuite) addTestEntities(c *gc.C) []*charm.Reference {
 			s.addCharm(c, url.Name, e)
 		}
 		// Associate some extra-info data with the entity.
-		key := strings.TrimPrefix(e, "cs:") + "/meta/extra-info/key"
+		key := url.Path() + "/meta/extra-info/key"
 		s.assertPut(c, key, "value "+e)
 		urls[i] = url
 	}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -52,7 +52,7 @@ func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (h
 	db := session.DB("charmstore")
 	store, err := charmstore.NewStore(db)
 	c.Assert(err, gc.IsNil)
-	srv, err := charmstore.NewServer(db, config, map[string]charmstore.NewAPIHandler{"v4": v4.NewHTTPHandler})
+	srv, err := charmstore.NewServer(db, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
 	c.Assert(err, gc.IsNil)
 	return srv, store
 }

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -34,7 +34,7 @@ import (
 
 // DELETE id/archive
 // http://tinyurl.com/ojmlwos
-func (h *handler) serveArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	switch req.Method {
 	default:
 		// TODO(rog) params.ErrMethodNotAllowed
@@ -62,7 +62,7 @@ func (h *handler) serveArchive(id *charm.Reference, w http.ResponseWriter, req *
 	return nil
 }
 
-func (h *handler) serveDeleteArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveDeleteArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	// Retrieve the entity blob name from the database.
 	blobName, err := h.findBlobName(id)
 	if err != nil {
@@ -81,7 +81,7 @@ func (h *handler) serveDeleteArchive(id *charm.Reference, w http.ResponseWriter,
 	return nil
 }
 
-func (h *handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) (err error) {
+func (h *Handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) (err error) {
 	defer func() {
 		// Upload stats don't include revision: it is assumed that each
 		// entity revision is only uploaded once.
@@ -173,7 +173,7 @@ func verifyConstraints(s string) error {
 
 // GET id/archive/…
 // http://tinyurl.com/lampm24
-func (h *handler) serveArchiveFile(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveArchiveFile(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	r, size, err := h.openBlob(id)
 	if err != nil {
 		return err
@@ -224,7 +224,7 @@ func (r *readerAtSeeker) ReadAt(buf []byte, p int64) (int, error) {
 	return r.r.Read(buf)
 }
 
-func (h *handler) nextRevisionForId(id *charm.Reference) (int, error) {
+func (h *Handler) nextRevisionForId(id *charm.Reference) (int, error) {
 	id1 := *id
 	id1.Revision = -1
 	err := ResolveURL(h.store, &id1)
@@ -237,7 +237,7 @@ func (h *handler) nextRevisionForId(id *charm.Reference) (int, error) {
 	return 0, nil
 }
 
-func (h *handler) findBlobName(id *charm.Reference) (string, error) {
+func (h *Handler) findBlobName(id *charm.Reference) (string, error) {
 	var entity mongodoc.Entity
 	if err := h.store.DB.Entities().
 		FindId(id).
@@ -251,7 +251,7 @@ func (h *handler) findBlobName(id *charm.Reference) (string, error) {
 	return entity.BlobName, nil
 }
 
-func (h *handler) openBlob(id *charm.Reference) (blobstore.ReadSeekCloser, int64, error) {
+func (h *Handler) openBlob(id *charm.Reference) (blobstore.ReadSeekCloser, int64, error) {
 	blobName, err := h.findBlobName(id)
 	if err != nil {
 		return nil, 0, err
@@ -263,7 +263,7 @@ func (h *handler) openBlob(id *charm.Reference) (blobstore.ReadSeekCloser, int64
 	return r, size, nil
 }
 
-func (h *handler) bundleCharms(ids []string) (map[string]charm.Charm, error) {
+func (h *Handler) bundleCharms(ids []string) (map[string]charm.Charm, error) {
 	numIds := len(ids)
 	urls := make([]*charm.Reference, 0, numIds)
 	idKeys := make([]string, 0, numIds)

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -18,7 +18,7 @@ const basicRealm = "CharmStore4"
 // authenticate checks that the request's headers HTTP basic auth credentials
 // match the superuser credentials stored in the API handler.
 // A params.ErrUnauthorized is returned if the authentication fails.
-func (h *handler) authenticate(w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) authenticate(w http.ResponseWriter, req *http.Request) error {
 	user, passwd, err := parseCredentials(req)
 	if err != nil {
 		return unauthorized(w, "authentication failed", err)

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -10,5 +10,5 @@ import (
 )
 
 func BundleCharms(h http.Handler) func([]string) (map[string]charm.Charm, error) {
-	return h.(*handler).bundleCharms
+	return h.(*Handler).bundleCharms
 }

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -16,7 +16,7 @@ import (
 
 // GET id/meta/charm-related[?include=meta[&include=meta…]]
 // http://tinyurl.com/q7vdmzl
-func (h *handler) metaCharmRelated(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaCharmRelated(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	if id.Series == "bundle" {
 		return nil, nil
 	}
@@ -92,7 +92,7 @@ type entityRelatedInterfacesGetter func(mongodoc.Entity) []string
 //           {Id: "cs:utopic/memcached-0", Meta: ...},
 //       },
 //   }
-func (h *handler) getRelatedCharmsResponse(
+func (h *Handler) getRelatedCharmsResponse(
 	ifaces []string,
 	entities []mongodoc.Entity,
 	getInterfaces entityRelatedInterfacesGetter,
@@ -110,7 +110,7 @@ func (h *handler) getRelatedCharmsResponse(
 	return results, nil
 }
 
-func (h *handler) getRelatedIfaceResponses(
+func (h *Handler) getRelatedIfaceResponses(
 	iface string,
 	entities []mongodoc.Entity,
 	getInterfaces entityRelatedInterfacesGetter,
@@ -139,7 +139,7 @@ func (h *handler) getRelatedIfaceResponses(
 
 // GET id/meta/bundles-containing[?include=meta[&include=meta…]][&any-series=1][&any-revision=1]
 // http://tinyurl.com/oqc386r
-func (h *handler) metaBundlesContaining(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+func (h *Handler) metaBundlesContaining(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 	if id.Series == "bundle" {
 		return nil, nil
 	}

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -40,7 +40,7 @@ func entityStatsKey(url *charm.Reference, kind string) []string {
 
 // GET stats/counter/key[:key]...?[by=unit]&start=date][&stop=date][&list=1]
 // http://tinyurl.com/nkdovcf
-func (s *handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+func (s *Handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	base := strings.TrimPrefix(r.URL.Path, "/")
 	if strings.Index(base, "/") > 0 {
 		return nil, errgo.WithCausef(nil, params.ErrNotFound, "invalid key")

--- a/server.go
+++ b/server.go
@@ -19,8 +19,8 @@ const (
 	V4 = "v4"
 )
 
-var versions = map[string]charmstore.NewAPIHandler{
-	V4: v4.NewHTTPHandler,
+var versions = map[string]charmstore.NewAPIHandlerFunc{
+	V4: v4.NewAPIHandler,
 }
 
 // Versions returns all known API version strings in alphabetical order.
@@ -43,7 +43,7 @@ type ServerParams struct {
 // its data in the given database. The handler will serve the specified
 // versions of the API using the given configuration.
 func NewServer(db *mgo.Database, config ServerParams, serveVersions ...string) (http.Handler, error) {
-	newAPIs := make(map[string]charmstore.NewAPIHandler)
+	newAPIs := make(map[string]charmstore.NewAPIHandlerFunc)
 	for _, vers := range serveVersions {
 		newAPI := versions[vers]
 		if newAPI == nil {

--- a/server.go
+++ b/server.go
@@ -20,7 +20,7 @@ const (
 )
 
 var versions = map[string]charmstore.NewAPIHandler{
-	V4: v4.New,
+	V4: v4.NewHTTPHandler,
 }
 
 // Versions returns all known API version strings in alphabetical order.


### PR DESCRIPTION
When implementing the legacy API we want access to parts of the v4 implementation
and this provides that.
