### PR TITLE
internal/router: allow top level meta endpoint list

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -378,6 +378,12 @@ func (r *Router) metaNames() []string {
 func (r *Router) serveBulkMeta(w http.ResponseWriter, req *http.Request) error {
 	switch req.Method {
 	case "GET", "HEAD":
+		// A bare meta returns all endpoints.
+		// See http://tinyurl.com/q2qd9nn
+		if req.URL.Path == "/" || req.URL.Path == "" {
+			jsonhttp.WriteJSON(w, http.StatusOK, r.metaNames())
+			return nil
+		}
 		resp, err := r.serveBulkMetaGet(req)
 		if err != nil {
 			return errgo.Mask(err, errgo.Any)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -261,14 +261,42 @@ var routerGetTests = []struct {
 	about: "meta list",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
-			"foo": testMetaHandler(0),
-			"bar": testMetaHandler(1),
+			"foo":  testMetaHandler(0),
+			"bar":  testMetaHandler(1),
 			"bar/": testMetaHandler(2),
 			"foo/": testMetaHandler(3),
-			"baz": testMetaHandler(4),
+			"baz":  testMetaHandler(4),
 		},
 	},
 	urlStr:       "/precise/wordpress-42/meta",
+	expectStatus: http.StatusOK,
+	expectBody:   []string{"bar", "baz", "foo"},
+}, {
+	about: "meta list at root",
+	handlers: Handlers{
+		Meta: map[string]BulkIncludeHandler{
+			"foo":  testMetaHandler(0),
+			"bar":  testMetaHandler(1),
+			"bar/": testMetaHandler(2),
+			"foo/": testMetaHandler(3),
+			"baz":  testMetaHandler(4),
+		},
+	},
+	urlStr:       "/meta",
+	expectStatus: http.StatusOK,
+	expectBody:   []string{"bar", "baz", "foo"},
+}, {
+	about: "meta list at root with trailing /",
+	handlers: Handlers{
+		Meta: map[string]BulkIncludeHandler{
+			"foo":  testMetaHandler(0),
+			"bar":  testMetaHandler(1),
+			"bar/": testMetaHandler(2),
+			"foo/": testMetaHandler(3),
+			"baz":  testMetaHandler(4),
+		},
+	},
+	urlStr:       "/meta/",
 	expectStatus: http.StatusOK,
 	expectBody:   []string{"bar", "baz", "foo"},
 }, {


### PR DESCRIPTION
We want to be able to find all meta endpoints without
necessarily inventing an entity id.
