### PR TITLE
Add Search functionality to the API

### DIFF
--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -4,6 +4,7 @@
 package charmstore
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -150,7 +151,7 @@ func (s *Store) AddCharm(url *charm.Reference, c charm.Charm, blobName, blobHash
 	}
 
 	// Add to ElasticSearch.
-	if err := s.ES.Put(entity); err != nil {
+	if err := s.ES.put(entity); err != nil {
 		return errgo.Notef(err, "cannot index %s to ElasticSearch", entity.URL)
 	}
 	return nil
@@ -269,7 +270,7 @@ func (s *Store) AddBundle(url *charm.Reference, b charm.Bundle, blobName, blobHa
 		return errgo.Mask(err)
 	}
 	// Add to ElasticSearch.
-	if err := s.ES.Put(entity); err != nil {
+	if err := s.ES.put(entity); err != nil {
 		return errgo.Notef(err, "cannot index %s to ElasticSearch", entity.URL)
 	}
 	return nil
@@ -429,18 +430,41 @@ type StoreElasticSearch struct {
 	Index string
 }
 
+const typeName = "entity"
+
 // Put inserts the mongodoc.Entity into elasticsearch if elasticsearch
 // is configured.
-func (ses *StoreElasticSearch) Put(entity *mongodoc.Entity) error {
+func (ses *StoreElasticSearch) put(entity *mongodoc.Entity) error {
 	if ses == nil || ses.Database == nil {
 		return nil
 	}
-	return ses.PutDocument(ses.Index, "entity", ses.getID(entity), entity)
+	return ses.PutDocument(ses.Index, typeName, ses.getID(entity), entity)
 }
 
 // getID returns the id to be used for indexing the entity into ElasticSearch.
 func (ses *StoreElasticSearch) getID(entity *mongodoc.Entity) string {
 	return url.QueryEscape(entity.URL.String())
+}
+
+// Search searches for entities. The query is a json string which conforms
+// to the elasticsearch querydsl.
+// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html
+// Returns a slice containing each Id of the matching documents returned by
+// elasticsearch.
+func (ses *StoreElasticSearch) search(query string) ([]string, error) {
+	if ses == nil {
+		return nil, nil
+	}
+	results, err := ses.Database.Search(ses.Index, typeName, query)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(results.Hits.Hits))
+	for _, hit := range results.Hits.Hits {
+		ids = append(ids, hit.ID)
+	}
+	return ids, nil
+	// TODO: return more than just ids e.g. total, hits, score, information, serach time
 }
 
 // ExportToElasticSearch reads all of the mongodoc Entities and writes
@@ -450,7 +474,7 @@ func (store *Store) ExportToElasticSearch() error {
 	iter := store.DB.Entities().Find(nil).Iter()
 	defer iter.Close()
 	for iter.Next(&result) {
-		if err := store.ES.Put(&result); err != nil {
+		if err := store.ES.put(&result); err != nil {
 			return errgo.Notef(err, "cannot index %s", result.URL)
 		}
 	}
@@ -458,4 +482,90 @@ func (store *Store) ExportToElasticSearch() error {
 		return err
 	}
 	return nil
+}
+
+// SearchParams represents the search parameters used by the store.
+type SearchParams struct {
+	// The test for which to search.
+	Text string
+	// If autocomplete is specified, the search will return only charms and
+	// bundles with a name that has text as a prefix.
+	AutoComplete bool
+	// Limit the search to items with attributes that match the specified filter value.
+	Filters map[string][]string
+	// Limit the number of returned items to the specified count.
+	Limit int
+}
+
+// Search the store for the given SearchParams.
+// Returns a slice containing each Id of the matching documents returned by
+// elasticsearch.
+func (store *Store) Search(sp SearchParams) ([]string, error) {
+	query := createSearchDSL(sp)
+	return store.ES.search(query)
+}
+
+// createSearchDSL builds an elasticsearch query from the query parameters.
+// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html
+func createSearchDSL(sp SearchParams) string {
+	qdsl := elasticsearch.QueryDSL{
+		Size: sp.Limit,
+		Sort: []elasticsearch.Sort{{
+			Field: "UploadTime",
+			Order: elasticsearch.Order{"desc"}}},
+	}
+	var q elasticsearch.Query
+	if sp.Text == "" {
+		q.MatchAll = &elasticsearch.MatchAllQuery{}
+	} else if sp.AutoComplete {
+		// NOTE: just a prefix query for now, this will change.
+		q.Prefix = &elasticsearch.PrefixQuery{
+			"CharmMeta.Name": sp.Text,
+		}
+	} else {
+		q.Match = &elasticsearch.MatchQuery{
+			"CharmMeta.Name": sp.Text,
+		}
+	}
+
+	qdsl.Query = elasticsearch.Query{
+		Filtered: &elasticsearch.FilteredQuery{
+			Query:  &q,
+			Filter: createFilters(sp.Filters),
+		},
+	}
+
+	bytes, err := json.Marshal(qdsl)
+	if err != nil {
+		panic(err)
+	}
+	return string(bytes)
+}
+
+func createFilters(filters map[string][]string) *elasticsearch.Filter {
+	af := elasticsearch.AndFilter{}
+	for k, v := range filters {
+		of := elasticsearch.OrFilter{}
+		filterField := filterFields[k]
+		if filterField == "" {
+			filterField = k
+		}
+		for _, term := range v {
+			of = append(of, elasticsearch.Filter{
+				Term: &elasticsearch.TermFilter{
+					filterField: term,
+				},
+			})
+		}
+		af = append(af, elasticsearch.Filter{
+			Or: of,
+		})
+	}
+	return &elasticsearch.Filter{
+		And: af,
+	}
+}
+
+var filterFields = map[string]string{
+	"name": "CharmMeta.Name",
 }

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"sort"
 	"time"
@@ -56,9 +57,9 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool) {
 	// Ensure the document was indexed in ElasticSearch, if an ES database was provided.
 	if ses != nil {
 		var result mongodoc.Entity
-		err = ses.Database.GetDocument(ses.Index, "entity", ses.getID(&doc), &result)
+		err = ses.Database.GetDocument(ses.Index, typeName, ses.getID(&doc), &result)
 		c.Assert(err, gc.IsNil)
-		exists, err := ses.Database.EnsureID(ses.Index, "entity", ses.getID(&doc))
+		exists, err := ses.Database.EnsureID(ses.Index, typeName, ses.getID(&doc))
 		c.Assert(err, gc.IsNil)
 		c.Assert(exists, gc.Equals, true)
 	}
@@ -134,7 +135,7 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bool) 
 	// Ensure the document was indexed in ElasticSearch, if an ES database was provided.
 	if ses != nil {
 		var result mongodoc.Entity
-		err = ses.Database.GetDocument(ses.Index, "entity", ses.getID(&doc), &result)
+		err = ses.Database.GetDocument(ses.Index, typeName, ses.getID(&doc), &result)
 		c.Assert(err, gc.IsNil)
 	}
 
@@ -900,51 +901,17 @@ var fakeBlobSize, fakeBlobHash = func() (int64, string) {
 	return int64(len(b)), fmt.Sprintf("%x", h.Sum(nil))
 }()
 
-var exportTestCharms = map[string]string{
-	"wordpress": "cs:precise/wordpress-23",
-	"mysql":     "cs:precise/mysql-42",
-}
-
-func (s *StoreSuite) TestSuccessfulExport(c *gc.C) {
-	store, err := NewStore(s.Session.DB("juju_test"), &StoreElasticSearch{
-		Database: s.ES,
-		Index:    s.NewIndex(c),
-	})
-	c.Assert(err, gc.IsNil)
-	s.addCharmsToStore(store)
-	err = store.ExportToElasticSearch()
-	c.Assert(err, gc.IsNil)
-
-	for _, ref := range exportTestCharms {
-		var expected mongodoc.Entity
-		var actual mongodoc.Entity
-		err = store.DB.Entities().FindId(ref).One(&expected)
-		c.Assert(err, gc.IsNil)
-		err = s.ES.GetDocument(store.ES.Index, "entity", store.ES.getID(&expected), &actual)
-		c.Assert(err, gc.IsNil)
-		// make sure everything agrees on the time zone
-		// TODO(mhilton) separate the functionality for comparing mongodoc.Entitys
-		// if that needs to be performed in other places
-		expected.UploadTime = expected.UploadTime.In(time.UTC)
-		actual.UploadTime = actual.UploadTime.In(time.UTC)
-		c.Assert(actual, jc.DeepEquals, expected)
-	}
-}
-
-func (s *StoreSuite) addCharmsToStore(store *Store) {
-	for name, ref := range exportTestCharms {
-		charmArchive := testing.Charms.CharmDir(name)
-		url := mustParseReference(ref)
-		store.AddCharmWithArchive(url, charmArchive)
-	}
-}
-
-func (s *StoreSuite) TestSESPutIsNoopWithNoESConfigured(c *gc.C) {
+func (s *StoreSuite) TestSESPutDoesNotErrorWithNoESConfigured(c *gc.C) {
 	store, err := NewStore(s.Session.DB("mongodoctoelasticsearch"), nil)
 	c.Assert(err, gc.IsNil)
 	var entity mongodoc.Entity
-	err = store.ES.Put(&entity)
+	err = store.ES.put(&entity)
 	c.Assert(err, gc.IsNil)
+}
+
+type StoreSearchSuite struct {
+	storetesting.IsolatedMgoESSuite
+	store *Store
 }
 
 func (s *StoreSuite) TestAddCharmDirIndexed(c *gc.C) {
@@ -968,4 +935,141 @@ func (s *StoreSuite) TestAddBundleArchiveIndexed(c *gc.C) {
 	)
 	c.Assert(err, gc.IsNil)
 	s.checkAddBundle(c, bundleArchive, true)
+}
+
+var _ = gc.Suite(&StoreSearchSuite{})
+
+func (s *StoreSearchSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoESSuite.SetUpTest(c)
+	store, err := NewStore(s.Session.DB("foo"), &StoreElasticSearch{
+		Database: s.ES,
+		Index:    s.TestIndex,
+	})
+	c.Assert(err, gc.IsNil)
+	s.store = store
+	s.addCharmsToStore(store)
+}
+
+var exportTestCharms = map[string]string{
+	"wordpress": "cs:precise/wordpress-23",
+	"mysql":     "cs:precise/mysql-42",
+}
+
+func (s *StoreSearchSuite) TestSuccessfulExport(c *gc.C) {
+	err := s.store.ExportToElasticSearch()
+	c.Assert(err, gc.IsNil)
+
+	for _, ref := range exportTestCharms {
+		var expected mongodoc.Entity
+		var actual mongodoc.Entity
+		err = s.store.DB.Entities().FindId(ref).One(&expected)
+		c.Assert(err, gc.IsNil)
+		err = s.store.ES.GetDocument(s.TestIndex, typeName, url.QueryEscape(ref), &actual)
+		c.Assert(err, gc.IsNil)
+		// make sure everything agrees on the time zone
+		// TODO(mhilton) separate the functionality for comparing mongodoc.Entitys
+		// if that needs to be performed in other places
+		expected.UploadTime = expected.UploadTime.In(time.UTC)
+		actual.UploadTime = actual.UploadTime.In(time.UTC)
+		c.Assert(actual, jc.DeepEquals, expected)
+	}
+}
+
+func (s *StoreSearchSuite) addCharmsToStore(store *Store) {
+	for name, ref := range exportTestCharms {
+		charmArchive := testing.Charms.CharmDir(name)
+		url := mustParseReference(ref)
+		store.AddCharmWithArchive(url, charmArchive)
+	}
+}
+
+func (s *StoreSearchSuite) TestBasicTextSearch(c *gc.C) {
+	err := s.store.ExportToElasticSearch()
+	c.Assert(err, gc.IsNil)
+	s.store.ES.Database.RefreshIndex(s.TestIndex)
+	sp := SearchParams{
+		Text: "wordpress",
+	}
+	ids, err := s.store.Search(sp)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ids, jc.DeepEquals, []string{url.QueryEscape(exportTestCharms["wordpress"])})
+}
+
+func (s *StoreSearchSuite) TestBlankTextSearch(c *gc.C) {
+	err := s.store.ExportToElasticSearch()
+	s.store.ES.Database.RefreshIndex(s.TestIndex)
+	c.Assert(err, gc.IsNil)
+	sp := SearchParams{
+		Text: "",
+	}
+	ids, err := s.store.Search(sp)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ids, jc.SameContents, []string{
+		url.QueryEscape(exportTestCharms["wordpress"]),
+		url.QueryEscape(exportTestCharms["mysql"]),
+	})
+}
+
+func (s *StoreSearchSuite) TestLimitTestSearch(c *gc.C) {
+	charmArchive := testing.Charms.CharmDir("wordpress")
+	ref := mustParseReference(exportTestCharms["wordpress"])
+	ref.Revision += 1
+	s.store.AddCharmWithArchive(ref, charmArchive)
+
+	err := s.store.ExportToElasticSearch()
+	s.store.ES.Database.RefreshIndex(s.TestIndex)
+	c.Assert(err, gc.IsNil)
+	sp := SearchParams{
+		Text:  "wordpress",
+		Limit: 1,
+	}
+	ids, err := s.store.Search(sp)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ids, jc.SameContents, []string{
+		url.QueryEscape(ref.String()),
+	})
+
+}
+
+func (s *StoreSearchSuite) TestAutoCompleteSearch(c *gc.C) {
+	err := s.store.ExportToElasticSearch()
+	c.Assert(err, gc.IsNil)
+	s.store.ES.Database.RefreshIndex(s.TestIndex)
+	sp := SearchParams{
+		Text:         "word",
+		AutoComplete: true,
+	}
+	ids, err := s.store.Search(sp)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ids, jc.DeepEquals, []string{url.QueryEscape(exportTestCharms["wordpress"])})
+}
+
+func (s *StoreSearchSuite) TestFilteredSearchWithNameAlias(c *gc.C) {
+	err := s.store.ExportToElasticSearch()
+	c.Assert(err, gc.IsNil)
+	s.store.ES.Database.RefreshIndex(s.TestIndex)
+	sp := SearchParams{
+		Text: "",
+		Filters: map[string][]string{
+			"name": {"mysql"},
+		},
+	}
+	ids, err := s.store.Search(sp)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ids, jc.DeepEquals, []string{url.QueryEscape(exportTestCharms["mysql"])})
+}
+
+func (s *StoreSearchSuite) TestFilteredSearchWithUnAliasedField(c *gc.C) {
+	err := s.store.ExportToElasticSearch()
+	c.Assert(err, gc.IsNil)
+	s.store.ES.Database.RefreshIndex(s.TestIndex)
+	sp := SearchParams{
+		Text: "",
+		Filters: map[string][]string{
+			"CharmMeta.Name": {"mysql"},
+		},
+	}
+	ids, err := s.store.Search(sp)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ids, jc.DeepEquals, []string{url.QueryEscape(exportTestCharms["mysql"])})
 }

