### PR TITLE
Only index latest charm version.

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -32,14 +32,17 @@ func (ses *StoreElasticSearch) put(entity *mongodoc.Entity) error {
 	if ses == nil || ses.Index == nil {
 		return nil
 	}
-	return ses.PutDocument(typeName, ses.getID(entity), entity)
+	_, err := ses.PutDocumentVersion(typeName, ses.getID(entity), int64(entity.URL.Revision), entity)
+	return err
 }
 
 // getID returns an ID for the elasticsearch document based on the contents of the
 // mongoDB document. This is to allow elasticsearch documents to be replaced with
 // updated versions when charm data is changed.
 func (ses *StoreElasticSearch) getID(entity *mongodoc.Entity) string {
-	b := sha1.Sum([]byte(entity.URL.String()))
+	ref := *entity.URL
+	ref.Revision = -1
+	b := sha1.Sum([]byte(ref.String()))
 	s := base64.URLEncoding.EncodeToString(b[:])
 	// Cut off any trailing = as there is no need for them and they will get URL escaped.
 	return strings.TrimRight(s, "=")

--- a/internal/elasticsearch/elasticsearch_test.go
+++ b/internal/elasticsearch/elasticsearch_test.go
@@ -70,7 +70,6 @@ func (s *Suite) TestSuccessfulPutNewDocument(c *gc.C) {
 	exists, err = s.ES.EnsureID(s.TestIndex, "testtype", "a")
 	c.Assert(err, gc.IsNil)
 	c.Assert(exists, gc.Equals, true)
-
 }
 
 func (s *Suite) TestSuccessfulPutUpdatedDocument(c *gc.C) {
@@ -85,6 +84,94 @@ func (s *Suite) TestSuccessfulPutUpdatedDocument(c *gc.C) {
 	var result map[string]string
 	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
 	c.Assert(result["a"], gc.Equals, "c")
+}
+
+func (s *Suite) TestPutVersionNewDocument(c *gc.C) {
+	doc := map[string]string{
+		"a": "b",
+	}
+	// Show that no document with this id exists.
+	exists, err := s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, false)
+	stored, err := s.ES.PutDocumentVersion(s.TestIndex, "testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	var result map[string]string
+	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "b")
+	exists, err = s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, true)
+}
+
+func (s *Suite) TestPutVersionUpdateCurrentDocumentVersion(c *gc.C) {
+	doc := map[string]string{
+		"a": "b",
+	}
+	// Show that no document with this id exists.
+	exists, err := s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, false)
+	stored, err := s.ES.PutDocumentVersion(s.TestIndex, "testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	doc["a"] = "c"
+	stored, err = s.ES.PutDocumentVersion(s.TestIndex, "testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	var result map[string]string
+	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "c")
+	exists, err = s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, true)
+}
+
+func (s *Suite) TestPutVersionUpdateLaterDocumentVersion(c *gc.C) {
+	doc := map[string]string{
+		"a": "b",
+	}
+	// Show that no document with this id exists.
+	exists, err := s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, false)
+	stored, err := s.ES.PutDocumentVersion(s.TestIndex, "testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	doc["a"] = "c"
+	stored, err = s.ES.PutDocumentVersion(s.TestIndex, "testtype", "a", 3, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	var result map[string]string
+	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "c")
+	exists, err = s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, true)
+}
+
+func (s *Suite) TestPutVersionUpdateEarlierDocumentVersion(c *gc.C) {
+	doc := map[string]string{
+		"a": "b",
+	}
+	// Show that no document with this id exists.
+	exists, err := s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, false)
+	stored, err := s.ES.PutDocumentVersion(s.TestIndex, "testtype", "a", 3, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	doc["a"] = "c"
+	stored, err = s.ES.PutDocumentVersion(s.TestIndex, "testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, false)
+	var result map[string]string
+	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "b")
+	exists, err = s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, true)
 }
 
 func (s *Suite) TestDelete(c *gc.C) {
@@ -179,6 +266,98 @@ func (s *Suite) TestIndexPutDocument(c *gc.C) {
 	var result map[string]string
 	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
 	c.Assert(result["a"], gc.Equals, "g")
+}
+
+func (s *Suite) TestIndexPutVersionNewDocument(c *gc.C) {
+	i := s.ES.Index(s.TestIndex)
+	doc := map[string]string{
+		"a": "b",
+	}
+	// Show that no document with this id exists.
+	exists, err := s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, false)
+	stored, err := i.PutDocumentVersion("testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	var result map[string]string
+	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "b")
+	exists, err = s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, true)
+}
+
+func (s *Suite) TestIndexPutVersionUpdateCurrentDocumentVersion(c *gc.C) {
+	i := s.ES.Index(s.TestIndex)
+	doc := map[string]string{
+		"a": "b",
+	}
+	// Show that no document with this id exists.
+	exists, err := s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, false)
+	stored, err := i.PutDocumentVersion("testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	doc["a"] = "c"
+	stored, err = i.PutDocumentVersion("testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	var result map[string]string
+	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "c")
+	exists, err = s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, true)
+}
+
+func (s *Suite) TestIndexPutVersionUpdateLaterDocumentVersion(c *gc.C) {
+	i := s.ES.Index(s.TestIndex)
+	doc := map[string]string{
+		"a": "b",
+	}
+	// Show that no document with this id exists.
+	exists, err := s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, false)
+	stored, err := i.PutDocumentVersion("testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	doc["a"] = "c"
+	stored, err = i.PutDocumentVersion("testtype", "a", 3, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	var result map[string]string
+	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "c")
+	exists, err = s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, true)
+}
+
+func (s *Suite) TestIndexPutVersionUpdateEarlierDocumentVersion(c *gc.C) {
+	i := s.ES.Index(s.TestIndex)
+	doc := map[string]string{
+		"a": "b",
+	}
+	// Show that no document with this id exists.
+	exists, err := s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, false)
+	stored, err := i.PutDocumentVersion("testtype", "a", 3, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, true)
+	doc["a"] = "c"
+	stored, err = i.PutDocumentVersion("testtype", "a", 1, doc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(stored, gc.Equals, false)
+	var result map[string]string
+	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
+	c.Assert(result["a"], gc.Equals, "b")
+	exists, err = s.ES.EnsureID(s.TestIndex, "testtype", "a")
+	c.Assert(err, gc.IsNil)
+	c.Assert(exists, gc.Equals, true)
 }
 
 func (s *Suite) TestIndexGetDocument(c *gc.C) {


### PR DESCRIPTION
Use elasticsearch versioning to make sure that only
the latest version of the charm or bundle is indexed.
Therefore only returning the latest version in search
results.
