### PR TITLE
CS Search: Experimental boosting & name resolution

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -127,9 +127,13 @@ func (store *Store) Search(sp SearchParams) (SearchResult, error) {
 func queryFields(sp SearchParams) map[string]float64 {
 	fields := map[string]float64{
 		"URL": 8,
+		"CharmMeta.Categories": 5,
+		// todo (mhilton) tests fail if BundleData.Tags are enabled
+		//"BundleData.Tags":         5,
 		"CharmProvidedInterfaces": 3,
 		"CharmRequiredInterfaces": 3,
 		"CharmMeta.Description":   1,
+		"BundleReadMe":            1,
 	}
 	if sp.AutoComplete {
 		fields["CharmMeta.Name.ngrams"] = 10

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -126,7 +126,10 @@ func (store *Store) Search(sp SearchParams) (SearchResult, error) {
 // elasticsearch query.
 func queryFields(sp SearchParams) map[string]float64 {
 	fields := map[string]float64{
-		"CharmMeta.Description": 3,
+		"URL": 8,
+		"CharmProvidedInterfaces": 3,
+		"CharmRequiredInterfaces": 3,
+		"CharmMeta.Description":   1,
 	}
 	if sp.AutoComplete {
 		fields["CharmMeta.Name.ngrams"] = 10

--- a/internal/elasticsearch/definitions/entity.json
+++ b/internal/elasticsearch/definitions/entity.json
@@ -4,7 +4,7 @@
     "properties" : {
       "URL" : {
         "type" : "string",
-        "index" : "not_analyzed",
+        "analyzer" : "n3_20grams",
         "index_options" : "docs"
       },
       "BaseURL" : {

--- a/internal/elasticsearch/definitions/entity.json
+++ b/internal/elasticsearch/definitions/entity.json
@@ -215,7 +215,9 @@
           },
          "Tags" : {
             "type" : "string",
-            "index": "not_analyzed"
+            "index": "not_analyzed",
+            "omit_norms" : true,
+            "index_options" : "docs"
           }
         }
       },


### PR DESCRIPTION
To test, delete existing index and rerun essync with new entity.