--- a/internal/elasticsearch/query.go
+++ b/internal/elasticsearch/query.go
@@ -1,0 +1,76 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package elasticsearch
+
+import "encoding/json"
+
+// Query represents a query in the elasticsearch DSL.
+// Only one of the query types should be used at once.
+type Query struct {
+	Filtered *FilteredQuery `json:"filtered,omitempty"`
+	Match    *MatchQuery    `json:"match,omitempty"`
+	MatchAll *MatchAllQuery `json:"match_all,omitempty"`
+	Prefix   *PrefixQuery   `json:"prefix,omitempty"`
+}
+
+// MatchAllQuery provides a query that matches all
+// documents in the index.
+type MatchAllQuery struct {
+}
+
+// MatchQuery provides a query that matches against
+// a complete field.
+type MatchQuery map[string]interface{}
+
+// PrefixQuery provides a query that matches against
+// the start of a field.
+type PrefixQuery map[string]interface{}
+
+// Filtered Query provides a query that can be
+// subsequently filtered.
+type FilteredQuery struct {
+	Query  *Query  `json:"query,omitempty"`
+	Filter *Filter `json:"filter,omitempty"`
+}
+
+// Filter represents a filter in the elasticsearch DSL.
+type Filter struct {
+	And  AndFilter   `json:"and,omitempty"`
+	Or   OrFilter    `json:"or,omitempty"`
+	Term *TermFilter `json:"term,omitempty"`
+}
+
+// AndFilter provides a filter that requires all of the internal
+// filters to match.
+type AndFilter []Filter
+
+// OrFilter provides a filter that requires any of the internal
+// filters to match.
+type OrFilter []Filter
+
+// TermFilter provides a filter that requires a field to match.
+type TermFilter map[string]string
+
+// QueryDSL provides a structure to put together a query using the
+// elasticsearch DSL.
+type QueryDSL struct {
+	Size  int    `json:"size,omitempty"`
+	Query Query  `json:"query,omitempty"`
+	Sort  []Sort `json:"sort,omitempty"`
+}
+
+type Sort struct {
+	Field string
+	Order Order
+}
+
+type Order struct {
+	Order string `json:"order"`
+}
+
+func (s Sort) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]Order{
+		s.Field: {s.Order.Order},
+	})
+}

