### PR TITLE
Implement ES proxy in charmstore

### DIFF
--- a/internal/elasticsearch/test/elasticsearch.go
+++ b/internal/elasticsearch/test/elasticsearch.go
@@ -1,0 +1,4 @@
+package elasticsearch
+
+// Placeholder file for go build.
+// https://code.google.com/p/go/issues/detail?id=8279


### PR DESCRIPTION
Implement elasticsearch proxy endpoint in charmstore. Will be useful
in an environment where elasticsearch is unreachable.

https://canonical.leankit.com/Boards/View/102529849/111347878
