### PR TITLE
Adding Metadata to search results.

### DIFF
--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -45,9 +45,9 @@ func serve(confPath string) error {
 	}
 	defer session.Close()
 	db := session.DB("juju")
-	var es *elasticsearch.Database
+	var es *elasticsearch.Index
 	if conf.ESAddr != "" {
-		es = &elasticsearch.Database{conf.ESAddr}
+		es = (&elasticsearch.Database{conf.ESAddr}).Index("charmstore")
 	}
 	cfg := charmstore.ServerParams{
 		AuthUsername: conf.AuthUsername,

--- a/cmd/essync/main.go
+++ b/cmd/essync/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -23,11 +24,13 @@ var logger = loggo.GetLogger("essync")
 var (
 	index         = flag.String("index", "charmstore", "Name of index to populate.")
 	loggingConfig = flag.String("logging-config", "", "specify log levels for modules e.g. <root>=TRACE")
+	mapping       = flag.String("mapping", "", "File to use to configure the entity mapping.")
+	settings      = flag.String("settings", "", "File to use to configure the index.")
 )
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "usage: %s <config path>\n", filepath.Base(os.Args[0]))
+		fmt.Fprintf(os.Stderr, "usage: %s [options] <config path>\n", filepath.Base(os.Args[0]))
 		flag.PrintDefaults()
 		os.Exit(2)
 	}
@@ -63,10 +66,58 @@ func populate(confPath string) error {
 	}
 	defer session.Close()
 	db := session.DB("juju")
-	store, err := charmstore.NewStore(db, &charmstore.StoreElasticSearch{es, *index})
+	store, err := charmstore.NewStore(db, &charmstore.StoreElasticSearch{es.Index(*index)})
 	if err != nil {
 		return errgo.Notef(err, "unable to create store for ESSync")
 	}
+	if *settings != "" {
+		if err := writeSettings(es, *index, *settings); err != nil {
+			return err
+		}
+	}
+	if *mapping != "" {
+		err = writeMapping(es, *index, "entity", *mapping)
+		if err != nil {
+			return err
+		}
+	}
 	logger.Debugf("starting export to Elastic Search")
 	return store.ExportToElasticSearch()
