### PR TITLE
internal/v4: fix meta endpoints

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -362,7 +362,13 @@ func isNull(val interface{}) bool {
 func (r *Router) metaNames() []string {
 	names := make([]string, 0, len(r.handlers.Meta))
 	for name := range r.handlers.Meta {
-		names = append(names, strings.TrimSuffix(name, "/"))
+		// Ensure that we don't generate duplicate entries
+		// when there's an entry for both "x" and "x/".
+		trimmed := strings.TrimSuffix(name, "/")
+		if trimmed != name && r.handlers.Meta[trimmed] != nil {
+			continue
+		}
+		names = append(names, trimmed)
 	}
 	sort.Strings(names)
 	return names

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -263,11 +263,14 @@ var routerGetTests = []struct {
 		Meta: map[string]BulkIncludeHandler{
 			"foo": testMetaHandler(0),
 			"bar": testMetaHandler(1),
+			"bar/": testMetaHandler(2),
+			"foo/": testMetaHandler(3),
+			"baz": testMetaHandler(4),
 		},
 	},
 	urlStr:       "/precise/wordpress-42/meta",
 	expectStatus: http.StatusOK,
-	expectBody:   []string{"bar", "foo"},
+	expectBody:   []string{"bar", "baz", "foo"},
 }, {
 	about: "meta handler",
 	handlers: Handlers{

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -78,8 +78,8 @@ func New(store *charmstore.Store, config charmstore.ServerParams) *Handler {
 				"extrainfo",
 			),
 
-			// endpoints not yet implemented - use SingleIncludeHandler for the time being.
-			"color": router.SingleIncludeHandler(h.metaColor),
+			// endpoints not yet implemented:
+			// "color": router.SingleIncludeHandler(h.metaColor),
 		},
 	}, h.resolveURL)
 	return h

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -280,6 +280,33 @@ func (s *APISuite) TestEndpointGet(c *gc.C) {
 	}
 }
 
+func (s *APISuite) TestAllMetaEndpointsTested(c *gc.C) {
+	// Make sure that we're testing all the metadata
+	// endpoints that we need to.
+	rec := storetesting.DoRequest(c, storetesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL("precise/wordpress-23/meta"),
+	})
+	var list []string
+	err := json.Unmarshal(rec.Body.Bytes(), &list)
+	c.Assert(err, gc.IsNil)
+
+	listNames := make(map[string]bool)
+	for _, name := range list {
+		c.Assert(listNames[name], gc.Equals, false, gc.Commentf("name %s", name))
+		listNames[name] = true
+	}
+
+	testNames := make(map[string]bool)
+	for _, test := range metaEndpoints {
+		if strings.Contains(test.name, "/") {
+			continue
+		}
+		testNames[test.name] = true
+	}
+	c.Assert(testNames, jc.DeepEquals, listNames)
+}
+
 var testEntities = []string{
 	// A stock charm.
 	"cs:precise/wordpress-23",


### PR DESCRIPTION
We were printing duplicate endpoints in the /meta list.
Also, when retrieving /meta/any with all meta endpoints included,
it was failing because color was not recognised.
