### PR TITLE
internal/mongodoc: add Contents field to mongodoc.Entity

### DIFF
--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -374,9 +374,14 @@ func (s *StoreSuite) TestBundleUnitCount(c *gc.C) {
 		}
 
 		// Add the bundle used for this test.
-		err := store.AddBundle(url, &testingBundle{
+		err := store.AddBundle(&testingBundle{
 			data: test.data,
-		}, "blobName", fakeBlobHash, fakeBlobSize)
+		}, AddParams{
+			URL:      url,
+			BlobName: "blobName",
+			BlobHash: fakeBlobHash,
+			BlobSize: fakeBlobSize,
+		})
 		c.Assert(err, gc.IsNil)
 
 		// Retrieve the bundle from the database.
@@ -698,10 +703,14 @@ func (s *StoreSuite) TestBundleMachineCount(c *gc.C) {
 		err := test.data.Verify(func(string) error { return nil })
 		c.Assert(err, gc.IsNil)
 		// Add the bundle used for this test.
-		err = store.AddBundle(url, &testingBundle{
+		err = store.AddBundle(&testingBundle{
 			data: test.data,
-		}, "blobName", fakeBlobHash, fakeBlobSize)
-		c.Assert(err, gc.IsNil)
+		}, AddParams{
+			URL:      url,
+			BlobName: "blobName",
+			BlobHash: fakeBlobHash,
+			BlobSize: fakeBlobSize,
+		})
 
 		// Retrieve the bundle from the database.
 		var doc mongodoc.Entity

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -72,4 +72,30 @@ type Entity struct {
 
 	// TODO Add fields denormalized for search purposes
 	// and search ranking field(s).
+
+	// Contents holds entries for frequently accessed
+	// entries in the file's blob. Storing this avoids
+	// the need to linearly read the zip file's manifest
+	// every time we access one of these files.
+	Contents map[FileId]ZipFile `json:",omitempty" bson:",omitempty"`
+}
+
+type FileId string
+
+const (
+	FileReadme FileId = "readme"
+	FileIcon   FileId = "icon"
+)
+
+// ZipFile refers to a specific file in the uploaded archive blob.
+type ZipFile struct {
+	// Compressed specifies whether the file is compressed or not.
+	Compressed bool
+
+	// Offset holds the offset into the zip archive of the start of
+	// the file's data.
+	Offset int64
+
+	// Size holds the size of the file before decompression.
+	Size int64
 }

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -797,7 +797,12 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 		},
 	}
 
-	err := s.store.AddBundle(charm.MustParseReference("cs:bundle/wordpressbundle-42"), bundle, "blobName", fakeBlobHash, fakeBlobSize)
+	err := s.store.AddBundle(bundle, charmstore.AddParams{
+		URL:      charm.MustParseReference("cs:bundle/wordpressbundle-42"),
+		BlobName: "blobName",
+		BlobHash: fakeBlobHash,
+		BlobSize: fakeBlobSize,
+	})
 	c.Assert(err, gc.IsNil)
 
 	rec := storetesting.DoRequest(c, storetesting.DoRequestParams{

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/juju/charm.v4"
 	"gopkg.in/mgo.v2/bson"
 
+	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/internal/mongodoc"
 	"github.com/juju/charmstore/params"
 )
@@ -224,7 +225,12 @@ func (h *Handler) addEntity(id *charm.Reference, r io.ReadSeeker, blobName strin
 			// TODO frankban: use multiError (defined in internal/router).
 			return errgo.Notef(verificationError(err), "bundle verification failed")
 		}
-		if err := h.store.AddBundle(id, b, blobName, hash, contentLength); err != nil {
+		if err := h.store.AddBundle(b, charmstore.AddParams{
+			URL:      id,
+			BlobName: blobName,
+			BlobHash: hash,
+			BlobSize: contentLength,
+		}); err != nil {
 			return errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload))
 		}
 		return nil
@@ -233,7 +239,12 @@ func (h *Handler) addEntity(id *charm.Reference, r io.ReadSeeker, blobName strin
 	if err != nil {
 		return errgo.Notef(err, "cannot read charm archive")
 	}
-	if err := h.store.AddCharm(id, ch, blobName, hash, contentLength); err != nil {
+	if err := h.store.AddCharm(ch, charmstore.AddParams{
+		URL:      id,
+		BlobName: blobName,
+		BlobHash: hash,
+		BlobSize: contentLength,
+	}); err != nil {
 		return errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload))
 	}
 	return nil

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -839,7 +839,13 @@ func (s *ArchiveSuite) TestDeleteError(c *gc.C) {
 	// Add a charm to the database (not including the archive).
 	id := "utopic/mysql-42"
 	url := charm.MustParseReference(id)
-	err := s.store.AddCharm(url, charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"), "no-such-name", fakeBlobHash, fakeBlobSize)
+	err := s.store.AddCharm(charmtesting.Charms.CharmArchive(c.MkDir(), "mysql"),
+		charmstore.AddParams{
+			URL:      url,
+			BlobName: "no-such-name",
+			BlobHash: fakeBlobHash,
+			BlobSize: fakeBlobSize,
+		})
 	c.Assert(err, gc.IsNil)
 
 	// Try to delete the charm using the API.

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -373,7 +373,12 @@ func (s *RelationsSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
 		// The blob related info are not used in these tests.
 		// The related charms are retrieved from the entities collection,
 		// without accessing the blob store.
-		err := s.store.AddCharm(url, ch, "blobName", fakeBlobHash, fakeBlobSize)
+		err := s.store.AddCharm(ch, charmstore.AddParams{
+			URL:      url,
+			BlobName: "blobName",
+			BlobHash: fakeBlobHash,
+			BlobSize: fakeBlobSize,
+		})
 		c.Assert(err, gc.IsNil)
 	}
 }
@@ -628,7 +633,12 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 		// The blob related info are not used in these tests.
 		// The charm-bundle relations are retrieved from the entities
 		// collection, without accessing the blob store.
-		err := s.store.AddBundle(url, b, "blobName", fakeBlobHash, fakeBlobSize)
+		err := s.store.AddBundle(b, charmstore.AddParams{
+			URL:      url,
+			BlobName: "blobName",
+			BlobHash: fakeBlobHash,
+			BlobSize: fakeBlobSize,
+		})
 		c.Assert(err, gc.IsNil)
 	}
 
@@ -646,7 +656,12 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 		}
 
 		// Add the charm we need bundle info on to the database.
-		err := s.store.AddCharm(url, &relationTestingCharm{}, "blobName", fakeBlobHash, fakeBlobSize)
+		err := s.store.AddCharm(&relationTestingCharm{}, charmstore.AddParams{
+			URL:      url,
+			BlobName: "blobName",
+			BlobHash: fakeBlobHash,
+			BlobSize: fakeBlobSize,
+		})
 		c.Assert(err, gc.IsNil)
 
 		// Perform the request and ensure the response is what we expect.


### PR DESCRIPTION
This will allow us to gain quick access to selected files
in an entity's archive such as README and icon.svg.

We'll actually use the field in an upcoming PR.
