### PR TITLE
implement PutDocument for updateEntity

### DIFF
--- a/internal/elasticsearch/elasticsearch_test.go
+++ b/internal/elasticsearch/elasticsearch_test.go
@@ -42,8 +42,36 @@ func (s *IsolatedElasticSearchSuite) TestSuccessfulPostDocument(c *gc.C) {
 	doc := map[string]string{
 		"a": "b",
 	}
-	err := s.db.PostDocument("testindex", "testtype", doc)
+	id, err := s.db.PostDocument("testindex", "testtype", doc)
 	c.Assert(err, gc.IsNil)
+	c.Assert(id, gc.NotNil)
+	var result map[string]string
+	err = s.db.GetDocument("testindex", "testtype", id, &result)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *IsolatedElasticSearchSuite) TestSuccessfulPutNewDocument(c *gc.C) {
+	doc := map[string]string{
+		"a": "b",
+	}
+	err := s.db.PutDocument("testindex", "testtype", "a", doc)
+	c.Assert(err, gc.IsNil)
+	var result map[string]string
+	err = s.db.GetDocument("testindex", "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "b")
+}
+
+func (s *IsolatedElasticSearchSuite) TestSuccessfulPutUpdatedDocument(c *gc.C) {
+	doc := map[string]string{
+		"a": "b",
+	}
+	err := s.db.PutDocument("testindex", "testtype", "a", doc)
+	doc["a"] = "c"
+	err = s.db.PutDocument("testindex", "testtype", "a", doc)
+	c.Assert(err, gc.IsNil)
+	var result map[string]string
+	err = s.db.GetDocument("testindex", "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "c")
 }
 
 func (s *IsolatedElasticSearchSuite) TestDelete(c *gc.C) {


### PR DESCRIPTION
The card says "extend ES package with a updateEntity for doc update functionality (not just adding new doc) " PUT does both add and update.

GetDocument comes along for the ride so that we can have proper tests.
