### PR TITLE
params: rename content header

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -14,7 +14,7 @@ import (
 
 // ContentHashHeader specifies the header attribute
 // that will hold the content hash for archive GET responses.
-const ContentHashHeader = "Content-SHA384"
+const ContentHashHeader = "Content-Sha384"
 
 // MetaAnyResponse holds the result of a meta/any
 // request. See http://tinyurl.com/q5vcjpk

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -1,0 +1,24 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package params_test
+
+import (
+	"net/textproto"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/charmstore/params"
+)
+
+type suite struct{}
+
+var _ = gc.Suite(&suite{})
+
+func (*suite) TestContentHashHeaderCanonicalized(c *gc.C) {
+	// The header key should be canonicalized, because otherwise
+	// the actually produced header will be different from that
+	// specified.
+	canon := textproto.CanonicalMIMEHeaderKey(params.ContentHashHeader)
+	c.Assert(canon, gc.Equals, params.ContentHashHeader)
+}


### PR DESCRIPTION
We just found out that Go canonicalises headers, so the all-caps SHA was
not appropriate.
