### PR TITLE
internal/charmstore: return blob hash when downloading a charm archive

### DIFF
--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -142,7 +142,7 @@ var updateEntitySHA256 = func(store *charmstore.Store, url *charm.Reference, sum
 }
 
 func (h *Handler) updateEntitySHA256(curl *charm.Reference) (string, error) {
-	r, _, err := h.store.OpenBlob(curl)
+	r, _, _, err := h.store.OpenBlob(curl)
 	defer r.Close()
 	hash := sha256.New()
 	_, err = io.Copy(hash, r)

--- a/internal/v4/httpfs.go
+++ b/internal/v4/httpfs.go
@@ -15,6 +15,7 @@ import (
 // We use http.FileServer under the covers because that
 // provides us with all the HTTP Content-Range goodness
 // that we'd like.
+// TODO use http.ServeContent instead of this.
 func serveContent(w http.ResponseWriter, req *http.Request, length int64, content io.ReadSeeker) {
 	fs := &archiveFS{
 		length:     length,

--- a/params/params.go
+++ b/params/params.go
@@ -12,6 +12,10 @@ import (
 	"gopkg.in/juju/charm.v4"
 )
 
+// ContentHashHeader specifies the header attribute
+// that will hold the content hash for archive GET responses.
+const ContentHashHeader = "x-content-sha384"
+
 // MetaAnyResponse holds the result of a meta/any
 // request. See http://tinyurl.com/q5vcjpk
 type MetaAnyResponse struct {


### PR DESCRIPTION
We want clients to get the hash as well as the data.
