### PR TITLE
internal/legacy: implement charm-info endpoint

### DIFF
--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -4,14 +4,20 @@
 package legacy
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"io"
+	"log"
 	"net/http"
 	"strings"
 
 	"github.com/juju/errgo"
 	"gopkg.in/juju/charm.v3"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/mongodoc"
 	"github.com/juju/charmstore/internal/router"
 	"github.com/juju/charmstore/internal/v4"
 	"github.com/juju/charmstore/params"
@@ -29,7 +35,7 @@ func NewAPIHandler(store *charmstore.Store, config charmstore.ServerParams) http
 		store: store,
 		mux:   http.NewServeMux(),
 	}
-	h.handle("/charm-info", http.HandlerFunc(h.serveCharmInfo))
+	h.handle("/charm-info", router.HandleJSON(h.serveCharmInfo))
 	h.handle("/charm/", router.HandleErrors(h.serveCharm))
 	return h
 }
@@ -40,24 +46,98 @@ func (h *Handler) handle(path string, handler http.Handler) {
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	req.ParseForm()
 	h.mux.ServeHTTP(w, req)
-}
-
-func (h *Handler) serveCharmInfo(w http.ResponseWriter, req *http.Request) {
-	router.WriteError(w, fmt.Errorf("charm-info not implemented"))
 }
 
 func (h *Handler) serveCharm(w http.ResponseWriter, req *http.Request) error {
 	if req.Method != "GET" && req.Method != "HEAD" {
 		return params.ErrMethodNotAllowed
 	}
-	url, err := charm.ParseReference(strings.TrimPrefix(req.URL.Path, "/"))
+	url, err := h.resolveURLStr(strings.TrimPrefix(req.URL.Path, "/"))
 	if err != nil {
-		return errgo.WithCausef(err, params.ErrNotFound, "")
-	}
-	if err := v4.ResolveURL(h.store, url); err != nil {
-		// Note: preserve error cause from resolveURL.
-		return errgo.Mask(err, errgo.Any)
+		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
 	return h.v4.Id["archive"](url, w, req)
+}
+
+func (h *Handler) resolveURLStr(urlStr string) (*charm.Reference, error) {
+	curl, err := charm.ParseReference(urlStr)
+	if err != nil {
+		return nil, errgo.WithCausef(err, params.ErrNotFound, "")
+	}
+	if err := v4.ResolveURL(h.store, curl); err != nil {
+		// Note: preserve error cause from resolveURL.
+		return nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
+	}
+	return curl, nil
+}
+
+var errNotFound = fmt.Errorf("entry not found")
+
+func (h *Handler) serveCharmInfo(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+	response := make(map[string]*charm.InfoResponse)
+	for _, url := range req.Form["charms"] {
+		c := &charm.InfoResponse{}
+		response[url] = c
+		curl, err := h.resolveURLStr(url)
+		var entity mongodoc.Entity
+		if err != nil {
+			if errgo.Cause(err) == params.ErrNotFound {
+				err = errNotFound
+			}
+		} else {
+			err = h.store.DB.Entities().FindId(curl).One(&entity)
+			if err == mgo.ErrNotFound {
+				// The old API actually returned "entry not found"
+				// on *any* error, but it seems reasonable to be
+				// a little more descriptive for other errors.
+				err = errNotFound
+			}
+		}
+		if err == nil && entity.BlobHash256 == "" {
+			// Lazily calulate SHA256 so that we don't burden
+			// non-legacy code with that task.
+			entity.BlobHash256, err = h.updateEntitySHA256(curl)
+		}
+		if err == nil {
+			// TODO(rog) increment charm-info stats counter?
+			c.CanonicalURL = curl.String()
+			c.Sha256 = entity.BlobHash256
+			c.Revision = curl.Revision
+			// TODO(rog) include Digest if it exists in extra-info ?
+		} else {
+			// TODO(rog) increment charm-missing stats counter?
+			c.Errors = append(c.Errors, err.Error())
+		}
+	}
+	return response, nil
+}
+
+// updateEntitySHA256 updates the BlobHash256 entry for the entity.
+// It is defined as a variable so that it can be mocked in tests.
+var updateEntitySHA256 = func(store *charmstore.Store, url *charm.Reference, sum256 string) {
+	err := store.DB.Entities().UpdateId(url, bson.D{{"$set", bson.D{{"blobhash256", sum256}}}})
+	if err != nil && err != mgo.ErrNotFound {
+		log.Printf("cannot update sha256 of archive: %v", err)
+	}
+}
+
+func (h *Handler) updateEntitySHA256(curl *charm.Reference) (string, error) {
+	r, _, err := h.store.OpenBlob(curl)
+	defer r.Close()
+	hash := sha256.New()
+	_, err = io.Copy(hash, r)
+	if err != nil {
+		return "", errgo.Notef(err, "cannot calculate sha256 of archive")
+	}
+	sum256 := fmt.Sprintf("%x", hash.Sum(nil))
+
+	// Update the entry asynchronously because it doesn't matter
+	// if it succeeds or fails, or if several instances of the
+	// charm store do it concurrently, and it doesn't
+	// need to be on the critical path for charm-info.
+	go updateEntitySHA256(h.store, curl, sum256)
+
+	return sum256, nil
 }

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -4,10 +4,16 @@
 package legacy_test
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"time"
 
+	jc "github.com/juju/testing/checkers"
 	"gopkg.in/juju/charm.v3"
 	charmtesting "gopkg.in/juju/charm.v3/testing"
 	"gopkg.in/mgo.v2"
@@ -106,15 +112,185 @@ func (s *APISuite) TestCharmArchiveUnresolvedURL(c *gc.C) {
 	})
 }
 
