### PR TITLE
internal/charmstore: add OpenCachedBlobFile method

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -99,3 +99,11 @@ type ZipFile struct {
 	// Size holds the size of the file before decompression.
 	Size int64
 }
+
+// Valid reports whether f is a valid (non-zero) reference to
+// a zip file.
+func (f ZipFile) IsValid() bool {
+	// Note that no valid zip files can start at offset zero,
+	// because that's where the zip header lives.
+	return f != ZipFile{}
+}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -895,7 +895,7 @@ var serveDiagramErrorsTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: "not found",
+		Message: "entity not found",
 	},
 }, {
 	about:        "diagram for a charm",

--- a/internal/v4/content.go
+++ b/internal/v4/content.go
@@ -1,0 +1,49 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4
+
+import (
+	"net/http"
+
+	"github.com/juju/jujusvg"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v4"
+
+	"github.com/juju/charmstore/internal/router"
+	"github.com/juju/charmstore/params"
+)
+
+// GET id/diagram.svg
+// http://tinyurl.com/nqjvxov
+func (h *Handler) serveDiagram(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+	if id.Series != "bundle" {
+		return errgo.WithCausef(nil, params.ErrNotFound, "diagrams not supported for charms")
+	}
+	entity, err := h.store.FindEntity(id, "bundledata")
+	if err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
+	}
+
+	var urlErr error
+	// TODO consider what happens when a charm's SVG does not exist.
+	canvas, err := jujusvg.NewFromBundle(entity.BundleData, func(id *charm.Reference) string {
+		// TODO change jujusvg so that the iconURL function can
+		// return an error.
+		absPath := "/" + id.Path() + "/archive/icon.svg"
+		p, err := router.RelativeURLPath(req.RequestURI, absPath)
+		if err != nil {
+			urlErr = errgo.Notef(err, "cannot make relative URL from %q and %q", req.RequestURI, absPath)
+		}
+		return p
+	})
+	if err != nil {
+		return errgo.Notef(err, "cannot create canvas")
+	}
+	if urlErr != nil {
+		return urlErr
+	}
+	w.Header().Set("Content-Type", "image/svg+xml")
+	canvas.Marshal(w)
+	return nil
+}


### PR DESCRIPTION
This will be used to serve both icon.svg and README (and potentially other
similar endpoints in the future).

We also move serveDiagram into a new file, v4/content.go, without any
other changes to it, in preparation for the other new methods.
