### PR TITLE
When adding charms or bundles to mongo, index in ES if configured.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ server: install
 
 # Update the project Go dependencies to the required revision.
 deps: $(GOPATH)/bin/godeps
-	godeps -u dependencies.tsv
+	$(GOPATH)/bin/godeps -u dependencies.tsv
 
 # Generate the dependencies file.
 create-deps: $(GOPATH)/bin/godeps
@@ -98,9 +98,10 @@ endif
 	sudo apt-get update
 	@sudo apt-get --yes install $(strip $(DEPENDENCIES)) \
 	$(shell apt-cache madison juju-mongodb mongodb-server | head -1 | cut -d '|' -f1)
-endif
+else
 	@echo sysdeps runs only on systems with apt-get
-	@echo on MacOSX with homebrew try: brew install bazaar mongodb elasticsearch
+	@echo on OS X with homebrew try: brew install bazaar mongodb elasticsearch
+endif
 
 help:
 	@echo -e 'Charmstore - list of make targets:\n'

--- a/internal/elasticsearch/elasticsearch_test.go
+++ b/internal/elasticsearch/elasticsearch_test.go
@@ -32,6 +32,7 @@ func (s *Suite) TearDownSuite(c *gc.C) {
 func (s *Suite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.ElasticSearchSuite.SetUpTest(c)
+	s.NewIndex(c)
 }
 func (s *Suite) TearDownTest(c *gc.C) {
 	s.ElasticSearchSuite.TearDownTest(c)
@@ -56,11 +57,19 @@ func (s *Suite) TestSuccessfulPutNewDocument(c *gc.C) {
 	doc := map[string]string{
 		"a": "b",
 	}
-	err := s.ES.PutDocument(s.Indexes[0], "testtype", "a", doc)
+	// Show that no document with this id exists.
+	exists, err := s.ES.EnsureID(s.Indexes[0], "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, false)
+	err = s.ES.PutDocument(s.Indexes[0], "testtype", "a", doc)
 	c.Assert(err, gc.IsNil)
 	var result map[string]string
 	err = s.ES.GetDocument(s.Indexes[0], "testtype", "a", &result)
 	c.Assert(result["a"], gc.Equals, "b")
+	exists, err = s.ES.EnsureID(s.Indexes[0], "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, true)
+
 }
 
 func (s *Suite) TestSuccessfulPutUpdatedDocument(c *gc.C) {


### PR DESCRIPTION
Also add EnsureID to ElasticSearch.
