### PR TITLE
internal/legacy: new package

### DIFF
--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -45,5 +45,9 @@ func NewServer(db *mgo.Database, config ServerParams, versions map[string]NewAPI
 }
 
 func handle(mux *router.ServeMux, path string, handler http.Handler) {
-	mux.Handle(path+"/", http.StripPrefix(path, handler))
+	if path != "/" {
+		handler = http.StripPrefix(path, handler)
+		path += "/"
+	}
+	mux.Handle(path, handler)
 }

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -75,7 +75,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	assertServesVersion(c, h, "version2")
 	assertServesVersion(c, h, "version3")
 
-	h, err = NewServer(db, serverParams, map[string]NewAPIHandler{
+	h, err = NewServer(db, serverParams, map[string]NewAPIHandlerFunc{
 		"version1": serveVersion("version1"),
 		"":         serveVersion(""),
 	})

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -74,6 +74,14 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	assertServesVersion(c, h, "version1")
 	assertServesVersion(c, h, "version2")
 	assertServesVersion(c, h, "version3")
+
+	h, err = NewServer(db, serverParams, map[string]NewAPIHandler{
+		"version1": serveVersion("version1"),
+		"":         serveVersion(""),
+	})
+	c.Assert(err, gc.IsNil)
+	assertServesVersion(c, h, "")
+	assertServesVersion(c, h, "version1")
 }
 
 func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
@@ -94,9 +102,13 @@ func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
 }
 
 func assertServesVersion(c *gc.C, h http.Handler, vers string) {
+	path := vers
+	if path != "" {
+		path = "/" + path
+	}
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler: h,
-		URL:     "/" + vers + "/some/path",
+		URL:     path + "/some/path",
 		ExpectBody: versionResponse{
 			Version: vers,
 			Path:    "/some/path",

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -31,10 +31,7 @@ func NewAPIHandler(store *charmstore.Store, config charmstore.ServerParams) http
 }
 
 func (h *Handler) handle(path string, handler http.HandlerFunc) {
-	prefix := path
-	if strings.HasSuffix(prefix, "/") {
-		prefix = prefix[0 : len(prefix)-1]
-	}
+	prefix := strings.TrimSuffix(path, "/")
 	h.mux.Handle(path, http.StripPrefix(prefix, handler))
 }
 

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -1,0 +1,51 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package legacy
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/router"
+	"github.com/juju/charmstore/internal/v4"
+)
+
+type Handler struct {
+	v4    *v4.Handler
+	store *charmstore.Store
+	mux   *http.ServeMux
+}
+
+func NewAPIHandler(store *charmstore.Store, config charmstore.ServerParams) http.Handler {
+	h := &Handler{
+		v4:    v4.New(store, config),
+		store: store,
+		mux:   http.NewServeMux(),
+	}
+	h.handle("/charm-info", h.serveCharmInfo)
+	h.handle("/charm/", h.serveCharm)
+	return h
+}
+
+func (h *Handler) handle(path string, handler http.HandlerFunc) {
+	prefix := path
+	if strings.HasSuffix(prefix, "/") {
+		prefix = prefix[0 : len(prefix)-1]
+	}
+	h.mux.Handle(path, http.StripPrefix(prefix, handler))
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h.mux.ServeHTTP(w, req)
+}
+
+func (h *Handler) serveCharmInfo(w http.ResponseWriter, req *http.Request) {
+	router.WriteError(w, fmt.Errorf("charm-info not implemented"))
+}
+
+func (h *Handler) serveCharm(w http.ResponseWriter, req *http.Request) {
+	router.WriteError(w, fmt.Errorf("charm not implemented"))
+}

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -1,0 +1,54 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package legacy_test
+
+import (
+	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/params"
+	"gopkg.in/mgo.v2"
+	gc "launchpad.net/gocheck"
+
+	"net/http"
+
+	"github.com/juju/charmstore/internal/legacy"
+	"github.com/juju/charmstore/internal/storetesting"
+)
+
+var serverParams = charmstore.ServerParams{
+	AuthUsername: "test-user",
+	AuthPassword: "test-password",
+}
+
+type APISuite struct {
+	storetesting.IsolatedMgoSuite
+	srv   http.Handler
+	store *charmstore.Store
+}
+
+var _ = gc.Suite(&APISuite{})
+
+func (s *APISuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	s.srv, s.store = newServer(c, s.Session, serverParams)
+}
+
+func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (http.Handler, *charmstore.Store) {
+	db := session.DB("charmstore")
+	store, err := charmstore.NewStore(db)
+	c.Assert(err, gc.IsNil)
+	srv, err := charmstore.NewServer(db, config, map[string]charmstore.NewAPIHandlerFunc{"": legacy.NewAPIHandler})
+	c.Assert(err, gc.IsNil)
+	return srv, store
+}
+
+func (s *APISuite) TestCharmInfo(c *gc.C) {
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:      s.srv,
+		URL:          "/charm-info",
+		ExpectStatus: http.StatusInternalServerError,
+		ExpectBody: params.Error{
+			Message: "charm-info not implemented",
+		},
+	})
+}

--- a/internal/legacy/package_test.go
+++ b/internal/legacy/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package legacy_test
+
+import (
+	"testing"
+
+	jujutesting "github.com/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	jujutesting.MgoTestPackage(t, nil)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -143,10 +143,7 @@ func New(handlers *Handlers, resolveURL func(url *charm.Reference) error) *Route
 	mux.Handle("/meta/", http.StripPrefix("/meta", HandleErrors(r.serveBulkMeta)))
 	for path, handler := range r.handlers.Global {
 		path = "/" + path
-		prefix := path
-		if strings.HasSuffix(prefix, "/") {
-			prefix = prefix[0 : len(prefix)-1]
-		}
+		prefix := strings.TrimSuffix(path, "/")
 		mux.Handle(path, http.StripPrefix(prefix, handler))
 	}
 	mux.Handle("/", HandleErrors(r.serveIds))

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/legacy"
 	"github.com/juju/charmstore/internal/v4"
 )
 

--- a/server.go
+++ b/server.go
@@ -16,11 +16,13 @@ import (
 
 // Versions of the API that can be served.
 const (
-	V4 = "v4"
+	V4     = "v4"
+	Legacy = ""
 )
 
 var versions = map[string]charmstore.NewAPIHandlerFunc{
-	V4: v4.NewAPIHandler,
+	V4:     v4.NewAPIHandler,
+	Legacy: legacy.NewAPIHandler,
 }
 
 // Versions returns all known API version strings in alphabetical order.

--- a/server_test.go
+++ b/server_test.go
@@ -55,7 +55,7 @@ type versionResponse struct {
 }
 
 func (s *ServerSuite) TestVersions(c *gc.C) {
-	c.Assert(charmstore.Versions(), gc.DeepEquals, []string{"v4"})
+	c.Assert(charmstore.Versions(), gc.DeepEquals, []string{"", "v4"})
 }
 
 func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {


### PR DESCRIPTION
We add a stub server for the legacy API. It has a version of "" because
the legacy API was not versioned. Currently all endpoints remain
unimplemented.
