### PR TITLE
Added elasticsearch configuration to charmstore.

### DIFF
--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -14,26 +15,26 @@ import (
 	"github.com/juju/charmstore"
 	"github.com/juju/charmstore/config"
 	"github.com/juju/charmstore/internal/debug"
+	"github.com/juju/charmstore/internal/elasticsearch"
 )
 
 func main() {
-	err := serve()
-	if err != nil {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: %s <config path>\n", filepath.Base(os.Args[0]))
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+	flag.Parse()
+	if flag.NArg() != 1 {
+		flag.Usage()
+	}
+	if err := serve(flag.Arg(0)); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }
 
-func serve() error {
-	var confPath string
-	if len(os.Args) == 2 {
-		if _, err := os.Stat(os.Args[1]); err == nil {
-			confPath = os.Args[1]
-		}
-	}
-	if confPath == "" {
-		return fmt.Errorf("usage: %s <config path>", filepath.Base(os.Args[0]))
-	}
+func serve(confPath string) error {
 	conf, err := config.Read(confPath)
 	if err != nil {
 		return err
@@ -44,11 +45,15 @@ func serve() error {
 	}
 	defer session.Close()
 	db := session.DB("juju")
+	var es *elasticsearch.Database
+	if conf.ESAddr != "" {
+		es = &elasticsearch.Database{conf.ESAddr}
+	}
 	cfg := charmstore.ServerParams{
 		AuthUsername: conf.AuthUsername,
 		AuthPassword: conf.AuthPassword,
 	}
-	server, err := charmstore.NewServer(db, cfg, charmstore.Legacy, charmstore.V4)
+	server, err := charmstore.NewServer(db, es, cfg, charmstore.Legacy, charmstore.V4)
 	if err != nil {
 		return err
 	}

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/errgo"
 	"gopkg.in/mgo.v2"
 
+	"github.com/juju/charmstore/internal/elasticsearch"
 	"github.com/juju/charmstore/internal/router"
 )
 
@@ -29,11 +30,11 @@ type ServerParams struct {
 // versions using db to store that charm store data.
 // The key of the versions map is the version name.
 // The handler configuration is provided to all version handlers.
-func NewServer(db *mgo.Database, config ServerParams, versions map[string]NewAPIHandlerFunc) (http.Handler, error) {
+func NewServer(db *mgo.Database, es *elasticsearch.Database, config ServerParams, versions map[string]NewAPIHandlerFunc) (http.Handler, error) {
 	if len(versions) == 0 {
 		return nil, errgo.Newf("charm store server must serve at least one version of the API")
 	}
-	store, err := NewStore(db, nil)
+	store, err := NewStore(db, es)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot make store")
 	}

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -51,7 +51,7 @@ func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (h
 	db := session.DB("charmstore")
 	store, err := charmstore.NewStore(db, nil)
 	c.Assert(err, gc.IsNil)
-	srv, err := charmstore.NewServer(db, config, map[string]charmstore.NewAPIHandlerFunc{"": legacy.NewAPIHandler})
+	srv, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"": legacy.NewAPIHandler})
 	c.Assert(err, gc.IsNil)
 	return srv, store
 }

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -53,7 +53,7 @@ func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (h
 	db := session.DB("charmstore")
 	store, err := charmstore.NewStore(db, nil)
 	c.Assert(err, gc.IsNil)
-	srv, err := charmstore.NewServer(db, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
+	srv, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
 	c.Assert(err, gc.IsNil)
 	return srv, store
 }

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/elasticsearch"
 	"github.com/juju/charmstore/internal/legacy"
 	"github.com/juju/charmstore/internal/v4"
 )
@@ -45,7 +46,7 @@ type ServerParams struct {
 // NewServer returns a new handler that handles charm store requests and stores
 // its data in the given database. The handler will serve the specified
 // versions of the API using the given configuration.
-func NewServer(db *mgo.Database, config ServerParams, serveVersions ...string) (http.Handler, error) {
+func NewServer(db *mgo.Database, es *elasticsearch.Database, config ServerParams, serveVersions ...string) (http.Handler, error) {
 	newAPIs := make(map[string]charmstore.NewAPIHandlerFunc)
 	for _, vers := range serveVersions {
 		newAPI := versions[vers]
@@ -54,5 +55,5 @@ func NewServer(db *mgo.Database, config ServerParams, serveVersions ...string) (
 		}
 		newAPIs[vers] = newAPI
 	}
-	return charmstore.NewServer(db, charmstore.ServerParams(config), newAPIs)
+	return charmstore.NewServer(db, es, charmstore.ServerParams(config), newAPIs)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -38,13 +38,13 @@ func (s *ServerSuite) SetUpSuite(c *gc.C) {
 }
 
 func (s *ServerSuite) TestNewServerWithNoVersions(c *gc.C) {
-	h, err := charmstore.NewServer(s.Session.DB("foo"), s.config)
+	h, err := charmstore.NewServer(s.Session.DB("foo"), nil, s.config)
 	c.Assert(err, gc.ErrorMatches, `charm store server must serve at least one version of the API`)
 	c.Assert(h, gc.IsNil)
 }
 
 func (s *ServerSuite) TestNewServerWithUnregisteredVersion(c *gc.C) {
-	h, err := charmstore.NewServer(s.Session.DB("foo"), s.config, "wrong")
+	h, err := charmstore.NewServer(s.Session.DB("foo"), nil, s.config, "wrong")
 	c.Assert(err, gc.ErrorMatches, `unknown version "wrong"`)
 	c.Assert(h, gc.IsNil)
 }
@@ -61,7 +61,7 @@ func (s *ServerSuite) TestVersions(c *gc.C) {
 func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	db := s.Session.DB("foo")
 
-	h, err := charmstore.NewServer(db, s.config, charmstore.V4)
+	h, err := charmstore.NewServer(db, nil, s.config, charmstore.V4)
 	c.Assert(err, gc.IsNil)
 
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{


### PR DESCRIPTION
The config.yaml file can now contain an optional
elasticsearch-addr parameter specifying an
elasticsearch endpoint to connect to for searching.
