### PR TITLE
Only digest entities if not present in the charm store.

### DIFF
--- a/lppublish/lpad.go
+++ b/lppublish/lpad.go
@@ -412,9 +412,9 @@ func (cl *charmLoader) putDigestExtraInfo(id *charm.Reference, digest string) er
 }
 
 // doCharmStoreRequest adds appropriate headers to the given HTTP request,
-// sends it to the charm store acting as the given user
-// and parses the result as JSON into the given result value,
-// which should be a pointer to the expected data.
+// sends it to the charm store acting as the given user and parses the result
+// as JSON into the given result value, which should be a pointer to the
+// expected data, but may be nil if no result is expected.
 // TODO(rog) factor this into a general charm store client package.
 func (cl *charmLoader) doCharmStoreRequest(req *http.Request, result interface{}) error {
 	if req.Method == "POST" || req.Method == "PUT" {

--- a/lppublish/lpad.go
+++ b/lppublish/lpad.go
@@ -237,7 +237,7 @@ func uniqueNameURLs(name string) (branchURL string, charmURL *charm.Reference, e
 	return branchURL, charmURL, nil
 }
 
-const BZR_DIGEST_KEY = "bzr-digest"
+const bzrDigestKey = "bzr-digest"
 
 func (cl *charmLoader) publishBazaarBranch(URLs []*charm.Reference, branchURL string, digest string) error {
 	// Check whether the entity is already present in the charm store.
@@ -368,7 +368,7 @@ func (cl *charmLoader) postArchive(r io.Reader, id *charm.Reference, size int64,
 }
 
 func (cl *charmLoader) getDigestExtraInfo(id *charm.Reference) (string, error) {
-	url := cl.StoreURL + id.Path() + "/meta/extra-info/" + BZR_DIGEST_KEY
+	url := cl.StoreURL + id.Path() + "/meta/extra-info/" + bzrDigestKey
 	logger.Infof("getting extra info from %v", url)
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -389,7 +389,7 @@ func (cl *charmLoader) putDigestExtraInfo(id *charm.Reference, digest string) er
 	if err != nil {
 		return errgo.Notef(err, "cannot marshal digest")
 	}
-	url := cl.StoreURL + id.Path() + "/meta/extra-info/" + BZR_DIGEST_KEY
+	url := cl.StoreURL + id.Path() + "/meta/extra-info/" + bzrDigestKey
 	logger.Infof("putting extra info to %v", url)
 	req, err := http.NewRequest("PUT", url, bytes.NewReader(body))
 	if err != nil {

--- a/lppublish/lpad.go
+++ b/lppublish/lpad.go
@@ -303,7 +303,7 @@ func (cl *charmLoader) publishBazaarBranch(urls []*charm.Reference, branchURL st
 		}
 		logger.Infof("bzr digest for %s set to %s", finalId, tipDigest)
 	}
-	return err
+	return nil
 }
 
 // excludeExistingEntities filters the given URLs slice to only include
@@ -403,7 +403,6 @@ func (cl *charmLoader) putDigestExtraInfo(id *charm.Reference, digest string) er
 		return errgo.Notef(err, "cannot make HTTP PUT request")
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.ContentLength = int64(len(body))
 
 	err = cl.doCharmStoreRequest(req, nil)
 	if err != nil {


### PR DESCRIPTION
Store the bzr-digest extra-info for all the ingested entities, and compare the value in subsequent charmload calls.
