### PR TITLE
update dependencies for new charm package version

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -12,7 +12,7 @@ github.com/juju/testing	git	cc1a29452f9a9af7a54c3a2af495fbf5cd64c640
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
 github.com/juju/utils	git	68554773385c32c354bf6357f8b6edd8a4742682	
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
-gopkg.in/juju/charm.v4	git	da11b857f86a3fc5eda8ce948e25edef28eed5f2	
+gopkg.in/juju/charm.v4	git	c2fca34024c7781bc5618af6fda4c180addeb909	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/yaml.v1	git	1b9791953ba4027efaeb728c7355e542a203be5e	
 launchpad.net/lpad	bzr	gustavo@niemeyer.net-20131113112110-fqow8xpml1pxyutb	65


### PR DESCRIPTION
This makes many more existing bundles import correctly.
