### PR TITLE
Use charm.MustParseReference.

### DIFF
--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -99,7 +99,7 @@ var getTests = []struct {
 
 func (s *suite) TestGet(c *gc.C) {
 	ch := charmtesting.Charms.CharmDir("wordpress")
-	url := mustParseReference("utopic/wordpress-42")
+	url := charm.MustParseReference("utopic/wordpress-42")
 	err := s.store.AddCharmWithArchive(url, ch)
 	c.Assert(err, gc.IsNil)
 
@@ -136,7 +136,7 @@ func (s *suite) TestGet(c *gc.C) {
 func (s *suite) TestDoAuthorization(c *gc.C) {
 	// Add a charm to be deleted.
 	ch := charmtesting.Charms.CharmDir("wordpress")
-	url := mustParseReference("utopic/wordpress-42")
+	url := charm.MustParseReference("utopic/wordpress-42")
 	err := s.store.AddCharmWithArchive(url, ch)
 	c.Assert(err, gc.IsNil)
 
@@ -287,7 +287,7 @@ func (s *suite) TestDo(c *gc.C) {
 	// Do is tested fairly comprehensively (but indirectly)
 	// in TestGet, so just a trivial smoke test here.
 	ch := charmtesting.Charms.CharmDir("wordpress")
-	url := mustParseReference("utopic/wordpress-42")
+	url := charm.MustParseReference("utopic/wordpress-42")
 	err := s.store.AddCharmWithArchive(url, ch)
 	c.Assert(err, gc.IsNil)
 	err = s.client.PutExtraInfo(url, map[string]interface{}{
@@ -328,7 +328,7 @@ var metaBadTypeTests = []struct {
 }}
 
 func (s *suite) TestMetaBadType(c *gc.C) {
-	id := mustParseReference("wordpress")
+	id := charm.MustParseReference("wordpress")
 	for _, test := range metaBadTypeTests {
 		_, err := s.client.Meta(id, test.result)
 		c.Assert(err, gc.ErrorMatches, test.expectError)
@@ -340,7 +340,7 @@ type embed struct{}
 
 func (s *suite) TestMeta(c *gc.C) {
 	ch := charmtesting.Charms.CharmDir("wordpress")
-	url := mustParseReference("utopic/wordpress-42")
+	url := charm.MustParseReference("utopic/wordpress-42")
 	err := s.store.AddCharmWithArchive(url, ch)
 	c.Assert(err, gc.IsNil)
 
@@ -431,7 +431,7 @@ func (s *suite) TestMeta(c *gc.C) {
 		// Make a result value of the same type as the expected result,
 		// but empty.
 		result := reflect.New(reflect.TypeOf(test.expectResult).Elem()).Interface()
-		id, err := s.client.Meta(mustParseReference(test.id), result)
+		id, err := s.client.Meta(charm.MustParseReference(test.id), result)
 		if test.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 			if code, ok := errgo.Cause(err).(params.ErrorCode); ok {
@@ -450,7 +450,7 @@ func (s *suite) TestMeta(c *gc.C) {
 
 func (s *suite) TestPutExtraInfo(c *gc.C) {
 	ch := charmtesting.Charms.CharmDir("wordpress")
-	url := mustParseReference("utopic/wordpress-42")
+	url := charm.MustParseReference("utopic/wordpress-42")
 	err := s.store.AddCharmWithArchive(url, ch)
 	c.Assert(err, gc.IsNil)
 
@@ -484,7 +484,7 @@ func (s *suite) TestPutExtraInfo(c *gc.C) {
 }
 
 func (s *suite) TestPutExtraInfoWithError(c *gc.C) {
-	err := s.client.PutExtraInfo(mustParseReference("wordpress"), map[string]interface{}{"attr": "val"})
+	err := s.client.PutExtraInfo(charm.MustParseReference("wordpress"), map[string]interface{}{"attr": "val"})
 	c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for "cs:wordpress"`)
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 }
@@ -504,15 +504,6 @@ type cannedRoundTripper struct {
 
 func (r *cannedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return r.resp, r.error
-}
-
-func mustParseReference(url string) *charm.Reference {
-	// TODO implement MustParseReference in charm.
-	ref, err := charm.ParseReference(url)
-	if err != nil {
-		panic(err)
-	}
-	return ref
 }
 
 func mustMarshalJSON(x interface{}) []byte {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -13,6 +13,6 @@ github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc
 github.com/juju/utils	git	e4e59c6fe058bce0da468ba70943afba85b11cd5	
 gopkg.in/check.v1	git	91ae5f88a67b14891cfd43895b01164f6c120420	
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	
-gopkg.in/juju/charm.v4	git	60ba92340ee6a4bc963da0b3e3d485ecac0f3b49	
+gopkg.in/juju/charm.v4	git	945e6bbaf19b3bdfc5caa14893f79e7f6c2778a0	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/yaml.v1	git	1b9791953ba4027efaeb728c7355e542a203be5e	

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -9,6 +9,7 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
 	"gopkg.in/juju/charm.v4/testing"
 
 	"github.com/juju/charmstore/internal/mongodoc"
@@ -78,13 +79,13 @@ func (s *StoreSearchSuite) TestSuccessfulExport(c *gc.C) {
 func (s *StoreSearchSuite) addCharmsToStore(store *Store) {
 	for name, ref := range exportTestCharms {
 		charmArchive := testing.Charms.CharmDir(name)
-		url := mustParseReference(ref)
+		url := charm.MustParseReference(ref)
 		charmArchive.Meta().Categories = []string{name}
 		store.AddCharmWithArchive(url, charmArchive)
 	}
 	for name, ref := range exportTestBundles {
 		bundleArchive := testing.Charms.BundleDir(name)
-		url := mustParseReference(ref)
+		url := charm.MustParseReference(ref)
 		bundleArchive.Data().Tags = []string{name}
 		store.AddBundleWithArchive(url, bundleArchive)
 	}
@@ -121,7 +122,7 @@ func (s *StoreSearchSuite) TestBlankTextSearch(c *gc.C) {
 
 func (s *StoreSearchSuite) TestLimitTestSearch(c *gc.C) {
 	charmArchive := testing.Charms.CharmDir("wordpress")
-	ref := mustParseReference(exportTestCharms["wordpress"])
+	ref := charm.MustParseReference(exportTestCharms["wordpress"])
 	ref.Revision += 1
 	s.store.AddCharmWithArchive(ref, charmArchive)
 

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -41,7 +41,7 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool) {
 	}
 	store, err := NewStore(s.Session.DB("juju_test"), ses)
 	c.Assert(err, gc.IsNil)
-	url := mustParseReference("cs:precise/wordpress-23")
+	url := charm.MustParseReference("cs:precise/wordpress-23")
 
 	// Add the charm to the store.
 	beforeAdding := time.Now()
@@ -78,7 +78,7 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool) {
 	doc.BlobName = ""
 	c.Assert(doc, jc.DeepEquals, mongodoc.Entity{
 		URL:                     url,
-		BaseURL:                 mustParseReference("cs:wordpress"),
+		BaseURL:                 charm.MustParseReference("cs:wordpress"),
 		BlobHash:                hash,
 		Size:                    size,
 		CharmMeta:               ch.Meta(),
@@ -118,7 +118,7 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bool) 
 	}
 	store, err := NewStore(s.Session.DB("juju_test"), ses)
 	c.Assert(err, gc.IsNil)
-	url := mustParseReference("cs:bundle/wordpress-simple-42")
+	url := charm.MustParseReference("cs:bundle/wordpress-simple-42")
 
 	// Add the bundle to the store.
 	beforeAdding := time.Now()
@@ -153,14 +153,14 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bool) 
 	size, hash := mustGetSizeAndHash(bundle)
 	c.Assert(doc, jc.DeepEquals, mongodoc.Entity{
 		URL:          url,
-		BaseURL:      mustParseReference("cs:wordpress-simple"),
+		BaseURL:      charm.MustParseReference("cs:wordpress-simple"),
 		BlobHash:     hash,
 		Size:         size,
 		BundleData:   bundle.Data(),
 		BundleReadMe: bundle.ReadMe(),
 		BundleCharms: []*charm.Reference{
-			mustParseReference("mysql"),
-			mustParseReference("wordpress"),
+			charm.MustParseReference("mysql"),
+			charm.MustParseReference("wordpress"),
 		},
 		BundleMachineCount: newInt(2),
 		BundleUnitCount:    newInt(2),
@@ -264,9 +264,9 @@ func (s *StoreSuite) testURLFinding(c *gc.C, check func(store *Store, expand *ch
 		}
 		expectURLs := make([]*charm.Reference, len(test.expect))
 		for i, expect := range test.expect {
-			expectURLs[i] = mustParseReference(expect)
+			expectURLs[i] = charm.MustParseReference(expect)
 		}
-		check(store, mustParseReference(test.expand), expectURLs)
+		check(store, charm.MustParseReference(test.expand), expectURLs)
 	}
 }
 
@@ -725,7 +725,7 @@ func urlStrings(urls []*charm.Reference) []string {
 func mustParseReferences(urlStrs []string) []*charm.Reference {
 	urls := make([]*charm.Reference, len(urlStrs))
 	for i, u := range urlStrs {
-		urls[i] = mustParseReference(u)
+		urls[i] = charm.MustParseReference(u)
 	}
 	return urls
 }
@@ -758,7 +758,7 @@ func (s *StoreSuite) TestOpenBlob(c *gc.C) {
 
 	store, err := NewStore(s.Session.DB("foo"), nil)
 	c.Assert(err, gc.IsNil)
-	url := mustParseReference("cs:precise/wordpress-23")
+	url := charm.MustParseReference("cs:precise/wordpress-23")
 
 	err = store.AddCharmWithArchive(url, charmArchive)
 	c.Assert(err, gc.IsNil)
@@ -785,7 +785,7 @@ func (s *StoreSuite) TestBlobNameAndHash(c *gc.C) {
 
 	store, err := NewStore(s.Session.DB("foo"), nil)
 	c.Assert(err, gc.IsNil)
-	url := mustParseReference("cs:precise/wordpress-23")
+	url := charm.MustParseReference("cs:precise/wordpress-23")
 
 	err = store.AddCharmWithArchive(url, charmArchive)
 	c.Assert(err, gc.IsNil)
@@ -872,14 +872,6 @@ func mustGetSizeAndHash(c interface{}) (int64, string) {
 		panic(err)
 	}
 	return size, fmt.Sprintf("%x", hash.Sum(nil))
-}
-
-func mustParseReference(url string) *charm.Reference {
-	ref, err := charm.ParseReference(url)
-	if err != nil {
-		panic(err)
-	}
-	return ref
 }
 
 // testingBundle implements charm.Bundle, allowing tests

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -307,7 +307,7 @@ func (s *APISuite) TestCharmPackageCharmInfo(c *gc.C) {
 	wordpressSHA256 := fileSHA256(c, wordpress.Path)
 	mysqlURL, mySQL := s.addCharm(c, "wordpress", "cs:precise/mysql-2")
 	mysqlSHA256 := fileSHA256(c, mySQL.Path)
-	notFoundURL := mustParseReference("cs:oneiric/not-found-3")
+	notFoundURL := charm.MustParseReference("cs:oneiric/not-found-3")
 
 	srv := httptest.NewServer(s.srv)
 	defer srv.Close()
@@ -405,17 +405,9 @@ func (s *APISuite) TestServerStatus(c *gc.C) {
 }
 
 func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.Reference, *charm.CharmArchive) {
-	url := mustParseReference(curl)
+	url := charm.MustParseReference(curl)
 	wordpress := charmtesting.Charms.CharmArchive(c.MkDir(), charmName)
 	err := s.store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
 	return url, wordpress
-}
-
-func mustParseReference(url string) *charm.Reference {
-	ref, err := charm.ParseReference(url)
-	if err != nil {
-		panic(err)
-	}
-	return ref
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -356,10 +356,10 @@ var routerGetTests = []struct {
 	expectBody: fieldSelectHandleGetInfo{
 		HandlerId: "handler1",
 		Doc: fieldSelectQueryInfo{
-			Id:       mustParseReference("cs:precise/wordpress-42"),
+			Id:       charm.MustParseReference("cs:precise/wordpress-42"),
 			Selector: map[string]int{"field1": 1, "field2": 1},
 		},
-		Id: mustParseReference("cs:precise/wordpress-42"),
+		Id: charm.MustParseReference("cs:precise/wordpress-42"),
 	},
 }, {
 	about:  "meta handler returning error with code",
@@ -379,7 +379,7 @@ var routerGetTests = []struct {
 	urlStr:       "/precise/wordpress-42/meta/any",
 	expectStatus: http.StatusOK,
 	expectBody: params.MetaAnyResponse{
-		Id: mustParseReference("cs:precise/wordpress-42"),
+		Id: charm.MustParseReference("cs:precise/wordpress-42"),
 	},
 }, {
 	about:  "meta/any, some includes all using same key",
@@ -394,31 +394,31 @@ var routerGetTests = []struct {
 	expectQueryCount: 1,
 	expectStatus:     http.StatusOK,
 	expectBody: params.MetaAnyResponse{
-		Id: mustParseReference("cs:precise/wordpress-42"),
+		Id: charm.MustParseReference("cs:precise/wordpress-42"),
 		Meta: map[string]interface{}{
 			"field1-1": fieldSelectHandleGetInfo{
 				HandlerId: "handler1",
 				Doc: fieldSelectQueryInfo{
-					Id:       mustParseReference("cs:precise/wordpress-42"),
+					Id:       charm.MustParseReference("cs:precise/wordpress-42"),
 					Selector: map[string]int{"field1": 1, "field2": 1},
 				},
-				Id: mustParseReference("cs:precise/wordpress-42"),
+				Id: charm.MustParseReference("cs:precise/wordpress-42"),
 			},
 			"field2": fieldSelectHandleGetInfo{
 				HandlerId: "handler2",
 				Doc: fieldSelectQueryInfo{
-					Id:       mustParseReference("cs:precise/wordpress-42"),
+					Id:       charm.MustParseReference("cs:precise/wordpress-42"),
 					Selector: map[string]int{"field1": 1, "field2": 1},
 				},
-				Id: mustParseReference("cs:precise/wordpress-42"),
+				Id: charm.MustParseReference("cs:precise/wordpress-42"),
 			},
 			"field1-2": fieldSelectHandleGetInfo{
 				HandlerId: "handler3",
 				Doc: fieldSelectQueryInfo{
-					Id:       mustParseReference("cs:precise/wordpress-42"),
+					Id:       charm.MustParseReference("cs:precise/wordpress-42"),
 					Selector: map[string]int{"field1": 1, "field2": 1},
 				},
-				Id: mustParseReference("cs:precise/wordpress-42"),
+				Id: charm.MustParseReference("cs:precise/wordpress-42"),
 			},
 		},
 	},
@@ -435,33 +435,33 @@ var routerGetTests = []struct {
 	expectQueryCount: 1,
 	expectStatus:     http.StatusOK,
 	expectBody: params.MetaAnyResponse{
-		Id: mustParseReference("cs:precise/wordpress-42"),
+		Id: charm.MustParseReference("cs:precise/wordpress-42"),
 		Meta: map[string]interface{}{
 			"item1/foo": fieldSelectHandleGetInfo{
 				HandlerId: "handler1",
 				Doc: fieldSelectQueryInfo{
-					Id:       mustParseReference("cs:precise/wordpress-42"),
+					Id:       charm.MustParseReference("cs:precise/wordpress-42"),
 					Selector: map[string]int{"field1": 1, "field2": 1, "field3": 1},
 				},
-				Id:   mustParseReference("cs:precise/wordpress-42"),
+				Id:   charm.MustParseReference("cs:precise/wordpress-42"),
 				Path: "/foo",
 			},
 			"item2/bar": fieldSelectHandleGetInfo{
 				HandlerId: "handler2",
 				Doc: fieldSelectQueryInfo{
-					Id:       mustParseReference("cs:precise/wordpress-42"),
+					Id:       charm.MustParseReference("cs:precise/wordpress-42"),
 					Selector: map[string]int{"field1": 1, "field2": 1, "field3": 1},
 				},
-				Id:   mustParseReference("cs:precise/wordpress-42"),
+				Id:   charm.MustParseReference("cs:precise/wordpress-42"),
 				Path: "/bar",
 			},
 			"item1": fieldSelectHandleGetInfo{
 				HandlerId: "handler3",
 				Doc: fieldSelectQueryInfo{
-					Id:       mustParseReference("cs:precise/wordpress-42"),
+					Id:       charm.MustParseReference("cs:precise/wordpress-42"),
 					Selector: map[string]int{"field1": 1, "field2": 1, "field3": 1},
 				},
-				Id: mustParseReference("cs:precise/wordpress-42"),
+				Id: charm.MustParseReference("cs:precise/wordpress-42"),
 			},
 		},
 	},
@@ -477,7 +477,7 @@ var routerGetTests = []struct {
 	},
 	expectStatus: http.StatusOK,
 	expectBody: params.MetaAnyResponse{
-		Id: mustParseReference("cs:precise/wordpress-42"),
+		Id: charm.MustParseReference("cs:precise/wordpress-42"),
 		Meta: map[string]interface{}{
 			"ok": metaHandlerTestResp{
 				CharmURL: "cs:precise/wordpress-42",
@@ -540,7 +540,7 @@ var routerGetTests = []struct {
 	expectStatus: http.StatusOK,
 	expectBody: map[string]params.MetaAnyResponse{
 		"precise/wordpress-42": {
-			Id: mustParseReference("cs:precise/wordpress-42"),
+			Id: charm.MustParseReference("cs:precise/wordpress-42"),
 			Meta: map[string]interface{}{
 				"foo": metaHandlerTestResp{
 					CharmURL: "cs:precise/wordpress-42",
@@ -552,7 +552,7 @@ var routerGetTests = []struct {
 			},
 		},
 		"quantal/foo-32": {
-			Id: mustParseReference("cs:quantal/foo-32"),
+			Id: charm.MustParseReference("cs:quantal/foo-32"),
 			Meta: map[string]interface{}{
 				"foo": metaHandlerTestResp{
 					CharmURL: "cs:quantal/foo-32",
@@ -1388,18 +1388,18 @@ var getMetadataTests = []struct {
 		"item1": fieldSelectHandleGetInfo{
 			HandlerId: "handler1",
 			Doc: fieldSelectQueryInfo{
-				Id:       mustParseReference("cs:~rog/precise/wordpress-2"),
+				Id:       charm.MustParseReference("cs:~rog/precise/wordpress-2"),
 				Selector: map[string]int{"item1": 1, "item2": 1},
 			},
-			Id: mustParseReference("cs:~rog/precise/wordpress-2"),
+			Id: charm.MustParseReference("cs:~rog/precise/wordpress-2"),
 		},
 		"item2": fieldSelectHandleGetInfo{
 			HandlerId: "handler2",
 			Doc: fieldSelectQueryInfo{
-				Id:       mustParseReference("cs:~rog/precise/wordpress-2"),
+				Id:       charm.MustParseReference("cs:~rog/precise/wordpress-2"),
 				Selector: map[string]int{"item1": 1, "item2": 1},
 			},
-			Id: mustParseReference("cs:~rog/precise/wordpress-2"),
+			Id: charm.MustParseReference("cs:~rog/precise/wordpress-2"),
 		},
 		"test": &metaHandlerTestResp{
 			CharmURL: "cs:~rog/precise/wordpress-2",
@@ -1421,7 +1421,7 @@ func (s *RouterSuite) TestGetMetadata(c *gc.C) {
 				"test":  testMetaHandler(0),
 			},
 		}, noResolveURL)
-		id := mustParseReference(test.id)
+		id := charm.MustParseReference(test.id)
 		result, err := router.GetMetadata(id, test.includes)
 		if test.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
@@ -2021,14 +2021,6 @@ func selectiveIdHandler(m map[string]interface{}) BulkIncludeHandler {
 	return SingleIncludeHandler(func(id *charm.Reference, path string, flags url.Values) (interface{}, error) {
 		return m[id.String()], nil
 	})
-}
-
-func mustParseReference(url string) *charm.Reference {
-	ref, err := charm.ParseReference(url)
-	if err != nil {
-		panic(err)
-	}
-	return ref
 }
 
 type swapper interface {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -199,7 +199,7 @@ var metaEndpoints = []metaEndpoint{{
 	assertCheckData: func(c *gc.C, data interface{}) {
 		c.Assert(data, gc.DeepEquals, params.RevisionInfoResponse{
 			[]*charm.Reference{
-				mustParseReference("cs:precise/wordpress-99"),
+				charm.MustParseReference("cs:precise/wordpress-99"),
 			}})
 	},
 }, {
@@ -274,7 +274,7 @@ func (s *APISuite) TestEndpointGet(c *gc.C) {
 	s.addTestEntities(c)
 	for i, ep := range metaEndpoints {
 		c.Logf("test %d: %s\n", i, ep.name)
-		data, err := ep.get(s.store, mustParseReference(ep.checkURL))
+		data, err := ep.get(s.store, charm.MustParseReference(ep.checkURL))
 		c.Assert(err, gc.IsNil)
 		ep.assertCheckData(c, data)
 	}
@@ -292,7 +292,7 @@ var testEntities = []string{
 func (s *APISuite) addTestEntities(c *gc.C) []*charm.Reference {
 	urls := make([]*charm.Reference, len(testEntities))
 	for i, e := range testEntities {
-		url := mustParseReference(e)
+		url := charm.MustParseReference(e)
 		if url.Series == "bundle" {
 			s.addBundle(c, url.Name, e)
 		} else {
@@ -653,7 +653,7 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 
 	for i, test := range resolveURLTests {
 		c.Logf("test %d: %s", i, test.url)
-		url := mustParseReference(test.url)
+		url := charm.MustParseReference(test.url)
 		err := v4.ResolveURL(s.store, url)
 		if test.notFound {
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
@@ -755,20 +755,20 @@ var serveMetaRevisionInfoTests = []struct {
 	url:   "trusty/wordpress-42",
 	expect: params.RevisionInfoResponse{
 		[]*charm.Reference{
-			mustParseReference("cs:trusty/wordpress-43"),
-			mustParseReference("cs:trusty/wordpress-42"),
-			mustParseReference("cs:trusty/wordpress-41"),
-			mustParseReference("cs:trusty/wordpress-9"),
+			charm.MustParseReference("cs:trusty/wordpress-43"),
+			charm.MustParseReference("cs:trusty/wordpress-42"),
+			charm.MustParseReference("cs:trusty/wordpress-41"),
+			charm.MustParseReference("cs:trusty/wordpress-9"),
 		}},
 }, {
 	about: "partial url uses a default series",
 	url:   "wordpress",
 	expect: params.RevisionInfoResponse{
 		[]*charm.Reference{
-			mustParseReference("cs:trusty/wordpress-43"),
-			mustParseReference("cs:trusty/wordpress-42"),
-			mustParseReference("cs:trusty/wordpress-41"),
-			mustParseReference("cs:trusty/wordpress-9"),
+			charm.MustParseReference("cs:trusty/wordpress-43"),
+			charm.MustParseReference("cs:trusty/wordpress-42"),
+			charm.MustParseReference("cs:trusty/wordpress-41"),
+			charm.MustParseReference("cs:trusty/wordpress-9"),
 		}},
 }, {
 	about: "no entities found",
@@ -860,7 +860,7 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 		}
 
 		// Wait until the counters are updated.
-		url := mustParseReference(test.url)
+		url := charm.MustParseReference(test.url)
 		key := []string{params.StatsArchiveDownload, url.Series, url.Name, url.User, strconv.Itoa(url.Revision)}
 		stats.CheckCounterSum(c, s.store, key, false, test.downloads)
 
@@ -877,7 +877,7 @@ type publishSpec struct {
 }
 
 func (p publishSpec) published() params.Published {
-	id := mustParseReference(p.id)
+	id := charm.MustParseReference(p.id)
 	t, err := time.Parse("2006-01-02 15:04", p.time)
 	if err != nil {
 		panic(err)
@@ -1160,7 +1160,7 @@ func entitySizeChecker(c *gc.C, data interface{}) {
 }
 
 func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.Reference, charm.Charm) {
-	url := mustParseReference(curl)
+	url := charm.MustParseReference(curl)
 	wordpress := charmtesting.Charms.CharmDir(charmName)
 	err := s.store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
@@ -1168,7 +1168,7 @@ func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*charm.Reference, 
 }
 
 func (s *APISuite) addBundle(c *gc.C, bundleName string, curl string) (*charm.Reference, charm.Bundle) {
-	url := mustParseReference(curl)
+	url := charm.MustParseReference(curl)
 	bundle := charmtesting.Charms.BundleDir(bundleName)
 	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
@@ -1205,12 +1205,4 @@ func mustMarshalJSON(val interface{}) string {
 		panic(fmt.Errorf("cannot marshal %#v: %v", val, err))
 	}
 	return string(data)
-}
-
-func mustParseReference(url string) *charm.Reference {
-	ref, err := charm.ParseReference(url)
-	if err != nil {
-		panic(err)
-	}
-	return ref
 }

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -48,7 +48,7 @@ func (s *ArchiveSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ArchiveSuite) TestGet(c *gc.C) {
-	wordpress := s.assertUploadCharm(c, "POST", mustParseReference("cs:precise/wordpress-0"), "wordpress")
+	wordpress := s.assertUploadCharm(c, "POST", charm.MustParseReference("cs:precise/wordpress-0"), "wordpress")
 
 	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
 	c.Assert(err, gc.IsNil)
@@ -83,7 +83,7 @@ func (s *ArchiveSuite) TestGetCounters(c *gc.C) {
 
 	for i, id := range []string{"utopic/mysql-42", "~who/utopic/mysql-42"} {
 		c.Logf("test %d: %s", i, id)
-		url := mustParseReference(id)
+		url := charm.MustParseReference(id)
 
 		// Add a charm to the database (including the archive).
 		err := s.store.AddCharmWithArchive(url, charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"))
@@ -283,17 +283,17 @@ loop:
 
 func (s *ArchiveSuite) TestPostCharm(c *gc.C) {
 	// A charm that did not exist before should get revision 0.
-	s.assertUploadCharm(c, "POST", mustParseReference("precise/wordpress-0"), "wordpress")
+	s.assertUploadCharm(c, "POST", charm.MustParseReference("precise/wordpress-0"), "wordpress")
 
 	// Subsequent charm uploads should increment the
 	// revision by 1.
-	s.assertUploadCharm(c, "POST", mustParseReference("precise/wordpress-1"), "mysql")
+	s.assertUploadCharm(c, "POST", charm.MustParseReference("precise/wordpress-1"), "mysql")
 }
 
 func (s *ArchiveSuite) TestPutCharm(c *gc.C) {
-	s.assertUploadCharm(c, "PUT", mustParseReference("precise/wordpress-3"), "wordpress")
+	s.assertUploadCharm(c, "PUT", charm.MustParseReference("precise/wordpress-3"), "wordpress")
 
-	s.assertUploadCharm(c, "PUT", mustParseReference("precise/wordpress-1"), "wordpress")
+	s.assertUploadCharm(c, "PUT", charm.MustParseReference("precise/wordpress-1"), "wordpress")
 
 	// Check that we get a duplicate-upload error if we try to
 	// upload to the same revision again.
@@ -326,30 +326,30 @@ func (s *ArchiveSuite) TestPutCharm(c *gc.C) {
 func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 	// Upload the required charms.
 	err := s.store.AddCharmWithArchive(
-		mustParseReference("cs:utopic/mysql-42"),
+		charm.MustParseReference("cs:utopic/mysql-42"),
 		charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"))
 	c.Assert(err, gc.IsNil)
 	err = s.store.AddCharmWithArchive(
-		mustParseReference("cs:utopic/wordpress-47"),
+		charm.MustParseReference("cs:utopic/wordpress-47"),
 		charmtesting.Charms.CharmArchive(c.MkDir(), "wordpress"))
 	c.Assert(err, gc.IsNil)
 	err = s.store.AddCharmWithArchive(
-		mustParseReference("cs:utopic/logging-1"),
+		charm.MustParseReference("cs:utopic/logging-1"),
 		charmtesting.Charms.CharmArchive(c.MkDir(), "logging"))
 	c.Assert(err, gc.IsNil)
 
 	// A bundle that did not exist before should get revision 0.
-	s.assertUploadBundle(c, "POST", mustParseReference("bundle/wordpress-0"), "wordpress")
+	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-0"), "wordpress")
 
 	// Subsequent bundle uploads should increment the
 	// revision by 1.
-	s.assertUploadBundle(c, "POST", mustParseReference("bundle/wordpress-1"), "wordpress-with-logging")
+	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-1"), "wordpress-with-logging")
 
 	// Uploading the same archive twice should not increment the revision...
-	s.assertUploadBundle(c, "POST", mustParseReference("bundle/wordpress-1"), "wordpress-with-logging")
+	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-1"), "wordpress-with-logging")
 
 	// ... but uploading an archive used by a previous revision should.
-	s.assertUploadBundle(c, "POST", mustParseReference("bundle/wordpress-2"), "wordpress")
+	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-2"), "wordpress")
 }
 
 func (s *ArchiveSuite) TestPostHashMismatch(c *gc.C) {
@@ -407,7 +407,7 @@ func (s *ArchiveSuite) TestPostCounters(c *gc.C) {
 		c.Skip("MongoDB JavaScript not available")
 	}
 
-	s.assertUploadCharm(c, "POST", mustParseReference("precise/wordpress-0"), "wordpress")
+	s.assertUploadCharm(c, "POST", charm.MustParseReference("precise/wordpress-0"), "wordpress")
 
 	// Check that the upload count for the entity has been updated.
 	key := []string{params.StatsArchiveUpload, "precise", "wordpress", ""}
@@ -579,7 +579,7 @@ var archiveFileErrorsTests = []struct {
 
 func (s *ArchiveSuite) TestArchiveFileErrors(c *gc.C) {
 	wordpress := charmtesting.Charms.CharmArchive(c.MkDir(), "wordpress")
-	url := mustParseReference("cs:utopic/wordpress-0")
+	url := charm.MustParseReference("cs:utopic/wordpress-0")
 	err := s.store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
 	for i, test := range archiveFileErrorsTests {
@@ -599,7 +599,7 @@ func (s *ArchiveSuite) TestArchiveFileErrors(c *gc.C) {
 
 func (s *ArchiveSuite) TestArchiveFileGet(c *gc.C) {
 	ch := charmtesting.Charms.CharmArchive(c.MkDir(), "all-hooks")
-	err := s.store.AddCharmWithArchive(mustParseReference("cs:utopic/all-hooks-0"), ch)
+	err := s.store.AddCharmWithArchive(charm.MustParseReference("cs:utopic/all-hooks-0"), ch)
 	c.Assert(err, gc.IsNil)
 	zipFile, err := zip.OpenReader(ch.Path)
 	c.Assert(err, gc.IsNil)
@@ -651,15 +651,15 @@ func (s *ArchiveSuite) TestBundleCharms(c *gc.C) {
 	// Populate the store with some testing charms.
 	mysql := charmtesting.Charms.CharmArchive(c.MkDir(), "mysql")
 	err := s.store.AddCharmWithArchive(
-		mustParseReference("cs:saucy/mysql-0"), mysql)
+		charm.MustParseReference("cs:saucy/mysql-0"), mysql)
 	c.Assert(err, gc.IsNil)
 	riak := charmtesting.Charms.CharmArchive(c.MkDir(), "riak")
 	err = s.store.AddCharmWithArchive(
-		mustParseReference("cs:trusty/riak-42"), riak)
+		charm.MustParseReference("cs:trusty/riak-42"), riak)
 	c.Assert(err, gc.IsNil)
 	wordpress := charmtesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	err = s.store.AddCharmWithArchive(
-		mustParseReference("cs:utopic/wordpress-47"), wordpress)
+		charm.MustParseReference("cs:utopic/wordpress-47"), wordpress)
 	c.Assert(err, gc.IsNil)
 
 	// Retrieve the bundleCharms method.
@@ -742,7 +742,7 @@ func (s *ArchiveSuite) TestBundleCharms(c *gc.C) {
 func (s *ArchiveSuite) TestDelete(c *gc.C) {
 	// Add a charm to the database (including the archive).
 	id := "utopic/mysql-42"
-	url := mustParseReference(id)
+	url := charm.MustParseReference(id)
 	err := s.store.AddCharmWithArchive(url, charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"))
 	c.Assert(err, gc.IsNil)
 
@@ -775,7 +775,7 @@ func (s *ArchiveSuite) TestDeleteSpecificCharm(c *gc.C) {
 	// Add a couple of charms to the database.
 	for _, id := range []string{"trusty/mysql-42", "utopic/mysql-42", "utopic/mysql-47"} {
 		err := s.store.AddCharmWithArchive(
-			mustParseReference(id),
+			charm.MustParseReference(id),
 			charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"))
 		c.Assert(err, gc.IsNil)
 	}
@@ -792,8 +792,8 @@ func (s *ArchiveSuite) TestDeleteSpecificCharm(c *gc.C) {
 
 	// The other two charms are still present in the database.
 	urls := []*charm.Reference{
-		mustParseReference("trusty/mysql-42"),
-		mustParseReference("utopic/mysql-47"),
+		charm.MustParseReference("trusty/mysql-42"),
+		charm.MustParseReference("utopic/mysql-47"),
 	}
 	count, err := s.store.DB.Entities().Find(bson.D{{
 		"_id", bson.D{{"$in", urls}},
@@ -821,7 +821,7 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 func (s *ArchiveSuite) TestDeleteError(c *gc.C) {
 	// Add a charm to the database (not including the archive).
 	id := "utopic/mysql-42"
-	url := mustParseReference(id)
+	url := charm.MustParseReference(id)
 	err := s.store.AddCharm(url, charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"), "no-such-name", fakeBlobHash, fakeBlobSize)
 	c.Assert(err, gc.IsNil)
 
@@ -847,7 +847,7 @@ func (s *ArchiveSuite) TestDeleteCounters(c *gc.C) {
 	// Add a charm to the database (including the archive).
 	id := "utopic/mysql-42"
 	err := s.store.AddCharmWithArchive(
-		mustParseReference(id),
+		charm.MustParseReference(id),
 		charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"))
 	c.Assert(err, gc.IsNil)
 

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -118,17 +118,17 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"memcache": {{
-				Id: mustParseReference("utopic/memcached-42"),
+				Id: charm.MustParseReference("utopic/memcached-42"),
 			}},
 			"mount": {{
-				Id: mustParseReference("precise/nfs-1"),
+				Id: charm.MustParseReference("precise/nfs-1"),
 			}},
 		},
 		Requires: map[string][]params.MetaAnyResponse{
 			"http": {{
-				Id: mustParseReference("precise/haproxy-48"),
+				Id: charm.MustParseReference("precise/haproxy-48"),
 			}, {
-				Id: mustParseReference("trusty/haproxy-47"),
+				Id: charm.MustParseReference("trusty/haproxy-47"),
 			}},
 		},
 	},
@@ -139,7 +139,7 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"http": {{
-				Id: mustParseReference("utopic/wordpress-0"),
+				Id: charm.MustParseReference("utopic/wordpress-0"),
 			}},
 		},
 	},
@@ -150,7 +150,7 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Requires: map[string][]params.MetaAnyResponse{
 			"memcache": {{
-				Id: mustParseReference("utopic/wordpress-0"),
+				Id: charm.MustParseReference("utopic/wordpress-0"),
 			}},
 		},
 	},
@@ -230,11 +230,11 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"memcache": {{
-				Id: mustParseReference("utopic/memcached-1"),
+				Id: charm.MustParseReference("utopic/memcached-1"),
 			}, {
-				Id: mustParseReference("utopic/memcached-2"),
+				Id: charm.MustParseReference("utopic/memcached-2"),
 			}, {
-				Id: mustParseReference("utopic/memcached-3"),
+				Id: charm.MustParseReference("utopic/memcached-3"),
 			}},
 		},
 	},
@@ -314,18 +314,18 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Provides: map[string][]params.MetaAnyResponse{
 			"memcache": {{
-				Id: mustParseReference("utopic/memcached-1"),
+				Id: charm.MustParseReference("utopic/memcached-1"),
 			}, {
-				Id: mustParseReference("utopic/memcached-2"),
+				Id: charm.MustParseReference("utopic/memcached-2"),
 			}, {
-				Id: mustParseReference("utopic/redis-90"),
+				Id: charm.MustParseReference("utopic/redis-90"),
 			}},
 			"mount": {{
-				Id: mustParseReference("precise/nfs-42"),
+				Id: charm.MustParseReference("precise/nfs-42"),
 			}, {
-				Id: mustParseReference("precise/nfs-47"),
+				Id: charm.MustParseReference("precise/nfs-47"),
 			}, {
-				Id: mustParseReference("trusty/nfs-47"),
+				Id: charm.MustParseReference("trusty/nfs-47"),
 			}},
 		},
 	},
@@ -337,7 +337,7 @@ var metaCharmRelatedTests = []struct {
 	expectBody: params.RelatedResponse{
 		Requires: map[string][]params.MetaAnyResponse{
 			"mount": {{
-				Id: mustParseReference("utopic/wordpress-0"),
+				Id: charm.MustParseReference("utopic/wordpress-0"),
 				Meta: map[string]interface{}{
 					"archive-size": params.ArchiveSizeResponse{Size: fakeBlobSize},
 					"charm-metadata": &charm.Meta{
@@ -369,7 +369,7 @@ var metaCharmRelatedTests = []struct {
 
 func (s *RelationsSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
 	for id, ch := range charms {
-		url := mustParseReference(id)
+		url := charm.MustParseReference(id)
 		// The blob related info are not used in these tests.
 		// The related charms are retrieved from the entities collection,
 		// without accessing the blob store.
@@ -500,18 +500,18 @@ var metaBundlesContainingTests = []struct {
 	id:           "utopic/wordpress-42",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/useless-0"),
+		Id: charm.MustParseReference("bundle/useless-0"),
 	}, {
-		Id: mustParseReference("bundle/wordpress-complex-1"),
+		Id: charm.MustParseReference("bundle/wordpress-complex-1"),
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Id: charm.MustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
 	about:        "specific charm present in one bundle",
 	id:           "trusty/memcached-2",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-complex-1"),
+		Id: charm.MustParseReference("bundle/wordpress-complex-1"),
 	}},
 }, {
 	about:        "specific charm not present in any bundle",
@@ -524,7 +524,7 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?include=archive-size&include=bundle-metadata",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-complex-1"),
+		Id: charm.MustParseReference("bundle/wordpress-complex-1"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-complex-1"].Data(),
@@ -535,7 +535,7 @@ var metaBundlesContainingTests = []struct {
 	id:           "mysql", // The test will add cs:utopic/mysql-0.
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Id: charm.MustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
 	about:        "any series set to true",
@@ -543,9 +543,9 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-series=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/wordpress-complex-1"),
+		Id: charm.MustParseReference("bundle/wordpress-complex-1"),
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Id: charm.MustParseReference("bundle/wordpress-simple-0"),
 	}},
 }, {
 	about:        "invalid any series",
@@ -562,9 +562,9 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-revision=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/django-generic-42"),
+		Id: charm.MustParseReference("bundle/django-generic-42"),
 	}, {
-		Id: mustParseReference("bundle/wordpress-complex-1"),
+		Id: charm.MustParseReference("bundle/wordpress-complex-1"),
 	}},
 }, {
 	about:        "invalid any revision",
@@ -581,15 +581,15 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-series=1&any-revision=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/django-generic-42"),
+		Id: charm.MustParseReference("bundle/django-generic-42"),
 	}, {
-		Id: mustParseReference("bundle/mediawiki-47"),
+		Id: charm.MustParseReference("bundle/mediawiki-47"),
 	}, {
-		Id: mustParseReference("bundle/wordpress-complex-1"),
+		Id: charm.MustParseReference("bundle/wordpress-complex-1"),
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Id: charm.MustParseReference("bundle/wordpress-simple-0"),
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-1"),
+		Id: charm.MustParseReference("bundle/wordpress-simple-1"),
 	}},
 }, {
 	about:        "any series and revision with includes",
@@ -597,25 +597,25 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?any-series=1&any-revision=1&include=archive-size&include=bundle-metadata",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: mustParseReference("bundle/useless-0"),
+		Id: charm.MustParseReference("bundle/useless-0"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
 			"bundle-metadata": metaBundlesContainingBundles["bundle/useless-0"].Data(),
 		},
 	}, {
-		Id: mustParseReference("bundle/wordpress-complex-1"),
+		Id: charm.MustParseReference("bundle/wordpress-complex-1"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-complex-1"].Data(),
 		},
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-0"),
+		Id: charm.MustParseReference("bundle/wordpress-simple-0"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-0"].Data(),
 		},
 	}, {
-		Id: mustParseReference("bundle/wordpress-simple-1"),
+		Id: charm.MustParseReference("bundle/wordpress-simple-1"),
 		Meta: map[string]interface{}{
 			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
 			"bundle-metadata": metaBundlesContainingBundles["bundle/wordpress-simple-1"].Data(),
@@ -634,7 +634,7 @@ var metaBundlesContainingTests = []struct {
 func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 	// Add the bundles used for testing to the database.
 	for id, b := range metaBundlesContainingBundles {
-		url := mustParseReference(id)
+		url := charm.MustParseReference(id)
 		// The blob related info are not used in these tests.
 		// The charm-bundle relations are retrieved from the entities
 		// collection, without accessing the blob store.
@@ -647,7 +647,7 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 
 		// Expand the URL if required before adding the charm to the database,
 		// so that at least one matching charm can be resolved.
-		url := mustParseReference(test.id)
+		url := charm.MustParseReference(test.id)
 		if url.Series == "" {
 			url.Series = "utopic"
 		}


### PR DESCRIPTION
Mostly mechanical, except for mustParseReferences (trailing slash).
