### PR TITLE
all: use charm.v4

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,7 +10,7 @@ import (
 
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/charmstore/config"
 )

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -8,11 +8,11 @@ github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098
 github.com/juju/loggo	git	158009fb40c4a52b3d2c23eb56e72859cfc5321a	
 github.com/juju/names	git	cfcf5a79106d26fce039a35ffca277def4496f4b	
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	
-github.com/juju/testing	git	8bdbb45d87dd9724c254eb6afeacd84b127d7e76	
+github.com/juju/testing	git	cc1a29452f9a9af7a54c3a2af495fbf5cd64c640	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
 github.com/juju/utils	git	68554773385c32c354bf6357f8b6edd8a4742682	
-gopkg.in/juju/charm.v3	git	ceed5c31c0689a79a0c8a0dbf197e4933d21069a	
+gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
+gopkg.in/juju/charm.v4	git	174c69f63f84a7e5a1ad0dfa94747374b5fe4860	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/yaml.v1	git	1b9791953ba4027efaeb728c7355e542a203be5e	
-launchpad.net/gocheck	bzr	gustavo@niemeyer.net-20140225173054-xu9zlkf9kxhvow02	87
 launchpad.net/lpad	bzr	gustavo@niemeyer.net-20131113112110-fqow8xpml1pxyutb	65

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	jujutesting "github.com/juju/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/charmstore/internal/blobstore"
 	"github.com/juju/charmstore/internal/storetesting"

--- a/internal/charmstore/archive.go
+++ b/internal/charmstore/archive.go
@@ -9,7 +9,7 @@ import (
 	"os"
 
 	"github.com/juju/errgo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/internal/blobstore"
 )

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -6,7 +6,7 @@ package charmstore
 import (
 	"net/http"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/charmstore/internal/router"
 	"github.com/juju/charmstore/internal/storetesting"

--- a/internal/charmstore/stats_test.go
+++ b/internal/charmstore/stats_test.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
+	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2/bson"
-	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/storetesting"

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/juju/errgo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/juju/errgo"
 	jc "github.com/juju/testing/checkers"
-	"gopkg.in/juju/charm.v3"
-	"gopkg.in/juju/charm.v3/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+	"gopkg.in/juju/charm.v4/testing"
 
 	"github.com/juju/charmstore/internal/blobstore"
 	"github.com/juju/charmstore/internal/mongodoc"

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/juju/errgo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -15,11 +15,11 @@ import (
 	"time"
 
 	jc "github.com/juju/testing/checkers"
-	"gopkg.in/juju/charm.v3"
-	charmtesting "gopkg.in/juju/charm.v3/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+	charmtesting "gopkg.in/juju/charm.v4/testing"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/legacy"

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -3,7 +3,7 @@ package mongodoc
 import (
 	"time"
 
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 )
 
 // Entity holds the in-database representation of charm or bundle's

--- a/internal/router/fieldinclude.go
+++ b/internal/router/fieldinclude.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 
 	"github.com/juju/errgo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 )
 
 // A FieldQueryFunc is used to retrieve a metadata document for the given URL,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	"github.com/juju/errgo"
-	charm "gopkg.in/juju/charm.v3"
+	charm "gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/params"
 )

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/juju/errgo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"gopkg.in/juju/charm.v3"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/internal/storetesting"
 	"github.com/juju/charmstore/params"

--- a/internal/router/singleinclude.go
+++ b/internal/router/singleinclude.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 
 	"github.com/juju/errgo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 )
 
 var _ BulkIncludeHandler = SingleIncludeHandler(nil)

--- a/internal/storetesting/http.go
+++ b/internal/storetesting/http.go
@@ -11,7 +11,7 @@ import (
 	"net/http/httptest"
 
 	jc "github.com/juju/testing/checkers"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 // JSONCallParams holds parameters for AssertJSONCall.

--- a/internal/storetesting/stats/stats.go
+++ b/internal/storetesting/stats/stats.go
@@ -6,7 +6,7 @@ package stats
 import (
 	"time"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/charmstore/internal/charmstore"
 )

--- a/internal/storetesting/suite.go
+++ b/internal/storetesting/suite.go
@@ -5,7 +5,7 @@ package storetesting
 
 import (
 	jujutesting "github.com/juju/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type IsolatedMgoSuite struct {

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/juju/errgo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -17,11 +17,11 @@ import (
 
 	"github.com/juju/errgo"
 	jc "github.com/juju/testing/checkers"
-	"gopkg.in/juju/charm.v3"
-	charmtesting "gopkg.in/juju/charm.v3/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+	charmtesting "gopkg.in/juju/charm.v4/testing"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/mongodoc"

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	"github.com/juju/errgo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/charmstore/internal/mongodoc"

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -19,11 +19,11 @@ import (
 	"sync"
 
 	jc "github.com/juju/testing/checkers"
-	"gopkg.in/juju/charm.v3"
-	"gopkg.in/juju/charm.v3/testing"
-	charmtesting "gopkg.in/juju/charm.v3/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+	"gopkg.in/juju/charm.v4/testing"
+	charmtesting "gopkg.in/juju/charm.v4/testing"
 	"gopkg.in/mgo.v2/bson"
-	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/blobstore"
 	"github.com/juju/charmstore/internal/charmstore"

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -6,7 +6,7 @@ package v4
 import (
 	"net/http"
 
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 )
 
 func BundleCharms(h http.Handler) func([]string) (map[string]charm.Charm, error) {

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	"github.com/juju/errgo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/charmstore/internal/mongodoc"

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"gopkg.in/juju/charm.v3"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2/bson"
-	gc "launchpad.net/gocheck"
 
 	"github.com/juju/charmstore/internal/blobstore"
 	"github.com/juju/charmstore/internal/charmstore"

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/juju/errgo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/params"

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/storetesting"

--- a/lppublish/lpad.go
+++ b/lppublish/lpad.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/juju/errgo"
 	"github.com/juju/loggo"
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 	"launchpad.net/lpad"
 
 	"github.com/juju/charmstore/params"

--- a/params/package_test.go
+++ b/params/package_test.go
@@ -6,7 +6,7 @@ package params_test
 import (
 	"testing"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *testing.T) {

--- a/params/params.go
+++ b/params/params.go
@@ -9,7 +9,7 @@ package params
 import (
 	"time"
 
-	"gopkg.in/juju/charm.v3"
+	"gopkg.in/juju/charm.v4"
 )
 
 // MetaAnyResponse holds the result of a meta/any

--- a/server_test.go
+++ b/server_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	jujutesting "github.com/juju/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/charmstore"
 	"github.com/juju/charmstore/internal/storetesting"


### PR DESCRIPTION
Automatic change made by running:

```
govers gopkg.in/charm.v4
govers -m launchpad.net/gocheck gopkg.in/check.v1
```
