### PR TITLE
internal/v4: do not create new revision if content matches latest

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -11,7 +11,7 @@ github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d
 github.com/juju/testing	git	8bdbb45d87dd9724c254eb6afeacd84b127d7e76	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
 github.com/juju/utils	git	68554773385c32c354bf6357f8b6edd8a4742682	
-gopkg.in/juju/charm.v3	git	14ee49844221d5700512989cef15ea95b30969d5	
+gopkg.in/juju/charm.v3	git	ceed5c31c0689a79a0c8a0dbf197e4933d21069a	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/yaml.v1	git	1b9791953ba4027efaeb728c7355e542a203be5e	
 launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -166,7 +166,7 @@ func (o orderedURLs) Len() int {
 	return len(o)
 }
 
-var expandURLTests = []struct {
+var urlFindingTests = []struct {
 	inStore []string
 	expand  string
 	expect  []string
@@ -209,8 +209,18 @@ var expandURLTests = []struct {
 }}
 
 func (s *StoreSuite) TestExpandURL(c *gc.C) {
+	s.testURLFinding(c, func(store *Store, expand *charm.Reference, expect []*charm.Reference) {
+		gotURLs, err := store.ExpandURL(expand)
+		c.Assert(err, gc.IsNil)
+
+		sort.Sort(orderedURLs(gotURLs))
+		c.Assert(gotURLs, jc.DeepEquals, expect)
+	})
+}
+
+func (s *StoreSuite) testURLFinding(c *gc.C, check func(store *Store, expand *charm.Reference, expect []*charm.Reference)) {
 	wordpress := testing.Charms.CharmDir("wordpress")
-	for i, test := range expandURLTests {
+	for i, test := range urlFindingTests {
 		c.Logf("test %d: %q from %q", i, test.expand, test.inStore)
 		store, err := NewStore(s.Session.DB("foo"))
 		c.Assert(err, gc.IsNil)
@@ -221,14 +231,49 @@ func (s *StoreSuite) TestExpandURL(c *gc.C) {
 			err := store.AddCharmWithArchive(url, wordpress)
 			c.Assert(err, gc.IsNil)
 		}
-		gotURLs, err := store.ExpandURL((*charm.Reference)(mustParseReference(test.expand)))
-		c.Assert(err, gc.IsNil)
-
-		gotURLStrs := urlStrings(gotURLs)
-		sort.Strings(gotURLStrs)
-		c.Assert(gotURLStrs, jc.DeepEquals, test.expect)
+		expectURLs := make([]*charm.Reference, len(test.expect))
+		for i, expect := range test.expect {
+			expectURLs[i] = mustParseReference(expect)
+		}
+		check(store, mustParseReference(test.expand), expectURLs)
 	}
 }
+
+func (s *StoreSuite) TestFindEntities(c *gc.C) {
+	s.testURLFinding(c, func(store *Store, expand *charm.Reference, expect []*charm.Reference) {
+		// check FindEntities works when just retrieving the id.
+		gotEntities, err := store.FindEntities(expand, "_id")
+		c.Assert(err, gc.IsNil)
+		sort.Sort(entitiesByURL(gotEntities))
+		c.Assert(gotEntities, gc.HasLen, len(expect))
+		for i, url := range expect {
+			c.Assert(gotEntities[i], jc.DeepEquals, &mongodoc.Entity{
+				URL: url,
+			})
+		}
+
+		// check FindEntities works when retrieving all fields.
+		gotEntities, err = store.FindEntities(expand)
+		c.Assert(err, gc.IsNil)
+		sort.Sort(entitiesByURL(gotEntities))
+		c.Assert(gotEntities, gc.HasLen, len(expect))
+		for i, url := range expect {
+			var entity mongodoc.Entity
+			err := store.DB.Entities().FindId(url).One(&entity)
+			c.Assert(err, gc.IsNil)
+			c.Assert(gotEntities[i], jc.DeepEquals, &entity)
+		}
+	})
+}
+
+type entitiesByURL []*mongodoc.Entity
+
+func (s entitiesByURL) Len() int      { return len(s) }
+func (s entitiesByURL) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s entitiesByURL) Less(i, j int) bool {
+	return s[i].URL.String() < s[j].URL.String()
+}
+
 
 var bundleUnitCountTests = []struct {
 	about       string

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -274,7 +274,6 @@ func (s entitiesByURL) Less(i, j int) bool {
 	return s[i].URL.String() < s[j].URL.String()
 }
 
-
 var bundleUnitCountTests = []struct {
 	about       string
 	data        *charm.BundleData

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -106,7 +106,7 @@ func (h *Handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 		return badRequestf(nil, "Content-Length not specified")
 	}
 
-	oldId, oldHash, err := h.hashOfLatestRevision(id)
+	oldId, oldHash, err := h.latestRevisionInfo(id)
 	if err != nil && errgo.Cause(err) != params.ErrNotFound {
 		return errgo.Notef(err, "cannot get hash of latest revision")
 	}
@@ -175,8 +175,8 @@ func (h *Handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 	})
 }
 
-func (h *Handler) hashOfLatestRevision(id *charm.Reference) (*charm.Reference, string, error) {
-	entities, err := h.store.FindEntities(id)
+func (h *Handler) latestRevisionInfo(id *charm.Reference) (*charm.Reference, string, error) {
+	entities, err := h.store.FindEntities(id, "_id", "blobhash")
 	if err != nil {
 		return nil, "", errgo.Mask(err)
 	}

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -106,6 +106,18 @@ func (h *Handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 		return badRequestf(nil, "Content-Length not specified")
 	}
 
+	oldId, oldHash, err := h.hashOfLatestRevision(id)
+	if err != nil && errgo.Cause(err) != params.ErrNotFound {
+		return errgo.Notef(err, "cannot get hash of latest revision")
+	}
+	if oldHash == hash {
+		// The hash matches the hash of the latest revision, so
+		// no need to upload anything.
+		return router.WriteJSON(w, http.StatusOK, &params.ArchivePostResponse{
+			Id: oldId,
+		})
+	}
+
 	// Upload the actual blob, and make sure that it is removed
 	// if we fail later.
 	name := bson.NewObjectId().Hex()
@@ -161,6 +173,23 @@ func (h *Handler) servePostArchive(id *charm.Reference, w http.ResponseWriter, r
 	return router.WriteJSON(w, http.StatusOK, &params.ArchivePostResponse{
 		Id: id,
 	})
+}
+
+func (h *Handler) hashOfLatestRevision(id *charm.Reference) (*charm.Reference, string, error) {
+	entities, err := h.store.FindEntities(id)
+	if err != nil {
+		return nil, "", errgo.Mask(err)
+	}
+	if len(entities) == 0 {
+		return nil, "", params.ErrNotFound
+	}
+	latest := entities[0]
+	for _, entity := range entities {
+		if entity.URL.Revision > latest.URL.Revision {
+			latest = entity
+		}
+	}
+	return latest.URL, latest.BlobHash, nil
 }
 
 func verifyConstraints(s string) error {

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -285,7 +285,7 @@ func (s *ArchiveSuite) TestPostCharm(c *gc.C) {
 
 	// Subsequent charm uploads should increment the
 	// revision by 1.
-	s.assertUploadCharm(c, mustParseReference("precise/wordpress-1"), "wordpress")
+	s.assertUploadCharm(c, mustParseReference("precise/wordpress-1"), "mysql")
 }
 
 func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
@@ -298,13 +298,23 @@ func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 		mustParseReference("cs:utopic/wordpress-47"),
 		charmtesting.Charms.CharmArchive(c.MkDir(), "wordpress"))
 	c.Assert(err, gc.IsNil)
+	err = s.store.AddCharmWithArchive(
+		mustParseReference("cs:utopic/logging-1"),
+		charmtesting.Charms.CharmArchive(c.MkDir(), "logging"))
+	c.Assert(err, gc.IsNil)
 
 	// A bundle that did not exist before should get revision 0.
 	s.assertUploadBundle(c, mustParseReference("bundle/wordpress-0"), "wordpress")
 
 	// Subsequent bundle uploads should increment the
 	// revision by 1.
-	s.assertUploadBundle(c, mustParseReference("bundle/wordpress-1"), "wordpress")
+	s.assertUploadBundle(c, mustParseReference("bundle/wordpress-1"), "wordpress-with-logging")
+
+	// Uploading the same archive twice should not increment the revision...
+	s.assertUploadBundle(c, mustParseReference("bundle/wordpress-1"), "wordpress-with-logging")
+
+	// ... but uploading an archive used by a previous revision should.
+	s.assertUploadBundle(c, mustParseReference("bundle/wordpress-2"), "wordpress")
 }
 
 func (s *ArchiveSuite) TestPostHashMismatch(c *gc.C) {


### PR DESCRIPTION
When the content is the same as the latest version, there's no need to
bump the revision number. We needed to add another bundle to
test this, hence the change to the charm.v3 dependency.
