### PR TITLE
all: update to use errgo.v1

### DIFF
--- a/cmd/charmload/main.go
+++ b/cmd/charmload/main.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/errgo"
 	"github.com/juju/loggo"
+	"gopkg.in/errgo.v1"
 	"launchpad.net/lpad"
 
 	"github.com/juju/charmstore/config"

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/yaml.v1"
 )
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,9 +10,10 @@ github.com/juju/names	git	cfcf5a79106d26fce039a35ffca277def4496f4b
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	
 github.com/juju/testing	git	cc1a29452f9a9af7a54c3a2af495fbf5cd64c640	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
-github.com/juju/utils	git	e33796665b926ce6ff7766a5884aa9f8ab7e540c	
+github.com/juju/utils	git	e4e59c6fe058bce0da468ba70943afba85b11cd5	
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
-gopkg.in/juju/charm.v4	git	c2fca34024c7781bc5618af6fda4c180addeb909	
+gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	
+gopkg.in/juju/charm.v4	git	60ba92340ee6a4bc963da0b3e3d485ecac0f3b49	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/yaml.v1	git	1b9791953ba4027efaeb728c7355e542a203be5e	
 launchpad.net/lpad	bzr	gustavo@niemeyer.net-20131113112110-fqow8xpml1pxyutb	65

--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 
 	"github.com/juju/blobstore"
-	"github.com/juju/errgo"
 	"github.com/juju/errors"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2"
 )
 

--- a/internal/charmstore/archive.go
+++ b/internal/charmstore/archive.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/internal/blobstore"

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -9,7 +9,7 @@ package charmstore
 import (
 	"net/http"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2"
 
 	"github.com/juju/charmstore/internal/elasticsearch"

--- a/internal/charmstore/stats.go
+++ b/internal/charmstore/stats.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -13,9 +13,9 @@ import (
 	"sort"
 	"time"
 
-	"github.com/juju/errgo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/juju/charm.v4/testing"
 

--- a/internal/elasticsearch/elasticsearch.go
+++ b/internal/elasticsearch/elasticsearch.go
@@ -19,8 +19,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/juju/errgo"
 	"github.com/juju/loggo"
+	"gopkg.in/errgo.v1"
 )
 
 var log = loggo.GetLogger("charmstore.elasticsearch")

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"

--- a/internal/router/fieldinclude.go
+++ b/internal/router/fieldinclude.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 )
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -14,8 +14,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/errgo"
 	"github.com/juju/utils/jsonhttp"
+	"gopkg.in/errgo.v1"
 	charm "gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/params"

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -16,11 +16,11 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/juju/errgo"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/jsonhttp"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/internal/storetesting"

--- a/internal/router/singleinclude.go
+++ b/internal/router/singleinclude.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 )
 

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/juju/errgo"
 	"github.com/juju/utils/jsonhttp"
+	"gopkg.in/errgo.v1"
 
 	"github.com/juju/charmstore/params"
 )

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/errgo"
 	"github.com/juju/utils/jsonhttp"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/errgo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 	charmtesting "gopkg.in/juju/charm.v4/testing"
 	"gopkg.in/mgo.v2"

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -15,8 +15,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/errgo"
 	"github.com/juju/utils/jsonhttp"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2/bson"
 

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 
 	"github.com/juju/charmstore/params"
 )

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -6,7 +6,7 @@ package v4
 import (
 	"net/url"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2/bson"
 

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -3,12 +3,11 @@
 
 package v4
 
-import (
-	//	"encoding/json"
+import ( //	"encoding/json"
 	"net/http"
 	"strconv"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/router"

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/internal/charmstore"

--- a/lppublish/legacy.go
+++ b/lppublish/legacy.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/params"

--- a/lppublish/lpad.go
+++ b/lppublish/lpad.go
@@ -19,9 +19,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/errgo"
 	"github.com/juju/loggo"
 	"github.com/juju/utils/fs"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/juju/charm.v4/migratebundle"
 	"gopkg.in/yaml.v1"


### PR DESCRIPTION
This is the new canonical location for the errgo package.
