### PR TITLE
charmloader: log fails to file

### DIFF
--- a/cmd/charmload/main.go
+++ b/cmd/charmload/main.go
@@ -51,7 +51,7 @@ func load() error {
 			return errgo.Notef(err, "cannot configure loggers")
 		}
 	}
-	writer, err := os.OpenFile("charmload-err", os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
+	writer, err := os.OpenFile("charmload.err", os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}

--- a/lppublish/lpad.go
+++ b/lppublish/lpad.go
@@ -28,6 +28,7 @@ import (
 )
 
 var logger = loggo.GetLogger("charmload")
+var failsLogger = loggo.GetLogger("charmload_v4.loadfails")
 
 type PublishBranchError struct {
 	URL string
@@ -184,6 +185,7 @@ func (cl *charmLoader) publisher(results <-chan entityResult, errs chan<- error)
 		)
 		err := cl.publishBazaarBranch(URLs, result.branchURL, result.tip.Revision)
 		if err != nil {
+			failsLogger.Errorf("cannot publish branch %v to charm store: %v", result.branchURL, err)
 			errs <- errgo.NoteMask(err, "cannot publish branch "+result.branchURL, errgo.Is(params.ErrUnauthorized))
 		}
 		logger.Debugf("done publishing URLs for %s", result.charmURL)


### PR DESCRIPTION
Log all charms and bundles that failed the ingestion process. With err descriptions if possible.