--- a/internal/storetesting/elasticsearch.go
+++ b/internal/storetesting/elasticsearch.go
@@ -45,8 +45,9 @@ func ElasticSearchTestPackage(t *testing.T, cb func(t *testing.T)) {
 }
 
 type ElasticSearchSuite struct {
-	ES      *elasticsearch.Database
-	Indexes []string
+	ES        *elasticsearch.Database
+	indexes   []string
+	TestIndex string
 }
 
 func (s *ElasticSearchSuite) SetUpSuite(c *gc.C) {
@@ -57,13 +58,14 @@ func (s *ElasticSearchSuite) TearDownSuite(c *gc.C) {
 }
 
 func (s *ElasticSearchSuite) SetUpTest(c *gc.C) {
-	s.NewIndex(c)
+	s.TestIndex = s.NewIndex(c)
 }
 
 func (s *ElasticSearchSuite) TearDownTest(c *gc.C) {
-	for _, index := range s.Indexes {
+	for _, index := range s.indexes {
 		s.ES.DeleteIndex(index)
 	}
+	s.indexes = nil
 }
 
 // NewIndex creates a new index name and ensures that it will be cleaned up at
@@ -72,6 +74,6 @@ func (s *ElasticSearchSuite) NewIndex(c *gc.C) string {
 	uuid, err := utils.NewUUID()
 	c.Assert(err, gc.IsNil)
 	id := time.Now().Format("20060102") + uuid.String() + "-"
-	s.Indexes = append(s.Indexes, id)
+	s.indexes = append(s.indexes, id)
 	return id
 }

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -41,7 +41,7 @@ func New(store *charmstore.Store, config charmstore.ServerParams) *Handler {
 			"changes/published":  router.HandleJSON(h.serveChangesPublished),
 			"debug":              http.HandlerFunc(h.serveDebug),
 			"debug/status":       router.HandleJSON(h.serveDebugStatus),
-			"search":             http.HandlerFunc(h.serveSearch),
+			"search":             router.HandleJSON(h.serveSearch),
 			"search/interesting": http.HandlerFunc(h.serveSearchInteresting),
 			"stats/":             router.NotFoundHandler(),
 			"stats/counter/":     router.HandleJSON(h.serveStatsCounter),
@@ -214,18 +214,6 @@ func parseBool(value string) (bool, error) {
 }
 
 var errNotImplemented = errgo.Newf("method not implemented")
-
-// GET search[?text=text][&autocomplete=1][&filter=value…][&limit=limit][&include=meta]
-// http://tinyurl.com/qzobc69
-func (h *Handler) serveSearch(w http.ResponseWriter, req *http.Request) {
-	router.WriteError(w, errNotImplemented)
-}
-
-// GET search/interesting[?limit=limit][&include=meta]
-// http://tinyurl.com/ntmdrg8
-func (h *Handler) serveSearchInteresting(w http.ResponseWriter, req *http.Request) {
-	router.WriteError(w, errNotImplemented)
-}
 
 // GET /debug
 // http://tinyurl.com/m63xhz8

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -30,11 +30,13 @@ func (h *Handler) metaCharmRelated(entity *mongodoc.Entity, id *charm.Reference,
 	// Build the query to retrieve the related entities.
 	query := bson.M{
 		"$or": []bson.M{
-			bson.M{"charmrequiredinterfaces": bson.M{
-				"$elemMatch": bson.M{"$in": entity.CharmProvidedInterfaces},
+			{"charmrequiredinterfaces": bson.M{
+				"$elemMatch": bson.M{
+					"$in": entity.CharmProvidedInterfaces},
 			}},
-			bson.M{"charmprovidedinterfaces": bson.M{
-				"$elemMatch": bson.M{"$in": entity.CharmRequiredInterfaces},
+			{"charmprovidedinterfaces": bson.M{
+				"$elemMatch": bson.M{
+					"$in": entity.CharmRequiredInterfaces},
 			}},
 		},
 	}

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -117,15 +117,15 @@ var metaCharmRelatedTests = []struct {
 	id:     "utopic/wordpress-0",
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
-			"memcache": []params.MetaAnyResponse{{
+			"memcache": {{
 				Id: mustParseReference("utopic/memcached-42"),
 			}},
-			"mount": []params.MetaAnyResponse{{
+			"mount": {{
 				Id: mustParseReference("precise/nfs-1"),
 			}},
 		},
 		Requires: map[string][]params.MetaAnyResponse{
-			"http": []params.MetaAnyResponse{{
+			"http": {{
 				Id: mustParseReference("precise/haproxy-48"),
 			}, {
 				Id: mustParseReference("trusty/haproxy-47"),
@@ -138,7 +138,7 @@ var metaCharmRelatedTests = []struct {
 	id:     "trusty/haproxy-47",
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
-			"http": []params.MetaAnyResponse{{
+			"http": {{
 				Id: mustParseReference("utopic/wordpress-0"),
 			}},
 		},
@@ -149,7 +149,7 @@ var metaCharmRelatedTests = []struct {
 	id:     "utopic/memcached-42",
 	expectBody: params.RelatedResponse{
 		Requires: map[string][]params.MetaAnyResponse{
-			"memcache": []params.MetaAnyResponse{{
+			"memcache": {{
 				Id: mustParseReference("utopic/wordpress-0"),
 			}},
 		},
@@ -229,7 +229,7 @@ var metaCharmRelatedTests = []struct {
 	id: "trusty/wordpress-0",
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
-			"memcache": []params.MetaAnyResponse{{
+			"memcache": {{
 				Id: mustParseReference("utopic/memcached-1"),
 			}, {
 				Id: mustParseReference("utopic/memcached-2"),
@@ -313,14 +313,14 @@ var metaCharmRelatedTests = []struct {
 	id: "trusty/wordpress-0",
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
-			"memcache": []params.MetaAnyResponse{{
+			"memcache": {{
 				Id: mustParseReference("utopic/memcached-1"),
 			}, {
 				Id: mustParseReference("utopic/memcached-2"),
 			}, {
 				Id: mustParseReference("utopic/redis-90"),
 			}},
-			"mount": []params.MetaAnyResponse{{
+			"mount": {{
 				Id: mustParseReference("precise/nfs-42"),
 			}, {
 				Id: mustParseReference("precise/nfs-47"),
@@ -336,7 +336,7 @@ var metaCharmRelatedTests = []struct {
 	querystring: "?include=archive-size&include=charm-metadata",
 	expectBody: params.RelatedResponse{
 		Requires: map[string][]params.MetaAnyResponse{
-			"mount": []params.MetaAnyResponse{{
+			"mount": {{
 				Id: mustParseReference("utopic/wordpress-0"),
 				Meta: map[string]interface{}{
 					"archive-size": params.ArchiveSizeResponse{Size: fakeBlobSize},

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -1,0 +1,82 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4
+
+import (
+	//	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/juju/errgo"
+
+	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/router"
+	"github.com/juju/charmstore/params"
+)
+
+// GET search[?text=text][&autocomplete=1][&filter=value…][&limit=limit][&include=meta]
+// http://tinyurl.com/qzobc69
+func (h *Handler) serveSearch(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+	sp, err := parseSearchParams(req)
+	if err != nil {
+		return "", err
+	}
+	// perform query
+	ids, err := h.store.Search(sp.SearchParams)
+	if err != nil {
+		router.WriteError(w, errgo.Notef(err, "error performing search"))
+	}
+	results := []params.SearchResult{}
+	for _, id := range ids {
+		sr := params.SearchResult{Id: id}
+		// TODO (mhilton) get metadata
+		results = append(results, sr)
+	}
+	return results, nil
+}
+
+// GET search/interesting[?limit=limit][&include=meta]
+// http://tinyurl.com/ntmdrg8
+func (h *Handler) serveSearchInteresting(w http.ResponseWriter, req *http.Request) {
+	router.WriteError(w, errNotImplemented)
+}
+
+type searchParams struct {
+	charmstore.SearchParams
+	Include []string
+}
+
+// parseSearchParms extracts the search paramaters from the request
+func parseSearchParams(req *http.Request) (searchParams, error) {
+	var sp searchParams
+	var err error
+	for k, v := range req.Form {
+		switch k {
+		case "text":
+			sp.Text = v[0]
+		case "autocomplete":
+			sp.AutoComplete, err = parseBool(v[0])
+			if err != nil {
+				return searchParams{}, badRequestf(err, "invalid autocomplete parameter")
+			}
+		case "limit":
+			sp.Limit, err = strconv.Atoi(v[0])
+			if err != nil {
+				return searchParams{}, badRequestf(err, "invalid limit parameter: could not parse integer")
+			}
+			if sp.Limit < 1 {
+				return searchParams{}, badRequestf(err, "invalid limit parameter: expected integer greater than zero")
+			}
+		case "include":
+			sp.Include = v
+		default:
+			if sp.Filters == nil {
+				sp.Filters = map[string][]string{}
+			}
+			sp.Filters[k] = v
+		}
+	}
+
+	return sp, nil
+}

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -1,0 +1,63 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4
+
+import (
+	"net/http"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/charmstore/internal/storetesting"
+)
+
+type SearchSuite struct {
+	storetesting.IsolatedMgoESSuite
+}
+
+var _ = gc.Suite(&SearchSuite{})
+
+func (s *SearchSuite) TestParseSearchParamsText(c *gc.C) {
+	var req http.Request
+	req.Form = map[string][]string{"text": {"test text"}}
+	sp, err := parseSearchParams(&req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(sp.Text, gc.Equals, "test text")
+}
+
+func (s *SearchSuite) TestParseSearchParamsAutocompete(c *gc.C) {
+	var req http.Request
+	req.Form = map[string][]string{"autocomplete": {"1"}}
+	sp, err := parseSearchParams(&req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(sp.AutoComplete, gc.Equals, true)
+}
+
+func (s *SearchSuite) TestParseSearchParamsFilters(c *gc.C) {
+	var req http.Request
+	req.Form = map[string][]string{
+		"f1": {"f11", "f12"},
+		"f2": {"f21"},
+	}
+	sp, err := parseSearchParams(&req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(sp.Filters["f1"], jc.DeepEquals, []string{"f11", "f12"})
+	c.Assert(sp.Filters["f2"], jc.DeepEquals, []string{"f21"})
+}
+
+func (s *SearchSuite) TestParseSearchParamsLimit(c *gc.C) {
+	var req http.Request
+	req.Form = map[string][]string{"limit": {"20"}}
+	sp, err := parseSearchParams(&req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(sp.Limit, gc.Equals, 20)
+}
+
+func (s *SearchSuite) TestParseSearchParamsInclude(c *gc.C) {
+	var req http.Request
+	req.Form = map[string][]string{"include": {"meta1", "meta2"}}
+	sp, err := parseSearchParams(&req)
+	c.Assert(err, gc.IsNil)
+	c.Assert(sp.Include, jc.DeepEquals, []string{"meta1", "meta2"})
+}

--- a/params/params.go
+++ b/params/params.go
@@ -88,3 +88,14 @@ type DebugStatus struct {
 	Value  string
 	Passed bool
 }
+
+// SearchResult holds a single result from a search operation
+type SearchResult struct {
+	Id string
+	// Meta holds at most one entry for each meta value
+	// specified in the include flags, holding the
+	// data that would be returned by reading /meta/meta?id=id.
+	// Metadata not relevant to a particular result will not
+	// be included.
+	Meta map[string]interface{} `json:",omitempty"`
+}


### PR DESCRIPTION
This change includes functionality to parse the search API parameters, build a search DSL and perform the search against elasticsearch.
