### PR TITLE
Added pagination to search queries

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -106,6 +106,8 @@ type SearchParams struct {
 	Limit int
 	// Include the following metadata items in the search results
 	Include []string
+	// Start the the returned items at a specific offset
+	Skip int
 }
 
 // SearchResult represents the result of performing a search.
@@ -159,6 +161,7 @@ func encodeFields(fields map[string]float64) []string {
 // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html
 func createSearchDSL(sp SearchParams) elasticsearch.QueryDSL {
 	qdsl := elasticsearch.QueryDSL{
+		From: sp.Skip,
 		Size: sp.Limit,
 	}
 

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -284,6 +284,15 @@ var searchTests = []struct {
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
 		},
+	}, {
+		about: "paginated search",
+		sp: SearchParams{
+			Filters: map[string][]string{
+				"name": {"mysql"},
+			},
+			Skip: 1,
+		},
+		results: []string{},
 	},
 }
 
@@ -297,6 +306,20 @@ func (s *StoreSearchSuite) TestSearches(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		assertSearchResults(c, res, test.results)
 	}
+}
+
+func (s *StoreSearchSuite) TestPaginatedSearch(c *gc.C) {
+	err := s.store.ExportToElasticSearch()
+	s.store.ES.Database.RefreshIndex(s.TestIndex)
+	c.Assert(err, gc.IsNil)
+	sp := SearchParams{
+		Text: "wordpress",
+		Skip: 1,
+	}
+	res, err := s.store.Search(sp)
+	c.Assert(err, gc.IsNil)
+	c.Assert(res.Results, gc.HasLen, 1)
+	c.Assert(res.Total, gc.Equals, 2)
 }
 
 func (s *StoreSearchSuite) TestLimitTestSearch(c *gc.C) {

--- a/internal/elasticsearch/query.go
+++ b/internal/elasticsearch/query.go
@@ -195,6 +195,7 @@ func (t TermFilter) MarshalJSON() ([]byte, error) {
 // elasticsearch DSL.
 type QueryDSL struct {
 	Fields []string `json:"fields"`
+	From   int      `json:"from,omitempty"`
 	Size   int      `json:"size,omitempty"`
 	Query  Query    `json:"query,omitempty"`
 	Sort   []Sort   `json:"sort,omitempty"`

--- a/internal/elasticsearch/query_test.go
+++ b/internal/elasticsearch/query_test.go
@@ -121,6 +121,16 @@ func (s *QuerySuite) TestJSONEncodings(c *gc.C) {
 			},
 		},
 		json: `{"filter": {"term": {"foo": "bar"}}, "boost_factor": 1.5}`,
+	}, {
+		about: "paginated query",
+		query: QueryDSL{
+			Fields: []string{"foo", "bar"},
+			Size:   10,
+			Query:  TermQuery{Field: "baz", Value: "quz"},
+			Sort:   []Sort{{Field: "foo", Order: Order{"desc"}}},
+			From:   10,
+		},
+		json: `{"fields": ["foo", "bar"], "size": 10, "query": {"term": {"baz": "quz"}}, "sort": [{"foo": { "order": "desc"}}], "from": 10}`,
 	}}
 	for i, test := range tests {
 		c.Logf("%d: %s", i, test.about)


### PR DESCRIPTION
A new start parameter can be added to search queries and the results
will start from that offset in the overall search results.