+}
+
+// writeSetttings creates a new index with the settings loaded from path. An error
+// will be returned from elasticsearch if the index already exists.
+func writeSettings(es *elasticsearch.Database, index, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return errgo.Notef(err, "cannot read index settings")
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	var data map[string]interface{}
+	if err := dec.Decode(&data); err != nil {
+		return errgo.Notef(err, "cannot read index settings")
+	}
+	if err := es.PutIndex(index, data); err != nil {
+		return errgo.Notef(err, "cannot set index settings")
+	}
+	return nil
+}
+
+// writeMapping writes the mapping loaded from path as documentType on index.
+func writeMapping(es *elasticsearch.Database, index, documentType, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return errgo.Notef(err, "cannot read %s mapping", documentType)
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	var data map[string]interface{}
+	if err := dec.Decode(&data); err != nil {
+		return errgo.Notef(err, "cannot read %s mapping", documentType)
+	}
+	if err := es.PutMapping(index, documentType, data); err != nil {
+		return errgo.Notef(err, "cannot set %s mapping", documentType)
+	}
+	return nil
 }

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -4,10 +4,13 @@
 package charmstore
 
 import (
-	"encoding/json"
-	"net/url"
+	"crypto/sha1"
+	"encoding/base64"
+	"strings"
+	"time"
 
-	"github.com/juju/errgo"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/internal/elasticsearch"
 	"github.com/juju/charmstore/internal/mongodoc"
@@ -18,8 +21,7 @@ import (
 // elasticsearch is not configured, allowing them to be safely called even if
 // it is not enabled in this service.
 type StoreElasticSearch struct {
-	*elasticsearch.Database
-	Index string
+	*elasticsearch.Index
 }
 
 const typeName = "entity"
@@ -27,36 +29,48 @@ const typeName = "entity"
 // Put inserts the mongodoc.Entity into elasticsearch if elasticsearch
 // is configured.
 func (ses *StoreElasticSearch) put(entity *mongodoc.Entity) error {
-	if ses == nil || ses.Database == nil {
+	if ses == nil || ses.Index == nil {
 		return nil
 	}
-	return ses.PutDocument(ses.Index, typeName, ses.getID(entity), entity)
+	return ses.PutDocument(typeName, ses.getID(entity), entity)
 }
 
-// getID returns the id to be used for indexing the entity into ElasticSearch.
+// getID returns an ID for the elasticsearch document based on the contents of the
+// mongoDB document. This is to allow elasticsearch documents to be replaced with
+// updated versions when charm data is changed.
 func (ses *StoreElasticSearch) getID(entity *mongodoc.Entity) string {
-	return url.QueryEscape(entity.URL.String())
+	b := sha1.Sum([]byte(entity.URL.String()))
+	s := base64.URLEncoding.EncodeToString(b[:])
+	// Cut off any trailing = as there is no need for them and they will get URL escaped.
+	return strings.TrimRight(s, "=")
 }
 
-// Search searches for entities. The query is a json string which conforms
-// to the elasticsearch querydsl.
-// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html
-// It returns a slice containing each Id of the matching documents returned by
-// elasticsearch.
-func (ses *StoreElasticSearch) search(query string) ([]string, error) {
-	if ses == nil || ses.Database == nil {
-		return nil, nil
+// Search searches for matching entities in the configured elasticsearch index.
+// If there is no elasticsearch index configured then it will return an empty
+// SearchResult, as if no results were found.
+func (ses *StoreElasticSearch) search(sp SearchParams) (SearchResult, error) {
+	if ses == nil || ses.Index == nil {
+		return SearchResult{}, nil
 	}
-	results, err := ses.Database.Search(ses.Index, typeName, query)
+	q := createSearchDSL(sp)
+	q.Fields = append(q.Fields, "URL")
+	esr, err := ses.Search(typeName, q)
 	if err != nil {
-		return nil, err
+		return SearchResult{}, errgo.Mask(err)
 	}
-	ids := make([]string, 0, len(results.Hits.Hits))
-	for _, hit := range results.Hits.Hits {
-		ids = append(ids, hit.ID)
+	r := SearchResult{
+		SearchTime: time.Duration(esr.Took) * time.Millisecond,
+		Total:      esr.Hits.Total,
+		Results:    make([]*charm.Reference, 0, len(esr.Hits.Hits)),
 	}
-	return ids, nil
-	// TODO: return more than just ids e.g. total, hits, score, information, serach time
+	for _, h := range esr.Hits.Hits {
+		ref, err := charm.ParseReference(h.Fields.GetString("URL"))
+		if err != nil {
+			return SearchResult{}, errgo.Notef(err, "invalid result %q", h.Fields.GetString("URL"))
+		}
+		r.Results = append(r.Results, ref)
+	}
+	return r, nil
 }
 
 // ExportToElasticSearch reads all of the mongodoc Entities and writes
@@ -64,7 +78,7 @@ func (ses *StoreElasticSearch) search(query string) ([]string, error) {
 func (store *Store) ExportToElasticSearch() error {
 	var result mongodoc.Entity
 	iter := store.DB.Entities().Find(nil).Iter()
-	defer iter.Close()
+	defer iter.Close() // Make sure we always close on error.
 	for iter.Next(&result) {
 		if err := store.ES.put(&result); err != nil {
 			return errgo.Notef(err, "cannot index %s", result.URL)
@@ -76,7 +90,7 @@ func (store *Store) ExportToElasticSearch() error {
 	return nil
 }
 
-// SearchParams represents the search parameters used by the store.
+// SearchParams represents the search parameters used to search the store.
 type SearchParams struct {
 	// The text to use in the full text search query.
 	Text string
@@ -87,14 +101,25 @@ type SearchParams struct {
 	Filters map[string][]string
 	// Limit the number of returned items to the specified count.
 	Limit int
+	// Include the following metadata items in the search results
+	Include []string
 }
 
-// Search the store for the given SearchParams.
-// Returns a slice containing each Id of the matching documents returned by
-// elasticsearch.
-func (store *Store) Search(sp SearchParams) ([]string, error) {
-	query := createSearchDSL(sp)
-	return store.ES.search(query)
+// SearchResult represents the result of performing a search.
+type SearchResult struct {
+	SearchTime time.Duration
+	Total      int
+	Results    []*charm.Reference
+}
+
+// Search searches the store for the given SearchParams.
+// It returns a slice a SearchResult containing the results of the search.
+func (store *Store) Search(sp SearchParams) (SearchResult, error) {
+	results, err := store.ES.search(sp)
+	if err != nil {
+		return SearchResult{}, errgo.Mask(err)
+	}
+	return results, nil
 }
 
 // queryFields provides a map of fields to weighting to use with the
@@ -123,7 +148,7 @@ func encodeFields(fields map[string]float64) []string {
 
 // createSearchDSL builds an elasticsearch query from the query parameters.
 // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html
-func createSearchDSL(sp SearchParams) string {
+func createSearchDSL(sp SearchParams) elasticsearch.QueryDSL {
 	qdsl := elasticsearch.QueryDSL{
 		Size: sp.Limit,
 	}
@@ -157,11 +182,7 @@ func createSearchDSL(sp SearchParams) string {
 		Filter: createFilters(sp.Filters),
 	}
 
-	bytes, err := json.Marshal(qdsl)
-	if err != nil {
-		panic(err)
-	}
-	return string(bytes)
+	return qdsl
 }
 
 // createFilters converts the filters requested with the serch API into
@@ -169,8 +190,8 @@ func createSearchDSL(sp SearchParams) string {
 // for details of how filters are specified in the API. For each key in f a filter is
 // created that matches any one of the set of values specified for that key.
 // The created filter will only match when at least one of the requested values
-// matches for all of the requested keys. createFilters will silently skip over any
-// filter names that are not mapped.
+// matches for all of the requested keys. Any filter names that are not defined
+// in the filters map will be silently skipped.
 func createFilters(f map[string][]string) elasticsearch.Filter {
 	af := make(elasticsearch.AndFilter, 0, len(f))
 	for k, vals := range f {
@@ -192,7 +213,7 @@ func createFilters(f map[string][]string) elasticsearch.Filter {
 // given value.
 var filters = map[string]func(string) elasticsearch.Filter{
 	"description": descriptionFilter,
-	"name":        termFilter("CharmMeta.Name"),
+	"name":        nameFilter,
 	"owner":       ownerFilter,
 	"provides":    termFilter("CharmProvidedInterfaces"),
 	"requires":    termFilter("CharmRequiredInterfaces"),
@@ -214,12 +235,28 @@ func descriptionFilter(value string) elasticsearch.Filter {
 	}
 }
 
+// nameFilter generates a filter that will match against the
+// name of the charm or bundle.
+func nameFilter(value string) elasticsearch.Filter {
+	// TODO(mhilton) implement wildcards as in http://tinyurl.com/k46xexe
+	return elasticsearch.RegexpFilter{
+		Field:  "URL",
+		Regexp: `cs:(\~[^/]*/)?[^/]*/` + elasticsearch.EscapeRegexp(value) + "-[1-9][0-9]*",
+	}
+}
+
 // ownerFilter generates a filter that will match against the
 // owner taken from the URL.
 func ownerFilter(value string) elasticsearch.Filter {
+	var re string
+	if value == "" {
+		re = `cs:[^\~].*`
+	} else {
+		re = `cs:\~` + elasticsearch.EscapeRegexp(value) + "/.*"
+	}
 	return elasticsearch.RegexpFilter{
 		Field:  "URL",
-		Regexp: "cs:~" + value + "/.*",
+		Regexp: re,
 	}
 }
 
@@ -228,7 +265,7 @@ func ownerFilter(value string) elasticsearch.Filter {
 func seriesFilter(value string) elasticsearch.Filter {
 	return elasticsearch.RegexpFilter{
 		Field:  "URL",
-		Regexp: "cs:(~[^/]*/)?" + value + "/.*",
+		Regexp: `cs:(\~[^/]*/)?` + elasticsearch.EscapeRegexp(value) + "/.*-[1-9][0-9]*",
 	}
 }
 
@@ -248,26 +285,42 @@ func summaryFilter(value string) elasticsearch.Filter {
 // in the data. For charms this is the Categories field and for bundles this
 // is the Tags field.
 func tagsFilter(value string) elasticsearch.Filter {
-	return elasticsearch.OrFilter{
-		elasticsearch.TermFilter{
-			Field: "CharmMeta.Categories",
-			Value: value,
-		},
-		elasticsearch.TermFilter{
-			Field: "BundleData.Tags",
-			Value: value,
-		},
+	tags := strings.Split(value, " ")
+	af := make(elasticsearch.AndFilter, 0, len(tags))
+	for _, t := range tags {
+		if t == "" {
+			continue
+		}
+		af = append(af, elasticsearch.OrFilter{
+			elasticsearch.TermFilter{
+				Field: "CharmMeta.Categories",
+				Value: t,
+			},
+			elasticsearch.TermFilter{
+				Field: "BundleData.Tags",
+				Value: t,
+			},
+		})
 	}
+	return af
 }
 
 // termFilter creates a function that generates a filter on the specified
 // document field.
 func termFilter(field string) func(string) elasticsearch.Filter {
 	return func(value string) elasticsearch.Filter {
-		return elasticsearch.TermFilter{
-			Field: field,
-			Value: value,
+		terms := strings.Split(value, " ")
+		af := make(elasticsearch.AndFilter, 0, len(terms))
+		for _, t := range terms {
+			if t == "" {
+				continue
+			}
+			af = append(af, elasticsearch.TermFilter{
+				Field: field,
+				Value: t,
+			})
 		}
+		return af
 	}
 }
 

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -30,11 +30,11 @@ type ServerParams struct {
 // versions using db to store that charm store data.
 // The key of the versions map is the version name.
 // The handler configuration is provided to all version handlers.
-func NewServer(db *mgo.Database, es *elasticsearch.Database, config ServerParams, versions map[string]NewAPIHandlerFunc) (http.Handler, error) {
+func NewServer(db *mgo.Database, es *elasticsearch.Index, config ServerParams, versions map[string]NewAPIHandlerFunc) (http.Handler, error) {
 	if len(versions) == 0 {
 		return nil, errgo.Newf("charm store server must serve at least one version of the API")
 	}
-	store, err := NewStore(db, &StoreElasticSearch{es, "charmstore"})
+	store, err := NewStore(db, &StoreElasticSearch{es})
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot make store")
 	}

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -107,7 +107,7 @@ func (s *ServerSuite) TestNewServerWithElasticSearch(c *gc.C) {
 			return config, nil
 		})
 	}
-	h, err := NewServer(s.Session.DB("foo"), s.ES, serverParams, map[string]NewAPIHandlerFunc{
+	h, err := NewServer(s.Session.DB("foo"), s.ES.Index(s.TestIndex), serverParams, map[string]NewAPIHandlerFunc{
 		"version1": serveConfig,
 	})
 	c.Assert(err, gc.IsNil)

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -35,8 +35,7 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool) {
 	var ses *StoreElasticSearch
 	if addToES {
 		ses = &StoreElasticSearch{
-			Database: s.ES,
-			Index:    s.NewIndex(c),
+			s.ES.Index(s.TestIndex),
 		}
 	}
 	store, err := NewStore(s.Session.DB("juju_test"), ses)
@@ -56,9 +55,9 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool) {
 	// Ensure the document was indexed in ElasticSearch, if an ES database was provided.
 	if ses != nil {
 		var result mongodoc.Entity
-		err = ses.Database.GetDocument(ses.Index, typeName, ses.getID(&doc), &result)
+		err = ses.GetDocument(typeName, ses.getID(&doc), &result)
 		c.Assert(err, gc.IsNil)
-		exists, err := ses.Database.EnsureID(ses.Index, typeName, ses.getID(&doc))
+		exists, err := ses.Database.EnsureID(ses.Index.Index, typeName, ses.getID(&doc))
 		c.Assert(err, gc.IsNil)
 		c.Assert(exists, gc.Equals, true)
 	}
@@ -112,8 +111,7 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bool) 
 
 	if addToES {
 		ses = &StoreElasticSearch{
-			Database: s.ES,
-			Index:    s.NewIndex(c),
+			s.ES.Index(s.TestIndex),
 		}
 	}
 	store, err := NewStore(s.Session.DB("juju_test"), ses)
@@ -134,7 +132,7 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bool) 
 	// Ensure the document was indexed in ElasticSearch, if an ES database was provided.
 	if ses != nil {
 		var result mongodoc.Entity
-		err = ses.Database.GetDocument(ses.Index, typeName, ses.getID(&doc), &result)
+		err = ses.GetDocument(typeName, ses.getID(&doc), &result)
 		c.Assert(err, gc.IsNil)
 	}
 

--- a/internal/elasticsearch/definitions/entity.json
+++ b/internal/elasticsearch/definitions/entity.json
@@ -1,141 +1,74 @@
 {
-    "entity" : {
+  "entity" : {
+    "dynamic" : "false",
+    "properties" : {
+      "URL" : {
+        "type" : "string",
+        "index" : "not_analyzed",
+        "index_options" : "docs"
+      },
+      "BaseURL" : {
+        "type" : "string",
+        "index": "not_analyzed",
+        "index_options" : "docs"
+      },
+      "BlobHash" : {
+        "type" : "string",
+        "index" : "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+      "UploadTime" : {
+        "type" : "date",
+        "format" : "dateOptionalTime"
+      },
+      "CharmMeta" : {
         "dynamic" : "false",
         "properties" : {
-          "id" : {
-            "type" : "string",
-            "index" : "not_analyzed",
-            "omit_norms" : true,
-            "index_options" : "docs"
+          "Name" : {
+            "type" : "multi_field",
+            "fields" : {
+              "Name" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
+              },
+              "ngrams" : {
+                "type" : "string",
+                "analyzer" : "n3_20grams",
+                "include_in_all" : false
+              }
+            }
           },
-          "baseurl" : {
-            "type" : "string",
-            "omit_norms" : true,
-            "index_options" : "docs"
+          "Summary" : {
+            "type" : "string"
           },
-          "blobhash" : {
-            "type" : "string",
-            "index" : "not_analyzed",
-            "omit_norms" : true,
-            "index_options" : "docs"
+          "Description" : {
+            "type" : "string"
           },
-          "uploadtime" : {
-            "type" : "date",
-            "format" : "dateOptionalTime"
-          },
-          "charmmeta" : {
+          "Provides" : {
             "dynamic" : "false",
             "properties" : {
-              "name" : {
-                "type" : "multi_field",
-                "fields" : {
-                  "name" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "ngrams" : {
-                    "type" : "string",
-                    "analyser" : "n3_20grams",
-                    "include_in_all" : false
-                  }
-                }
+              "Name" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
               },
-              "summary" : {
-                "type" : "string"
+              "Role" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
               },
-              "description" : {
-                "type" : "string"
+              "Interface" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
               },
-              "provides" : {
-                "dynamic" : "false",
-                "properties" : {
-                  "name" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "role" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "interface" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "scope" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  }
-                }
-              },
-              "requires" : {
-                "dynamic" : "false",
-                "properties" : {
-                  "name" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "role" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "interface" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "scope" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  }
-                }
-              },
-              "peers" : {
-                "dynamic" : "false",
-                "properties" : {
-                  "name" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "role" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "interface" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "scope" : {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  }
-                }
-              },
-              "categories" : {
+              "Scope" : {
                 "type" : "string",
                 "index" : "not_analyzed",
                 "omit_norms" : true,
@@ -143,29 +76,28 @@
               }
             }
           },
-          "charmconfig" : {
+          "Requires" : {
             "dynamic" : "false",
             "properties" : {
-              "options" : {
-                "dynamic" : "false",
-                "properties" : {
-                  "description" : {
-                    "type" : "string"
-                  },
-                  "default" : {
-                    "type" : "string"
-                  }
-                }
-              }
-            }
-          },
-          "charmactions" : {
-            "dynamic" : "false",
-            "properties" : {
-              "description" : {
-                "type" : "string"
+              "Name" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
               },
-              "action_name" : {
+              "Role" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
+              },
+              "Interface" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
+              },
+              "Scope" : {
                 "type" : "string",
                 "index" : "not_analyzed",
                 "omit_norms" : true,
@@ -173,69 +105,138 @@
               }
             }
           },
-          "charmprovidedinterfaces" : {
-            "type" : "string",
-            "index" : "not_analyzed",
-            "omit_norms" : true,
-            "index_options" : "docs"
-          },
-          "charmrequiredinterfaces" : {
-            "type" : "string",
-            "index" : "not_analyzed",
-            "omit_norms" : true,
-            "index_options" : "docs"
-          },
-
-
-          "bundledata" : {
-            "type": "object",
-            "dynamic": "false",
+          "Peers" : {
+            "dynamic" : "false",
             "properties" : {
-              "services" : {
-                "type": "object",
-                "dynamic": "false",
-                "properties": {
-                  "charm": {
-                    "type" : "string",
-                    "index" : "not_analyzed",
-                    "omit_norms" : true,
-                    "index_options" : "docs"
-                  },
-                  "numunits": {
-                    "type" : "integer",
-                    "index": "not_analyzed"
-                  }
-                }
+              "Name" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
               },
-              "series" : {
-                "type" : "string"
+              "Role" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
               },
-              "relations" : {
-                    "type" : "string",
-                    "index": "not_analyzed"
-                  }
-                }
+              "Interface" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
+              },
+              "Scope" : {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
               }
             }
           },
-          "bundlereadme" : {
-            "type": "string",
-            "index": "not_analyzed",
+          "Categories" : {
+            "type" : "string",
+            "index" : "not_analyzed",
             "omit_norms" : true,
             "index_options" : "docs"
-          },
-          "bundlecharms": {
-            "type": "string",
-            "index": "not_analyzed",
-            "omit_norms" : true,
-            "index_options" : "docs"
-          },
-          "bundlemachinecount": {
-            "type": "integer"
-          },
-          "bundleunitcount": {
-            "type": "integer"
           }
         }
+      },
+      "CharmConfig" : {
+        "dynamic" : "false",
+        "properties" : {
+          "Options" : {
+            "dynamic" : "false",
+            "properties" : {
+              "Description" : {
+                "type" : "string"
+              },
+              "Default" : {
+                "type" : "string"
+              }
+            }
+          }
+        }
+      },
+      "charmactions" : {
+        "dynamic" : "false",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "action_name" : {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "omit_norms" : true,
+            "index_options" : "docs"
+          }
+        }
+      },
+      "CharmProvidedInterfaces" : {
+        "type" : "string",
+        "index" : "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+      "CharmRequiredInterfaces" : {
+        "type" : "string",
+        "index" : "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+
+
+      "BundleData" : {
+        "type": "object",
+        "dynamic": "false",
+        "properties" : {
+          "Services" : {
+            "type": "object",
+            "dynamic": "false",
+            "properties": {
+              "Charm": {
+                "type" : "string",
+                "index" : "not_analyzed",
+                "omit_norms" : true,
+                "index_options" : "docs"
+              },
+              "NumUnits": {
+                "type" : "integer",
+                "index": "not_analyzed"
+              }
+            }
+          },
+          "Series" : {
+            "type" : "string"
+          },
+          "Relations" : {
+            "type" : "string",
+            "index": "not_analyzed"
+          },
+         "Tags" : {
+            "type" : "string",
+            "index": "not_analyzed"
+          }
+        }
+      },
+      "BundleReadMe" : {
+        "type": "string",
+        "index": "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+      "BundleCharms": {
+        "type": "string",
+        "index": "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+      "BundleMachineCount": {
+        "type": "integer"
+      },
+      "BundleUnitCount": {
+        "type": "integer"
       }
+    }
+  }
 }

--- a/internal/elasticsearch/definitions/index.json
+++ b/internal/elasticsearch/definitions/index.json
@@ -1,29 +1,24 @@
 {
-  "charmstore" : {
-    "settings" : {
-      "index": {
-        "number_of_replicas" : "0",
-        "number_of_shards" : "1"
+    "settings": {
+        "number_of_shards": 1,
+        "analysis": {
+            "filter": {
+                "n3_20grams_filter": {
+                    "type":     "nGram",
+                    "min_gram": 3,
+                    "max_gram": 20
+                }
+            },
+            "analyzer": {
+                "n3_20grams": {
+                    "type":      "custom",
+                    "tokenizer": "standard",
+                    "filter": [
+                        "lowercase",
+                        "n3_20grams_filter"
+                    ]
+                }
+            }
         }
-    },
-    "analysis": {
-      "filter": {
-        "n3_20grams_filter": {
-          "type": "ngram",
-          "min_gram": 3,
-          "max_gram": 20
-        }
-      },
-      "analyser": {
-        "n3_20grams": {
-          "type": "custom",
-          "tokenizer": "standard",
-          "filter": [
-            "lowercase",
-            "n3_20grams_filter"
-          ]
-        }
-      }
     }
-  }
 }

--- a/internal/elasticsearch/query_test.go
+++ b/internal/elasticsearch/query_test.go
@@ -1,0 +1,105 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package elasticsearch_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	. "github.com/juju/charmstore/internal/elasticsearch"
+	"github.com/juju/charmstore/internal/storetesting"
+)
+
+type QuerySuite struct{}
+
+var _ = gc.Suite(&QuerySuite{})
+
+func (s *QuerySuite) TestJSONEncodings(c *gc.C) {
+	var tests = []struct {
+		about string
+		query interface{}
+		json  string
+	}{{
+		about: "term query",
+		query: TermQuery{Field: "foo", Value: "bar"},
+		json:  `{"term": {"foo": "bar"}}`,
+	}, {
+		about: "match all query",
+		query: MatchAllQuery{},
+		json:  `{"match_all": {}}`,
+	}, {
+		about: "match query",
+		query: MatchQuery{Field: "foo", Query: "bar"},
+		json:  `{"match": {"foo": {"query": "bar"}}}`,
+	}, {
+		about: "match query with type",
+		query: MatchQuery{Field: "foo", Query: "bar", Type: "baz"},
+		json:  `{"match": {"foo": {"query": "bar", "type": "baz"}}}`,
+	}, {
+		about: "multi match query",
+		query: MultiMatchQuery{Query: "foo", Fields: []string{BoostField("bar", 2), "baz"}},
+		json:  `{"multi_match": {"query": "foo", "fields": ["bar^2.000000", "baz"]}}`,
+	}, {
+		about: "filtered query",
+		query: FilteredQuery{
+			Query:  TermQuery{Field: "foo", Value: "bar"},
+			Filter: TermFilter{Field: "baz", Value: "quz"}},
+		json: `{"filtered": {"query": {"term": {"foo": "bar"}}, "filter": {"term": {"baz": "quz"}}}}`,
+	}, {
+		about: "function score query",
+		query: FunctionScoreQuery{
+			Query: TermQuery{Field: "foo", Value: "bar"},
+			Functions: []Function{{
+				Function: "baz",
+				Field:    "foo",
+				Scale:    "quz",
+			}},
+		},
+		json: `{"function_score": {"query": {"term": {"foo": "bar"}}, "functions": [{"baz": {"foo":{"scale": "quz"}}}]}}`,
+	}, {
+		about: "term filter",
+		query: TermFilter{Field: "foo", Value: "bar"},
+		json:  `{"term": {"foo": "bar"}}`,
+	}, {
+		about: "and filter",
+		query: AndFilter{
+			TermFilter{Field: "foo", Value: "bar"},
+			TermFilter{Field: "baz", Value: "quz"},
+		},
+		json: `{"and": {"filters": [{"term": {"foo": "bar"}}, {"term": {"baz": "quz"}}]}}`,
+	}, {
+		about: "or filter",
+		query: OrFilter{
+			TermFilter{Field: "foo", Value: "bar"},
+			TermFilter{Field: "baz", Value: "quz"},
+		},
+		json: `{"or": {"filters": [{"term": {"foo": "bar"}}, {"term": {"baz": "quz"}}]}}`,
+	}, {
+		about: "not filter",
+		query: NotFilter{TermFilter{Field: "foo", Value: "bar"}},
+		json:  `{"not": {"term": {"foo": "bar"}}}`,
+	}, {
+		about: "query filter",
+		query: QueryFilter{Query: TermQuery{Field: "foo", Value: "bar"}},
+		json:  `{"query": {"term": {"foo": "bar"}}}`,
+	}, {
+		about: "regexp filter",
+		query: RegexpFilter{Field: "foo", Regexp: ".*"},
+		json:  `{"regexp": {"foo": ".*"}}`,
+	}, {
+		about: "query dsl",
+		query: QueryDSL{
+			Fields: []string{"foo", "bar"},
+			Size:   10,
+			Query:  TermQuery{Field: "baz", Value: "quz"},
+			Sort:   []Sort{{Field: "foo", Order: Order{"desc"}}},
+		},
+		json: `{"fields": ["foo", "bar"], "size": 10, "query": {"term": {"baz": "quz"}}, "sort": [{"foo": { "order": "desc"}}]}`,
+	}}
+	for i, test := range tests {
+		c.Logf("%d: %s", i, test.about)
+		// Note JSONEquals is being used a bit backwards here, this is fine
+		// but any error results may be a little confusing.
+		c.Assert([]byte(test.json), storetesting.JSONEquals, test.query)
+	}
+}

--- a/internal/storetesting/elasticsearch.go
+++ b/internal/storetesting/elasticsearch.go
@@ -51,6 +51,9 @@ type ElasticSearchSuite struct {
 }
 
 func (s *ElasticSearchSuite) SetUpSuite(c *gc.C) {
+	if serverAddr == "" {
+		c.Skip("elasticsearch disabled")
+	}
 	s.ES = &elasticsearch.Database{fmt.Sprintf(serverAddr)}
 }
 
@@ -76,4 +79,15 @@ func (s *ElasticSearchSuite) NewIndex(c *gc.C) string {
 	id := time.Now().Format("20060102") + uuid.String() + "-"
 	s.indexes = append(s.indexes, id)
 	return id
+}
+
+// LoadESConfig loads a canned test configuration to the specified index
+func (s *ElasticSearchSuite) LoadESConfig(index string) error {
+	if err := s.ES.PutIndex(index, esIndex); err != nil {
+		return err
+	}
+	if err := s.ES.PutMapping(index, "entity", esMapping); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/storetesting/essettings.go
+++ b/internal/storetesting/essettings.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-package charmstore
+package storetesting
 
 import "encoding/json"
 

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -44,7 +44,7 @@ var _ = gc.Suite(&ArchiveSuite{})
 
 func (s *ArchiveSuite) SetUpTest(c *gc.C) {
 	s.IsolatedMgoSuite.SetUpTest(c)
-	s.srv, s.store = newServer(c, s.Session, serverParams)
+	s.srv, s.store = newServer(c, s.Session, nil, serverParams)
 }
 
 func (s *ArchiveSuite) TestGet(c *gc.C) {

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -13,4 +13,5 @@ func BundleCharms(h http.Handler) func([]string) (map[string]charm.Charm, error)
 	return h.(*Handler).bundleCharms
 }
 
+var ParseSearchParams = parseSearchParams
 var StartTime = &startTime

--- a/internal/v4/package_test.go
+++ b/internal/v4/package_test.go
@@ -7,8 +7,12 @@ import (
 	"testing"
 
 	jujutesting "github.com/juju/testing"
+
+	"github.com/juju/charmstore/internal/storetesting"
 )
 
 func TestPackage(t *testing.T) {
-	jujutesting.MgoTestPackage(t, nil)
+	storetesting.ElasticSearchTestPackage(t, func(t2 *testing.T) {
+		jujutesting.MgoTestPackage(t2, nil)
+	})
 }

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -35,7 +35,7 @@ var _ = gc.Suite(&RelationsSuite{})
 
 func (s *RelationsSuite) SetUpTest(c *gc.C) {
 	s.IsolatedMgoSuite.SetUpTest(c)
-	s.srv, s.store = newServer(c, s.Session, serverParams)
+	s.srv, s.store = newServer(c, s.Session, nil, serverParams)
 }
 
 // metaCharmRelatedCharms defines a bunch of charms to be used in

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -1,27 +1,76 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-package v4
+package v4_test
 
 import (
+	"encoding/json"
 	"net/http"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+	"gopkg.in/juju/charm.v4/testing"
 
+	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/storetesting"
+	. "github.com/juju/charmstore/internal/v4"
+	"github.com/juju/charmstore/params"
 )
 
 type SearchSuite struct {
 	storetesting.IsolatedMgoESSuite
+	srv   http.Handler
+	store *charmstore.Store
 }
 
 var _ = gc.Suite(&SearchSuite{})
 
+var exportTestCharms = map[string]string{
+	"wordpress": "cs:precise/wordpress-23",
+	"mysql":     "cs:trusty/mysql-7",
+	"varnish":   "cs:~foo/trusty/varnish-1",
+}
+
+var exportTestBundles = map[string]string{
+	"wordpress": "cs:bundle/wordpress-4",
+}
+
+func (s *SearchSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoESSuite.SetUpTest(c)
+	s.srv, s.store = newServer(c, s.Session, s.ES.Index(s.TestIndex), serverParams)
+	err := s.LoadESConfig(s.TestIndex)
+	c.Assert(err, gc.IsNil)
+	s.addCharmsToStore(s.store)
+	err = s.ES.RefreshIndex(s.TestIndex)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *SearchSuite) addCharmsToStore(store *charmstore.Store) {
+	for name, ref := range exportTestCharms {
+		store.AddCharmWithArchive(charm.MustParseReference(ref), getCharm(name))
+	}
+	for name, ref := range exportTestBundles {
+		store.AddBundleWithArchive(charm.MustParseReference(ref), getBundle(name))
+	}
+}
+
+func getCharm(name string) *charm.CharmDir {
+	ca := testing.Charms.CharmDir(name)
+	ca.Meta().Categories = []string{name, "bar"}
+	return ca
+}
+
+func getBundle(name string) *charm.BundleDir {
+	ba := testing.Charms.BundleDir(name)
+	ba.Data().Tags = []string{name, "baz"}
+	return ba
+}
+
 func (s *SearchSuite) TestParseSearchParamsText(c *gc.C) {
 	var req http.Request
 	req.Form = map[string][]string{"text": {"test text"}}
-	sp, err := parseSearchParams(&req)
+	sp, err := ParseSearchParams(&req)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sp.Text, gc.Equals, "test text")
 }
@@ -29,7 +78,7 @@ func (s *SearchSuite) TestParseSearchParamsText(c *gc.C) {
 func (s *SearchSuite) TestParseSearchParamsAutocompete(c *gc.C) {
 	var req http.Request
 	req.Form = map[string][]string{"autocomplete": {"1"}}
-	sp, err := parseSearchParams(&req)
+	sp, err := ParseSearchParams(&req)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sp.AutoComplete, gc.Equals, true)
 }
@@ -40,7 +89,7 @@ func (s *SearchSuite) TestParseSearchParamsFilters(c *gc.C) {
 		"tags": {"f11", "f12"},
 		"name": {"f21"},
 	}
-	sp, err := parseSearchParams(&req)
+	sp, err := ParseSearchParams(&req)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sp.Filters["tags"], jc.DeepEquals, []string{"f11", "f12"})
 	c.Assert(sp.Filters["name"], jc.DeepEquals, []string{"f21"})
@@ -49,7 +98,7 @@ func (s *SearchSuite) TestParseSearchParamsFilters(c *gc.C) {
 func (s *SearchSuite) TestParseSearchParamsLimit(c *gc.C) {
 	var req http.Request
 	req.Form = map[string][]string{"limit": {"20"}}
-	sp, err := parseSearchParams(&req)
+	sp, err := ParseSearchParams(&req)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sp.Limit, gc.Equals, 20)
 }
@@ -57,7 +106,258 @@ func (s *SearchSuite) TestParseSearchParamsLimit(c *gc.C) {
 func (s *SearchSuite) TestParseSearchParamsInclude(c *gc.C) {
 	var req http.Request
 	req.Form = map[string][]string{"include": {"meta1", "meta2"}}
-	sp, err := parseSearchParams(&req)
+	sp, err := ParseSearchParams(&req)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sp.Include, jc.DeepEquals, []string{"meta1", "meta2"})
+}
+
+func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
+	tests := []struct {
+		about   string
+		query   string
+		results []string
+	}{{
+		about: "bare search",
+		query: "",
+		results: []string{
+			exportTestCharms["wordpress"],
+			exportTestCharms["mysql"],
+			exportTestCharms["varnish"],
+			exportTestBundles["wordpress"],
+		},
+	}, {
+		about: "text search",
+		query: "text=wordpress",
+		results: []string{
+			exportTestCharms["wordpress"],
+		},
+	}, {
+		about: "autocomplete search",
+		query: "text=word&autocomplete=1",
+		results: []string{
+			exportTestCharms["wordpress"],
+		},
+	}, {
+		about: "blank text search",
+		query: "text=",
+		results: []string{
+			exportTestCharms["wordpress"],
+			exportTestCharms["mysql"],
+			exportTestCharms["varnish"],
+			exportTestBundles["wordpress"],
+		},
+	}, {
+		about: "description filter search",
+		query: "description=database",
+		results: []string{
+			exportTestCharms["mysql"],
+			exportTestCharms["varnish"],
+		},
+	}, {
+		about: "name filter search",
+		query: "name=mysql",
+		results: []string{
+			exportTestCharms["mysql"],
+		},
+	}, {
+		about: "owner filter search",
+		query: "owner=foo",
+		results: []string{
+			exportTestCharms["varnish"],
+		},
+	}, {
+		about: "provides filter search",
+		query: "provides=mysql",
+		results: []string{
+			exportTestCharms["mysql"],
+		},
+	}, {
+		about: "requires filter search",
+		query: "requires=mysql",
+		results: []string{
+			exportTestCharms["wordpress"],
+		},
+	}, {
+		about: "series filter search",
+		query: "series=trusty",
+		results: []string{
+			exportTestCharms["mysql"],
+			exportTestCharms["varnish"],
+		},
+	}, {
+		about: "summary filter search",
+		query: "summary=database",
+		results: []string{
+			exportTestCharms["mysql"],
+			exportTestCharms["varnish"],
+		},
+	}, {
+		about: "tags filter search",
+		query: "tags=wordpress",
+		results: []string{
+			exportTestCharms["wordpress"],
+			exportTestBundles["wordpress"],
+		},
+	}, {
+		about: "type filter search",
+		query: "type=bundle",
+		results: []string{
+			exportTestBundles["wordpress"],
+		},
+	}, {
+		about: "multiple type filter search",
+		query: "type=bundle&type=charm",
+		results: []string{
+			exportTestCharms["wordpress"],
+			exportTestCharms["mysql"],
+			exportTestCharms["varnish"],
+			exportTestBundles["wordpress"],
+		},
+	}, {
+		about: "provides multiple interfaces filter search",
+		query: "provides=monitoring+http",
+		results: []string{
+			exportTestCharms["wordpress"],
+		},
+	}, {
+		about: "requires multiple interfaces filter search",
+		query: "requires=mysql+varnish",
+		results: []string{
+			exportTestCharms["wordpress"],
+		},
+	}, {
+		about: "multiple tags filter search",
+		query: "tags=mysql+bar",
+		results: []string{
+			exportTestCharms["mysql"],
+		},
+	}, {
+		about: "blank owner",
+		query: "owner=",
+		results: []string{
+			exportTestCharms["wordpress"],
+			exportTestCharms["mysql"],
+			exportTestBundles["wordpress"],
+		},
+	}}
+	for i, test := range tests {
+		c.Logf("test %d. %s", i, test.about)
+		rec := storetesting.DoRequest(c, storetesting.DoRequestParams{
+			Handler: s.srv,
+			URL:     storeURL("search?" + test.query),
+		})
+		var sr params.SearchResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &sr)
+		c.Assert(err, gc.IsNil)
+		c.Assert(sr.Results, gc.HasLen, len(test.results))
+	OUTER:
+		for _, res := range sr.Results {
+			for i, r := range test.results {
+				if res.Id.String() == r {
+					test.results[i] = ""
+					continue OUTER
+				}
+			}
+			c.Errorf("%s:Unexpected result received %q", test.about, res.Id.String())
+		}
+	}
+}
+
+func (s *SearchSuite) TestMetadataFields(c *gc.C) {
+	tests := []struct {
+		about string
+		query string
+		meta  map[string]interface{}
+	}{{
+		about: "archive-size",
+		query: "name=mysql&include=archive-size",
+		meta: map[string]interface{}{
+			"archive-size": params.ArchiveSizeResponse{438},
+		},
+	}, {
+		about: "bundle-metadata",
+		query: "name=wordpress&type=bundle&include=bundle-metadata",
+		meta: map[string]interface{}{
+			"bundle-metadata": getBundle("wordpress").Data(),
+		},
+	}, {
+		about: "bundle-machine-count",
+		query: "name=wordpress&type=bundle&include=bundle-machine-count",
+		meta: map[string]interface{}{
+			"bundle-machine-count": params.BundleCount{2},
+		},
+	}, {
+		about: "bundle-unit-count",
+		query: "name=wordpress&type=bundle&include=bundle-unit-count",
+		meta: map[string]interface{}{
+			"bundle-unit-count": params.BundleCount{2},
+		},
+	}, {
+		about: "charm-actions",
+		query: "name=wordpress&type=charm&include=charm-actions",
+		meta: map[string]interface{}{
+			"charm-actions": getCharm("wordpress").Actions(),
+		},
+	}, {
+		about: "charm-config",
+		query: "name=wordpress&type=charm&include=charm-config",
+		meta: map[string]interface{}{
+			"charm-config": getCharm("wordpress").Config(),
+		},
+	}, {
+		about: "charm-related",
+		query: "name=wordpress&type=charm&include=charm-related",
+		meta: map[string]interface{}{
+			"charm-related": params.RelatedResponse{
+				Provides: map[string][]params.MetaAnyResponse{
+					"mysql": {
+						{
+							Id: charm.MustParseReference(exportTestCharms["mysql"]),
+						},
+					},
+					"varnish": {
+						{
+							Id: charm.MustParseReference(exportTestCharms["varnish"]),
+						},
+					},
+				},
+			},
+		},
+	}, {
+		about: "multiple values",
+		query: "name=wordpress&type=charm&include=charm-related&include=charm-config",
+		meta: map[string]interface{}{
+			"charm-related": params.RelatedResponse{
+				Provides: map[string][]params.MetaAnyResponse{
+					"mysql": {
+						{
+							Id: charm.MustParseReference(exportTestCharms["mysql"]),
+						},
+					},
+					"varnish": {
+						{
+							Id: charm.MustParseReference(exportTestCharms["varnish"]),
+						},
+					},
+				},
+			},
+			"charm-config": getCharm("wordpress").Config(),
+		},
+	}}
+	for i, test := range tests {
+		c.Logf("test %d. %s", i, test.about)
+		rec := storetesting.DoRequest(c, storetesting.DoRequestParams{
+			Handler: s.srv,
+			URL:     storeURL("search?" + test.query),
+		})
+		var sr struct {
+			Results []struct {
+				Meta json.RawMessage
+			}
+		}
+		err := json.Unmarshal(rec.Body.Bytes(), &sr)
+		c.Assert(err, gc.IsNil)
+		c.Assert(sr.Results, gc.HasLen, 1)
+		c.Assert([]byte(sr.Results[0].Meta), storetesting.JSONEquals, test.meta)
+	}
 }

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -27,7 +27,7 @@ var _ = gc.Suite(&StatsSuite{})
 
 func (s *StatsSuite) SetUpTest(c *gc.C) {
 	s.IsolatedMgoSuite.SetUpTest(c)
-	s.srv, s.store = newServer(c, s.Session, serverParams)
+	s.srv, s.store = newServer(c, s.Session, nil, serverParams)
 }
 
 func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {

--- a/params/params.go
+++ b/params/params.go
@@ -101,13 +101,20 @@ type DebugStatus struct {
 
 // SearchResult holds a single result from a search operation
 type SearchResult struct {
-	Id string
+	Id *charm.Reference
 	// Meta holds at most one entry for each meta value
 	// specified in the include flags, holding the
 	// data that would be returned by reading /meta/meta?id=id.
 	// Metadata not relevant to a particular result will not
 	// be included.
 	Meta map[string]interface{} `json:",omitempty"`
+}
+
+// SearchResponse holds the response from a search operation.
+type SearchResponse struct {
+	SearchTime time.Duration
+	Total      int
+	Results    []SearchResult
 }
 
 // BzrDigestKey is the extra-info key used to store the Bazaar digest

--- a/server.go
+++ b/server.go
@@ -46,7 +46,7 @@ type ServerParams struct {
 // NewServer returns a new handler that handles charm store requests and stores
 // its data in the given database. The handler will serve the specified
 // versions of the API using the given configuration.
-func NewServer(db *mgo.Database, es *elasticsearch.Database, config ServerParams, serveVersions ...string) (http.Handler, error) {
+func NewServer(db *mgo.Database, es *elasticsearch.Index, config ServerParams, serveVersions ...string) (http.Handler, error) {
 	newAPIs := make(map[string]charmstore.NewAPIHandlerFunc)
 	for _, vers := range serveVersions {
 		newAPI := versions[vers]


### PR DESCRIPTION
Search results can now have metadata attached to them using the same mechanism
as the /meta handler uses. The change also includes:
- Some cleanup of the elasticsearch interface
- Search Time and Total in search response
- More tests
