### PR TITLE
internal/v4: implement archive PUT

### DIFF
--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -27,11 +27,17 @@ import (
 // GET id/archive
 // http://tinyurl.com/qjrwq53
 //
-// POST id/archive?sha256=hash
+// POST id/archive?hash=sha384hash
 // http://tinyurl.com/lzrzrgb
-
+//
 // DELETE id/archive
 // http://tinyurl.com/ojmlwos
+//
+// PUT id/archive?hash=sha384hash
+// This is like POST except that it puts the archive to a known revision
+// rather than choosing a new one. As this feature is to support legacy
+// ingestion methods, and will be removed in the future, it has no entry
+// in the specification.
 func (h *Handler) serveArchive(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	switch req.Method {
 	default:

--- a/lppublish/lpad.go
+++ b/lppublish/lpad.go
@@ -443,7 +443,7 @@ func (cl *charmLoader) postArchive(r io.Reader, id *charm.Reference, size int64,
 	req.Header.Set("Content-Type", "application/zip")
 	req.ContentLength = size
 
-	var resp params.ArchivePostResponse
+	var resp params.ArchiveUploadResponse
 	err = cl.doCharmStoreRequest(req, &resp)
 	if err != nil {
 		return nil, errgo.Mask(err, errgo.Is(params.ErrUnauthorized))

--- a/params/params.go
+++ b/params/params.go
@@ -19,9 +19,9 @@ type MetaAnyResponse struct {
 	Meta map[string]interface{} `json:",omitempty"`
 }
 
-// ArchivePostResponse holds the result of
-// a post to /$id/archive. See http://tinyurl.com/lzrzrgb
-type ArchivePostResponse struct {
+// ArchiveUploadResponse holds the result of
+// a post or a put to /$id/archive. See http://tinyurl.com/lzrzrgb
+type ArchiveUploadResponse struct {
 	Id *charm.Reference
 }
 


### PR DESCRIPTION
This will allow the ingester to match the uploaded charm URLs to the original
launchpad (and therefore legacy charm store) revisions.
