### PR TITLE
Svg rendering fixes

### DIFF
--- a/internal/v4/content.go
+++ b/internal/v4/content.go
@@ -35,7 +35,7 @@ func (h *Handler) serveDiagram(id *charm.Reference, w http.ResponseWriter, req *
 	canvas, err := jujusvg.NewFromBundle(entity.BundleData, func(id *charm.Reference) string {
 		// TODO change jujusvg so that the iconURL function can
 		// return an error.
-		absPath := "/" + id.Path() + "/archive/icon.svg"
+		absPath := "/" + id.Path() + "/icon.svg"
 		p, err := router.RelativeURLPath(req.RequestURI, absPath)
 		if err != nil {
 			urlErr = errgo.Notef(err, "cannot make relative URL from %q and %q", req.RequestURI, absPath)
@@ -64,6 +64,7 @@ var allowedReadMe = map[string]bool{
 	"readme.txt":      true,
 }
 
+// GET id/readme
 func (h *Handler) serveReadMe(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	entity, err := h.store.FindEntity(id, "_id", "contents", "blobname")
 	if err != nil {
@@ -84,6 +85,7 @@ func (h *Handler) serveReadMe(id *charm.Reference, w http.ResponseWriter, req *h
 	return nil
 }
 
+// GET id/icon.svg
 func (h *Handler) serveIcon(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	if id.Series == "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "icons not supported for bundles")

--- a/internal/v4/content.go
+++ b/internal/v4/content.go
@@ -65,6 +65,7 @@ var allowedReadMe = map[string]bool{
 }
 
 // GET id/readme
+// http://tinyurl.com/kygyvot
 func (h *Handler) serveReadMe(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	entity, err := h.store.FindEntity(id, "_id", "contents", "blobname")
 	if err != nil {
@@ -86,6 +87,7 @@ func (h *Handler) serveReadMe(id *charm.Reference, w http.ResponseWriter, req *h
 }
 
 // GET id/icon.svg
+// http://tinyurl.com/lhodocb
 func (h *Handler) serveIcon(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
 	if id.Series == "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "icons not supported for bundles")

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -108,8 +108,8 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	// icon link.
 	assertXMLContains(c, rec.Body.Bytes(), map[string]func(xml.Token) bool{
 		"svg element":    isStartElementWithName("svg"),
-		"wordpress icon": isStartElementWithAttr("image", "href", "../../wordpress/archive/icon.svg"),
-		"mysql icon":     isStartElementWithAttr("image", "href", "../../raring/mysql-23/archive/icon.svg"),
+		"wordpress icon": isStartElementWithAttr("image", "href", "../../wordpress/icon.svg"),
+		"mysql icon":     isStartElementWithAttr("image", "href", "../../raring/mysql-23/icon.svg"),
 	})
 
 	// Do the same check again, but with the short form of the id;
@@ -127,8 +127,8 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	// icon link.
 	assertXMLContains(c, rec.Body.Bytes(), map[string]func(xml.Token) bool{
 		"svg element":    isStartElementWithName("svg"),
-		"wordpress icon": isStartElementWithAttr("image", "href", "../wordpress/archive/icon.svg"),
-		"mysql icon":     isStartElementWithAttr("image", "href", "../raring/mysql-23/archive/icon.svg"),
+		"wordpress icon": isStartElementWithAttr("image", "href", "../wordpress/icon.svg"),
+		"mysql icon":     isStartElementWithAttr("image", "href", "../raring/mysql-23/icon.svg"),
 	})
 }
 

--- a/internal/v4/defaulticon.go
+++ b/internal/v4/defaulticon.go
@@ -1,7 +1,9 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
 package v4
 
-var defaultIcon = `
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+var defaultIcon = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg

--- a/internal/v4/defaulticon_test.go
+++ b/internal/v4/defaulticon_test.go
@@ -1,0 +1,22 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package v4_test
+
+import (
+	"strings"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/charmstore/internal/v4"
+)
+
+type iconSuite struct{}
+
+var _ = gc.Suite(&iconSuite{})
+
+func (s *iconSuite) TestValidXML(c *gc.C) {
+	// The XML declaration must be included in the first line of the icon.
+	hasXMLPrefix := strings.HasPrefix(v4.DefaultIcon, "<?xml")
+	c.Assert(hasXMLPrefix, gc.Equals, true)
+}


### PR DESCRIPTION
Make the bundle/diagram endpoint refer to the dynamic charm/icon one, so that icon rendering is faster and also the default icon is displayed when the charm has no icon.
Also fix the default icon rendering, avoiding new lines at the beginning of the SVG (XML declaration).
