### PR TITLE
internal/legacy: implement /charm endpoint

### DIFF
--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -8,29 +8,33 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/juju/errgo"
+	"gopkg.in/juju/charm.v3"
+
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/router"
 	"github.com/juju/charmstore/internal/v4"
+	"github.com/juju/charmstore/params"
 )
 
 type Handler struct {
-	v4    *v4.Handler
+	v4    *router.Handlers
 	store *charmstore.Store
 	mux   *http.ServeMux
 }
 
 func NewAPIHandler(store *charmstore.Store, config charmstore.ServerParams) http.Handler {
 	h := &Handler{
-		v4:    v4.New(store, config),
+		v4:    v4.New(store, config).Handlers(),
 		store: store,
 		mux:   http.NewServeMux(),
 	}
-	h.handle("/charm-info", h.serveCharmInfo)
-	h.handle("/charm/", h.serveCharm)
+	h.handle("/charm-info", http.HandlerFunc(h.serveCharmInfo))
+	h.handle("/charm/", router.HandleErrors(h.serveCharm))
 	return h
 }
 
-func (h *Handler) handle(path string, handler http.HandlerFunc) {
+func (h *Handler) handle(path string, handler http.Handler) {
 	prefix := strings.TrimSuffix(path, "/")
 	h.mux.Handle(path, http.StripPrefix(prefix, handler))
 }
@@ -43,6 +47,17 @@ func (h *Handler) serveCharmInfo(w http.ResponseWriter, req *http.Request) {
 	router.WriteError(w, fmt.Errorf("charm-info not implemented"))
 }
 
-func (h *Handler) serveCharm(w http.ResponseWriter, req *http.Request) {
-	router.WriteError(w, fmt.Errorf("charm not implemented"))
+func (h *Handler) serveCharm(w http.ResponseWriter, req *http.Request) error {
+	if req.Method != "GET" && req.Method != "HEAD" {
+		return params.ErrMethodNotAllowed
+	}
+	url, err := charm.ParseReference(strings.TrimPrefix(req.URL.Path, "/"))
+	if err != nil {
+		return errgo.WithCausef(err, params.ErrNotFound, "")
+	}
+	if err := v4.ResolveURL(h.store, url); err != nil {
+		// Note: preserve error cause from resolveURL.
+		return errgo.Mask(err, errgo.Any)
+	}
+	return h.v4.Id["archive"](url, w, req)
 }

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -4,15 +4,19 @@
 package legacy_test
 
 import (
-	"github.com/juju/charmstore/internal/charmstore"
-	"github.com/juju/charmstore/params"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"gopkg.in/juju/charm.v3"
+	charmtesting "gopkg.in/juju/charm.v3/testing"
 	"gopkg.in/mgo.v2"
 	gc "launchpad.net/gocheck"
 
-	"net/http"
-
+	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/legacy"
 	"github.com/juju/charmstore/internal/storetesting"
+	"github.com/juju/charmstore/params"
 )
 
 var serverParams = charmstore.ServerParams{
@@ -42,6 +46,66 @@ func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (h
 	return srv, store
 }
 
+func (s *APISuite) TestCharmArchive(c *gc.C) {
+	_, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-0")
+	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
+	c.Assert(err, gc.IsNil)
+
+	rec := storetesting.DoRequest(c, storetesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     "/charm/precise/wordpress-0",
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
+	c.Assert(rec.Header().Get("Content-Length"), gc.Equals, fmt.Sprint(len(rec.Body.Bytes())))
+
+	// Test with unresolved URL.
+	rec = storetesting.DoRequest(c, storetesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     "/charm/wordpress",
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
+	c.Assert(rec.Header().Get("Content-Length"), gc.Equals, fmt.Sprint(len(rec.Body.Bytes())))
+
+	// Check that the HTTP range logic is plugged in OK. If this
+	// is working, we assume that the whole thing is working OK,
+	// as net/http is well-tested.
+	rec = storetesting.DoRequest(c, storetesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     "/charm/precise/wordpress-0",
+		Header:  http.Header{"Range": {"bytes=10-100"}},
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusPartialContent, gc.Commentf("body: %q", rec.Body.Bytes()))
+	c.Assert(rec.Body.Bytes(), gc.HasLen, 100-10+1)
+	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes[10:101])
+}
+
+func (s *APISuite) TestPostNotAllowed(c *gc.C) {
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "POST",
+		URL:          "/charm/precise/wordpress",
+		ExpectStatus: http.StatusMethodNotAllowed,
+		ExpectBody: params.Error{
+			Code:    params.ErrMethodNotAllowed,
+			Message: params.ErrMethodNotAllowed.Error(),
+		},
+	})
+}
+
+func (s *APISuite) TestCharmArchiveUnresolvedURL(c *gc.C) {
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:      s.srv,
+		URL:          "/charm/wordpress",
+		ExpectStatus: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Code:    params.ErrNotFound,
+			Message: `no matching charm or bundle for "cs:wordpress"`,
+		},
+	})
+}
+
 func (s *APISuite) TestCharmInfo(c *gc.C) {
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler:      s.srv,
@@ -51,4 +115,42 @@ func (s *APISuite) TestCharmInfo(c *gc.C) {
 			Message: "charm-info not implemented",
 		},
 	})
+}
+
+var serverStatusTests = []struct {
+	path string
+	code int
+}{
+	{"/charm-info/any", 404},
+	{"/charm/bad-url", 404},
+	{"/charm/bad-series/wordpress", 404},
+}
+
+func (s *APISuite) TestServerStatus(c *gc.C) {
+	// TODO(rog) add tests from old TestServerStatus tests
+	// when we implement charm-info.
+	for i, test := range serverStatusTests {
+		c.Logf("test %d: %s", i, test.path)
+		resp := storetesting.DoRequest(c, storetesting.DoRequestParams{
+			Handler: s.srv,
+			URL:     test.path,
+		})
+		c.Assert(resp.Code, gc.Equals, test.code, gc.Commentf("body: %s", resp.Body))
+	}
+}
+
+func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.Reference, *charm.CharmArchive) {
+	url := mustParseReference(curl)
+	wordpress := charmtesting.Charms.CharmArchive(c.MkDir(), charmName)
+	err := s.store.AddCharmWithArchive(url, wordpress)
+	c.Assert(err, gc.IsNil)
+	return url, wordpress
+}
+
+func mustParseReference(url string) *charm.Reference {
+	ref, err := charm.ParseReference(url)
+	if err != nil {
+		panic(err)
+	}
+	return ref
 }


### PR DESCRIPTION
We use some of the tests from the old server.
