### PR TITLE
Allow ngrams in URL text.

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -126,10 +126,9 @@ func (store *Store) Search(sp SearchParams) (SearchResult, error) {
 // elasticsearch query.
 func queryFields(sp SearchParams) map[string]float64 {
 	fields := map[string]float64{
-		"URL": 8,
-		"CharmMeta.Categories": 5,
-		// todo (mhilton) tests fail if BundleData.Tags are enabled
-		//"BundleData.Tags":         5,
+		"URL.ngrams":              8,
+		"CharmMeta.Categories":    5,
+		"BundleData.Tags":         5,
 		"CharmProvidedInterfaces": 3,
 		"CharmRequiredInterfaces": 3,
 		"CharmMeta.Description":   1,
@@ -251,7 +250,7 @@ func nameFilter(value string) elasticsearch.Filter {
 	// TODO(mhilton) implement wildcards as in http://tinyurl.com/k46xexe
 	return elasticsearch.RegexpFilter{
 		Field:  "URL",
-		Regexp: `cs:(\~[^/]*/)?[^/]*/` + elasticsearch.EscapeRegexp(value) + "-[1-9][0-9]*",
+		Regexp: `cs:(\~[^/]*/)?[^/]*/` + elasticsearch.EscapeRegexp(value) + "-[0-9]+",
 	}
 }
 
@@ -275,7 +274,7 @@ func ownerFilter(value string) elasticsearch.Filter {
 func seriesFilter(value string) elasticsearch.Filter {
 	return elasticsearch.RegexpFilter{
 		Field:  "URL",
-		Regexp: `cs:(\~[^/]*/)?` + elasticsearch.EscapeRegexp(value) + "/.*-[1-9][0-9]*",
+		Regexp: `cs:(\~[^/]*/)?` + elasticsearch.EscapeRegexp(value) + "/.*-[0-9]+",
 	}
 }
 

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -86,6 +86,7 @@ var searchTests = []struct {
 		},
 		results: []string{
 			exportTestCharms["wordpress"],
+			exportTestBundles["wordpress"],
 		},
 	}, {
 		about: "blank text search",
@@ -106,6 +107,7 @@ var searchTests = []struct {
 		},
 		results: []string{
 			exportTestCharms["wordpress"],
+			exportTestBundles["wordpress"],
 		},
 	}, {
 		about: "description filter search",

--- a/internal/elasticsearch/definitions/entity.json
+++ b/internal/elasticsearch/definitions/entity.json
@@ -3,9 +3,20 @@
     "dynamic" : "false",
     "properties" : {
       "URL" : {
-        "type" : "string",
-        "analyzer" : "n3_20grams",
-        "index_options" : "docs"
+        "type" : "multi_field",
+        "fields" : {
+          "URL" : {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "omit_norms" : true,
+            "index_options" : "docs"
+          },
+          "ngrams" : {
+            "type" : "string",
+            "analyzer" : "n3_20grams",
+            "include_in_all" : false
+          }
+        }
       },
       "BaseURL" : {
         "type" : "string",

--- a/internal/storetesting/essettings.go
+++ b/internal/storetesting/essettings.go
@@ -3,288 +3,33 @@
 
 package storetesting
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
 
 var esIndex map[string]interface{}
 var esMapping map[string]interface{}
 
 func init() {
-	if err := json.Unmarshal(esIndexText, &esIndex); err != nil {
+	path := filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "juju", "charmstore", "internal", "elasticsearch", "definitions")
+	f, err := os.Open(filepath.Join(path, "index.json"))
+	if err != nil {
 		panic(err)
 	}
-	if err := json.Unmarshal(esMappingText, &esMapping); err != nil {
+	defer f.Close()
+	d := json.NewDecoder(f)
+	if err := d.Decode(&esIndex); err != nil {
+		panic(err)
+	}
+	f, err = os.Open(filepath.Join(path, "entity.json"))
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	d = json.NewDecoder(f)
+	if err := d.Decode(&esMapping); err != nil {
 		panic(err)
 	}
 }
-
-var esIndexText = []byte(`
-{
-  "settings": {
-    "number_of_shards": 1,
-    "analysis": {
-      "filter": {
-        "n3_20grams_filter": {
-          "type": "nGram",
-          "min_gram": 3,
-          "max_gram": 20
-        }
-      },
-      "analyzer": {
-        "n3_20grams": {
-          "type": "custom",
-          "tokenizer": "standard",
-          "filter": [
-            "lowercase",
-            "n3_20grams_filter"
-          ]
-        }
-      }
-    }
-  }
-}
-`)
-
-var esMappingText = []byte(`
-{
-  "entity": {
-    "dynamic": "false",
-    "properties": {
-      "URL": {
-        "type": "string",
-        "index": "not_analyzed",
-        "index_options": "docs"
-      },
-      "BaseURL": {
-        "type": "string",
-        "index": "not_analyzed",
-        "index_options": "docs"
-      },
-      "BlobHash": {
-        "type": "string",
-        "index": "not_analyzed",
-        "omit_norms": true,
-        "index_options": "docs"
-      },
-      "UploadTime": {
-        "type": "date",
-        "format": "dateOptionalTime"
-      },
-      "CharmMeta": {
-        "dynamic": "false",
-        "properties": {
-          "Name": {
-            "type": "multi_field",
-            "fields": {
-              "Name": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "ngrams": {
-                "type": "string",
-                "analyzer": "n3_20grams",
-                "include_in_all": false
-              }
-            }
-          },
-          "Summary": {
-            "type": "string"
-          },
-          "Description": {
-            "type": "string"
-          },
-          "Provides": {
-            "dynamic": "false",
-            "properties": {
-              "Name": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "Role": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "Interface": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "Scope": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              }
-            }
-          },
-          "Requires": {
-            "dynamic": "false",
-            "properties": {
-              "Name": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "Role": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "Interface": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "Scope": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              }
-            }
-          },
-          "Peers": {
-            "dynamic": "false",
-            "properties": {
-              "Name": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "Role": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "Interface": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "Scope": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              }
-            }
-          },
-          "Categories": {
-            "type": "string",
-            "index": "not_analyzed",
-            "omit_norms": true,
-            "index_options": "docs"
-          }
-        }
-      },
-      "CharmConfig": {
-        "dynamic": "false",
-        "properties": {
-          "Options": {
-            "dynamic": "false",
-            "properties": {
-              "Description": {
-                "type": "string"
-              },
-              "Default": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "CharmActions": {
-        "dynamic": "false",
-        "properties": {
-          "description": {
-            "type": "string"
-          },
-          "action_name": {
-            "type": "string",
-            "index": "not_analyzed",
-            "omit_norms": true,
-            "index_options": "docs"
-          }
-        }
-      },
-      "CharmProvidedInterfaces": {
-        "type": "string",
-        "index": "not_analyzed",
-        "omit_norms": true,
-        "index_options": "docs"
-      },
-      "CharmRequiredInterfaces": {
-        "type": "string",
-        "index": "not_analyzed",
-        "omit_norms": true,
-        "index_options": "docs"
-      },
-      "BundleData": {
-        "type": "object",
-        "dynamic": "false",
-        "properties": {
-          "Services": {
-            "type": "object",
-            "dynamic": "false",
-            "properties": {
-              "Charm": {
-                "type": "string",
-                "index": "not_analyzed",
-                "omit_norms": true,
-                "index_options": "docs"
-              },
-              "NumUnits": {
-                "type": "integer",
-                "index": "not_analyzed"
-              }
-            }
-          },
-          "Tags": {
-            "type": "string",
-            "index": "not_analyzed",
-            "omit_norms": true,
-            "index_options": "docs"
-          },
-          "Series": {
-            "type": "string"
-          },
-          "Relations": {
-            "type": "string",
-            "index": "not_analyzed"
-          }
-        }
-      },
-      "BundleReadMe": {
-        "type": "string",
-        "index": "not_analyzed",
-        "omit_norms": true,
-        "index_options": "docs"
-      },
-      "BundleCharms": {
-        "type": "string",
-        "index": "not_analyzed",
-        "omit_norms": true,
-        "index_options": "docs"
-      },
-      "BundleMachineCount": {
-        "type": "integer"
-      },
-      "BundleUnitCount": {
-        "type": "integer"
-      }
-    }
-  }
-}
-`)

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -130,12 +130,14 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		query: "text=wordpress",
 		results: []string{
 			exportTestCharms["wordpress"],
+			exportTestBundles["wordpress"],
 		},
 	}, {
 		about: "autocomplete search",
 		query: "text=word&autocomplete=1",
 		results: []string{
 			exportTestCharms["wordpress"],
+			exportTestBundles["wordpress"],
 		},
 	}, {
 		about: "blank text search",


### PR DESCRIPTION
This sorts out a number of search issues:
- ngrams match in URLs
- Bundle Tags are supported in search
- Support for charms and bundles with revision 0