-func (s *APISuite) TestCharmInfo(c *gc.C) {
+func (s *APISuite) TestCharmInfoNotFound(c *gc.C) {
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
 		Handler:      s.srv,
-		URL:          "/charm-info",
-		ExpectStatus: http.StatusInternalServerError,
-		ExpectBody: params.Error{
-			Message: "charm-info not implemented",
+		URL:          "/charm-info?charms=cs:precise/something-23",
+		ExpectStatus: http.StatusOK,
+		ExpectBody: map[string]charm.InfoResponse{
+			"cs:precise/something-23": {
+				Errors: []string{"entry not found"},
+			},
 		},
 	})
+}
+
+func (s *APISuite) TestServerCharmInfo(c *gc.C) {
+	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-1")
+	hashSum := fileSHA256(c, wordpress.Path)
+	tests := []struct {
+		url       string
+		canonical string
+		sha       string
+		digest    string
+		revision  int
+		err       string
+	}{{
+		url:       wordpressURL.String(),
+		canonical: "cs:precise/wordpress-1",
+		sha:       hashSum,
+		revision:  1,
+	}, {
+		url: "cs:oneiric/non-existent",
+		err: "entry not found",
+	}, {
+		url:       "cs:wordpress",
+		canonical: "cs:precise/wordpress-1",
+		sha:       hashSum,
+		revision:  1,
+	}, {
+		url: "cs:/bad",
+		err: `entry not found`,
+	}, {
+		url: "gopher:archie-server",
+		err: `entry not found`,
+	}, {
+		url: "/charm-info?charms=cs:not-found",
+		err: "entry not found",
+	}}
+
+	for i, test := range tests {
+		c.Logf("test %d: %s", i, test.url)
+		expectInfo := charm.InfoResponse{
+			CanonicalURL: test.canonical,
+			Sha256:       test.sha,
+			Revision:     test.revision,
+			Digest:       test.digest,
+		}
+		if test.err != "" {
+			expectInfo.Errors = []string{test.err}
+		}
+		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+			Handler:      s.srv,
+			URL:          "/charm-info?charms=" + test.url,
+			ExpectStatus: http.StatusOK,
+			ExpectBody: map[string]charm.InfoResponse{
+				test.url: expectInfo,
+			},
+		})
+	}
+
+	// TODO(rog) check stats events
+}
+
+func fileSHA256(c *gc.C, path string) string {
+	f, err := os.Open(path)
+	c.Assert(err, gc.IsNil)
+	hash := sha256.New()
+	_, err = io.Copy(hash, f)
+	c.Assert(err, gc.IsNil)
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}
+
+func (s *APISuite) TestCharmPackageGet(c *gc.C) {
+	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-0")
+	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
+	c.Assert(err, gc.IsNil)
+
+	srv := httptest.NewServer(s.srv)
+	defer srv.Close()
+
+	s.PatchValue(&charm.CacheDir, c.MkDir())
+	s.PatchValue(&charm.Store.BaseURL, srv.URL)
+
+	url, _ := wordpressURL.URL("")
+	ch, err := charm.Store.Get(url)
+	c.Assert(err, gc.IsNil)
+	chArchive := ch.(*charm.CharmArchive)
+
+	data, err := ioutil.ReadFile(chArchive.Path)
+	c.Assert(err, gc.IsNil)
+	c.Assert(data, gc.DeepEquals, archiveBytes)
+}
+
+func (s *APISuite) TestCharmPackageCharmInfo(c *gc.C) {
+	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-0")
+	wordpressSHA256 := fileSHA256(c, wordpress.Path)
+	mysqlURL, mySQL := s.addCharm(c, "wordpress", "cs:precise/mysql-2")
+	mysqlSHA256 := fileSHA256(c, mySQL.Path)
+	notFoundURL := mustParseReference("cs:oneiric/not-found-3")
+
+	srv := httptest.NewServer(s.srv)
+	defer srv.Close()
+	s.PatchValue(&charm.Store.BaseURL, srv.URL)
+
+	resp, err := charm.Store.Info(wordpressURL, mysqlURL, notFoundURL)
+	c.Assert(err, gc.IsNil)
+	c.Assert(resp, gc.HasLen, 3)
+	c.Assert(resp, jc.DeepEquals, []*charm.InfoResponse{{
+		CanonicalURL: wordpressURL.String(),
+		Sha256:       wordpressSHA256,
+	}, {
+		CanonicalURL: mysqlURL.String(),
+		Sha256:       mysqlSHA256,
+		Revision:     2,
+	}, {
+		Errors: []string{"charm not found: " + notFoundURL.String()},
+	}})
+}
+
+func (s *APISuite) TestSHA256Laziness(c *gc.C) {
+	updated := make(chan struct{}, 1)
+	// Patch updateEntitySHA256 so that we can know whether
+	// it has been called or not.
+	oldUpdate := *legacy.UpdateEntitySHA256
+	s.PatchValue(legacy.UpdateEntitySHA256, func(store *charmstore.Store, url *charm.Reference, sum256 string) {
+		oldUpdate(store, url, sum256)
+		updated <- struct{}{}
+	})
+
+	wordpressURL, wordpress := s.addCharm(c, "wordpress", "cs:precise/wordpress-0")
+	sum256 := fileSHA256(c, wordpress.Path)
+
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:      s.srv,
+		URL:          "/charm-info?charms=" + wordpressURL.String(),
+		ExpectStatus: http.StatusOK,
+		ExpectBody: map[string]charm.InfoResponse{
+			wordpressURL.String(): {
+				CanonicalURL: wordpressURL.String(),
+				Sha256:       sum256,
+				Revision:     0,
+			},
+		},
+	})
+
+	select {
+	case <-updated:
+	case <-time.After(5 * time.Second):
+		c.Fatalf("timed out waiting for update")
+	}
+
+	// Try again - we should not update the SHA256 the second time.
+
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:      s.srv,
+		URL:          "/charm-info?charms=" + wordpressURL.String(),
+		ExpectStatus: http.StatusOK,
+		ExpectBody: map[string]charm.InfoResponse{
+			wordpressURL.String(): {
+				CanonicalURL: wordpressURL.String(),
+				Sha256:       sum256,
+				Revision:     0,
+			},
+		},
+	})
+
+	select {
+	case <-updated:
+		c.Fatalf("update called twice")
+	case <-time.After(10 * time.Millisecond):
+	}
 }
 
 var serverStatusTests = []struct {

--- a/internal/legacy/export_test.go
+++ b/internal/legacy/export_test.go
@@ -1,0 +1,3 @@
+package legacy
+
+var UpdateEntitySHA256 = &updateEntitySHA256

--- a/internal/legacy/export_test.go
+++ b/internal/legacy/export_test.go
@@ -1,3 +1,6 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
 package legacy
 
 var UpdateEntitySHA256 = &updateEntitySHA256

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -22,6 +22,11 @@ type Entity struct {
 	// as created by blobstore.NewHash.
 	BlobHash string
 
+	// BlobHash256 holds the SHA256 hash checksum of the blob,
+	// in hexadecimal format. This is only used by the legacy
+	// API, and is calculated lazily the first time it is required.
+	BlobHash256 string
+
 	// Size holds the size of the archive blob.
 	// TODO(rog) rename this to BlobSize.
 	Size int64


### PR DESCRIPTION
This requires the SHA256 hash of the content. Rather than clutter the other code,
we calculate this lazily on demand.
