### PR TITLE
csclient: new package

### DIFF
--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -1,0 +1,119 @@
+// The csclient package provides access to the charm store API.
+package csclient
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/juju/errgo"
+
+	"github.com/juju/charmstore/params"
+)
+
+const apiVersion = "v4"
+
+// Client represents the client side of a charm store.
+type Client struct {
+	params Params
+}
+
+// Params holds parameters for creating a new charm store client.
+type Params struct {
+	// URL holds the root endpoint URL of the charmstore,
+	// with no trailing slash, not including the version.
+	// For example http://charms.ubuntu.com
+	// TODO default this to global charm store address.
+	URL string
+
+	// User and Password hold the authentication credentials
+	// for the client. If User is empty, no credentials will be
+	// sent.
+	User     string
+	Password string
+
+	// HTTPClient holds the HTTP client to use when making
+	// requests to the store. If nil, http.DefaultClient will
+	// be used.
+	HTTPClient *http.Client
+}
+
+// New returns a new charm store client.
+func New(p Params) *Client {
+	if p.HTTPClient == nil {
+		p.HTTPClient = http.DefaultClient
+	}
+	return &Client{
+		params: p,
+	}
+}
+
+// Do makes an arbitrary request to the charm store.
+// It adds appropriate headers to the given HTTP request,
+// sends it to the charm store and parses the result
+// as JSON into the given result value, which should be a pointer to the
+// expected data, but may be nil if no result is expected.
+//
+// The URL field in the request is ignored and overwritten.
+//
+// This is a low level method - more specific Client methods
+// should be used when possible.
+func (c *Client) Do(req *http.Request, path string, result interface{}) error {
+	if c.params.User != "" {
+		userPass := c.params.User + ":" + c.params.Password
+		authBasic := base64.StdEncoding.EncodeToString([]byte(userPass))
+		req.Header.Set("Authorization", "Basic "+authBasic)
+	}
+
+	// Prepare the request.
+	if !strings.HasPrefix(path, "/") {
+		return errgo.Newf("path %q is not absolute", path)
+	}
+	u, err := url.Parse(c.params.URL + "/" + apiVersion + path)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	req.URL = u
+
+	// Send the request.
+	resp, err := c.params.HTTPClient.Do(req)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	defer resp.Body.Close()
+
+	// Parse the response.
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errgo.Notef(err, "cannot read response body")
+	}
+	if resp.StatusCode != http.StatusOK {
+		var perr params.Error
+		if err := json.Unmarshal(data, &perr); err != nil {
+			return errgo.Notef(err, "cannot unmarshal error response %q", sizeLimit(data))
+		}
+		if perr.Message == "" {
+			return errgo.Newf("error response with empty message %s", sizeLimit(data))
+		}
+		return &perr
+	}
+	if result == nil {
+		// The caller doesn't care about the response body.
+		return nil
+	}
+	if err := json.Unmarshal(data, result); err != nil {
+		return errgo.Notef(err, "cannot unmarshal response %q", sizeLimit(data))
+	}
+	return nil
+}
+
+func sizeLimit(data []byte) []byte {
+	if len(data) < 1024 {
+		return data
+	}
+	return append(data[0:1024], fmt.Sprintf(" ... [%d bytes omitted]", len(data)-1024)...)
+}

--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -112,8 +112,9 @@ func (c *Client) Do(req *http.Request, path string, result interface{}) error {
 }
 
 func sizeLimit(data []byte) []byte {
-	if len(data) < 1024 {
+	const max = 1024
+	if len(data) < max {
 		return data
 	}
-	return append(data[0:1024], fmt.Sprintf(" ... [%d bytes omitted]", len(data)-1024)...)
+	return append(data[0:max], fmt.Sprintf(" ... [%d bytes omitted]", len(data)-max)...)
 }

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -66,6 +66,7 @@ var doTests = []struct {
 	about           string
 	method          string
 	path            string
+	nilResult       bool
 	expectResult    interface{}
 	expectError     string
 	expectErrorCode params.ErrorCode
@@ -76,9 +77,9 @@ var doTests = []struct {
 		Id: "cs:utopic/wordpress-42",
 	}},
 }, {
-	about:        "success with nil result",
-	path:         "/wordpress/expand-id",
-	expectResult: nil,
+	about:     "success with nil result",
+	path:      "/wordpress/expand-id",
+	nilResult: true,
 }, {
 	about:       "non-absolute path",
 	path:        "wordpress",
@@ -114,7 +115,7 @@ func (s *suite) TestDo(c *gc.C) {
 		// Send the request.
 		var result json.RawMessage
 		var resultPtr interface{}
-		if test.expectResult != nil {
+		if !test.nilResult {
 			resultPtr = &result
 		}
 		err = s.client.Do(req, test.path, resultPtr)

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -1,0 +1,298 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package csclient_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v4"
+	charmtesting "gopkg.in/juju/charm.v4/testing"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/charmstore/csclient"
+	"github.com/juju/charmstore/internal/charmstore"
+	"github.com/juju/charmstore/internal/storetesting"
+	"github.com/juju/charmstore/internal/v4"
+	"github.com/juju/charmstore/params"
+)
+
+type suite struct {
+	storetesting.IsolatedMgoSuite
+	client *csclient.Client
+	srv    *httptest.Server
+	store  *charmstore.Store
+}
+
+var _ = gc.Suite(&suite{})
+
+var serverParams = charmstore.ServerParams{
+	AuthUsername: "test-user",
+	AuthPassword: "test-password",
+}
+
+func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (*httptest.Server, *charmstore.Store) {
+	db := session.DB("charmstore")
+	store, err := charmstore.NewStore(db, nil)
+	c.Assert(err, gc.IsNil)
+	handler, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
+	c.Assert(err, gc.IsNil)
+	return httptest.NewServer(handler), store
+}
+
+func (s *suite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	s.srv, s.store = newServer(c, s.Session, serverParams)
+	s.client = csclient.New(csclient.Params{
+		URL:      s.srv.URL,
+		User:     serverParams.AuthUsername,
+		Password: serverParams.AuthPassword,
+	})
+}
+
+func (s *suite) TearDownTest(c *gc.C) {
+	s.srv.Close()
+	s.IsolatedMgoSuite.TearDownTest(c)
+}
+
+var doTests = []struct {
+	about           string
+	method          string
+	path            string
+	expectResult    interface{}
+	expectError     string
+	expectErrorCode params.ErrorCode
+}{{
+	about: "success",
+	path:  "/wordpress/expand-id",
+	expectResult: []params.ExpandedId{{
+		Id: "cs:utopic/wordpress-42",
+	}},
+}, {
+	about:        "success with nil result",
+	path:         "/wordpress/expand-id",
+	expectResult: nil,
+}, {
+	about:       "non-absolute path",
+	path:        "wordpress",
+	expectError: `path "wordpress" is not absolute`,
+}, {
+	about:       "URL parse error",
+	path:        "/wordpress/%zz",
+	expectError: `parse .*: invalid URL escape "%zz"`,
+}, {
+	about:           "result with error code",
+	path:            "/blahblah",
+	expectError:     "not found",
+	expectErrorCode: params.ErrNotFound,
+}}
+
+func (s *suite) TestDo(c *gc.C) {
+	ch := charmtesting.Charms.CharmDir("wordpress")
+	url := mustParseReference("utopic/wordpress-42")
+	err := s.store.AddCharmWithArchive(url, ch)
+	c.Assert(err, gc.IsNil)
+
+	for i, test := range doTests {
+		c.Logf("test %d: %s", i, test.about)
+
+		if test.method == "" {
+			test.method = "GET"
+		}
+
+		// Set up the request.
+		req, err := http.NewRequest(test.method, "", nil)
+		c.Assert(err, gc.IsNil)
+
+		// Send the request.
+		var result json.RawMessage
+		var resultPtr interface{}
+		if test.expectResult != nil {
+			resultPtr = &result
+		}
+		err = s.client.Do(req, test.path, resultPtr)
+
+		// Check the response.
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError, gc.Commentf("error is %T; %#v", err, err))
+			c.Assert(result, gc.IsNil)
+			cause := errgo.Cause(err)
+			if code, ok := cause.(params.ErrorCode); ok {
+				c.Assert(code, gc.Equals, test.expectErrorCode)
+			} else {
+				c.Assert(test.expectErrorCode, gc.Equals, params.ErrorCode(""))
+			}
+			continue
+		}
+		c.Assert(err, gc.IsNil)
+		if test.expectResult != nil {
+			c.Assert([]byte(result), storetesting.JSONEquals, test.expectResult)
+		}
+	}
+}
+
+func (s *suite) TestDoAuthorization(c *gc.C) {
+	// Add a charm to be deleted.
+	ch := charmtesting.Charms.CharmDir("wordpress")
+	url := mustParseReference("utopic/wordpress-42")
+	err := s.store.AddCharmWithArchive(url, ch)
+	c.Assert(err, gc.IsNil)
+
+	// Check that when we use incorrect authorization,
+	// we get an error trying to delete the charm
+	client := csclient.New(csclient.Params{
+		URL:      s.srv.URL,
+		User:     serverParams.AuthUsername,
+		Password: "bad password",
+	})
+	req, err := http.NewRequest("DELETE", "", nil)
+	c.Assert(err, gc.IsNil)
+	err = client.Do(req, "/utopic/wordpress-42/archive", nil)
+	c.Assert(err, gc.ErrorMatches, "invalid user name or password")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrUnauthorized)
+
+	// Check that it's still there.
+	req, err = http.NewRequest("GET", "", nil)
+	err = client.Do(req, "/utopic/wordpress-42/expand-id", nil)
+	c.Assert(err, gc.IsNil)
+
+	// Then check that when we use the correct authorization,
+	// the delete succeeds.
+	client = csclient.New(csclient.Params{
+		URL:      s.srv.URL,
+		User:     serverParams.AuthUsername,
+		Password: serverParams.AuthPassword,
+	})
+	req, err = http.NewRequest("DELETE", "", nil)
+	c.Assert(err, gc.IsNil)
+	err = client.Do(req, "/utopic/wordpress-42/archive", nil)
+	c.Assert(err, gc.IsNil)
+
+	// Check that it's now really gone.
+	req, err = http.NewRequest("GET", "", nil)
+	err = client.Do(req, "/utopic/wordpress-42/expand-id", nil)
+	c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for "cs:wordpress"`)
+}
+
+var doWithBadResponseTests = []struct {
+	about       string
+	error       error
+	response    *http.Response
+	responseErr error
+	expectError string
+}{{
+	about:       "http client Do failure",
+	error:       errgo.New("round trip failure"),
+	expectError: "Get .*: round trip failure",
+}, {
+	about: "body read error",
+	response: &http.Response{
+		Status:        "200 OK",
+		StatusCode:    200,
+		Proto:         "HTTP/1.0",
+		ProtoMajor:    1,
+		ProtoMinor:    0,
+		Body:          ioutil.NopCloser(&errorReader{"body read error"}),
+		ContentLength: -1,
+	},
+	expectError: "cannot read response body: body read error",
+}, {
+	about: "badly formatted json response",
+	response: &http.Response{
+		Status:        "200 OK",
+		StatusCode:    200,
+		Proto:         "HTTP/1.0",
+		ProtoMajor:    1,
+		ProtoMinor:    0,
+		Body:          ioutil.NopCloser(strings.NewReader("bad")),
+		ContentLength: -1,
+	},
+	expectError: `cannot unmarshal response "bad": .*`,
+}, {
+	about: "badly formatted json error",
+	response: &http.Response{
+		Status:        "404 Not found",
+		StatusCode:    404,
+		Proto:         "HTTP/1.0",
+		ProtoMajor:    1,
+		ProtoMinor:    0,
+		Body:          ioutil.NopCloser(strings.NewReader("bad")),
+		ContentLength: -1,
+	},
+	expectError: `cannot unmarshal error response "bad": .*`,
+}, {
+	about: "error response with empty message",
+	response: &http.Response{
+		Status:     "404 Not found",
+		StatusCode: 404,
+		Proto:      "HTTP/1.0",
+		ProtoMajor: 1,
+		ProtoMinor: 0,
+		Body: ioutil.NopCloser(bytes.NewReader(mustMarshalJSON(&params.Error{
+			Code: "foo",
+		}))),
+		ContentLength: -1,
+	},
+	expectError: "error response with empty message .*",
+}}
+
+func (s *suite) TestDoWithBadResponse(c *gc.C) {
+	for i, test := range doWithBadResponseTests {
+		c.Logf("test %d: %s", i, test.about)
+		cl := csclient.New(csclient.Params{
+			URL: "http://0.1.2.3",
+			HTTPClient: &http.Client{
+				Transport: &cannedRoundTripper{
+					resp:  test.response,
+					error: test.error,
+				},
+			},
+		})
+		var result interface{}
+		err := cl.Do(&http.Request{
+			Method: "GET",
+		}, "/foo", &result)
+		c.Assert(err, gc.ErrorMatches, test.expectError)
+	}
+}
+
+type errorReader struct {
+	error string
+}
+
+func (e *errorReader) Read(buf []byte) (int, error) {
+	return 0, errgo.New(e.error)
+}
+
+type cannedRoundTripper struct {
+	resp  *http.Response
+	error error
+}
+
+func (r *cannedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return r.resp, r.error
+}
+
+func mustParseReference(url string) *charm.Reference {
+	// TODO implement MustParseReference in charm.
+	ref, err := charm.ParseReference(url)
+	if err != nil {
+		panic(err)
+	}
+	return ref
+}
+
+func mustMarshalJSON(x interface{}) []byte {
+	data, err := json.Marshal(x)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/csclient/package_test.go
+++ b/csclient/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package csclient_test
+
+import (
+	"testing"
+
+	jujutesting "github.com/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	jujutesting.MgoTestPackage(t, nil)
+}

--- a/internal/storetesting/checkers.go
+++ b/internal/storetesting/checkers.go
@@ -1,0 +1,52 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package storetesting
+
+import (
+	"encoding/json"
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+// JSONEquals defines a checker that checks whether a byte slice, when
+// unmarshaled as JSON, is equal to the given value.
+// Rather than unmarshaling into something of the expected
+// body type, we reform the expected body in JSON and
+// back to interface{}, so we can check the whole content.
+// Otherwise we lose information when unmarshaling.
+var JSONEquals = &jsonEqualChecker{
+	&gc.CheckerInfo{Name: "JSONEquals", Params: []string{"obtained", "expected"}},
+}
+
+type jsonEqualChecker struct {
+	*gc.CheckerInfo
+}
+
+func (checker *jsonEqualChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	gotContent, ok := params[0].([]byte)
+	if !ok {
+		return false, fmt.Sprintf("expected []byte, got %T", params[0])
+	}
+	expectContent := params[1]
+	expectContentBytes, err := json.Marshal(expectContent)
+	if err != nil {
+		return false, fmt.Sprintf("cannot marshal expected contents: %v", err)
+	}
+	var expectContentVal interface{}
+	if err := json.Unmarshal(expectContentBytes, &expectContentVal); err != nil {
+		return false, fmt.Sprintf("cannot unmarshal expected contents: %v", err)
+	}
+
+	var gotContentVal interface{}
+	if err := json.Unmarshal(gotContent, &gotContentVal); err != nil {
+		return false, fmt.Sprintf("cannot unmarshal obtained contents: %v; %q", err, gotContent)
+	}
+
+	if ok, err := jc.DeepEqual(gotContentVal, expectContentVal); !ok {
+		return false, err.Error()
+	}
+	return true, ""
+}


### PR DESCRIPTION
This is the start of the client-side charm store code.

We also factor out the JSON equality checking so that the csclient tests
can use it.
