### PR TITLE
internal/v4: fix search error handling

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -12,7 +12,7 @@ github.com/juju/names	git	cfcf5a79106d26fce039a35ffca277def4496f4b
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	
 github.com/juju/testing	git	cc1a29452f9a9af7a54c3a2af495fbf5cd64c640	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
-github.com/juju/utils	git	e4e59c6fe058bce0da468ba70943afba85b11cd5	
+github.com/juju/utils	git	28f1fcf3aec9e481fa9fd7020d0b64c62fb30baf	
 gopkg.in/check.v1	git	f74cd4712c294b0b898bc694214563d14caf3b76	
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	
 gopkg.in/juju/charm.v4	git	3de66780d713611ccc906fe906c2696dac1f8f5e	

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -39,7 +39,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	serveVersion := func(vers string) NewAPIHandlerFunc {
 		return func(store *Store, config ServerParams) http.Handler {
 			c.Assert(store.DB.Database, gc.Equals, db)
-			return router.HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+			return router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 				return versionResponse{
 					Version: vers,
 					Path:    req.URL.Path,
@@ -86,7 +86,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 
 func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
 	serveConfig := func(store *Store, config ServerParams) http.Handler {
-		return router.HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+		return router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 			return config, nil
 		})
 	}
@@ -103,7 +103,7 @@ func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
 
 func (s *ServerSuite) TestNewServerWithElasticSearch(c *gc.C) {
 	serveConfig := func(store *Store, config ServerParams) http.Handler {
-		return router.HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+		return router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 			return config, nil
 		})
 	}

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -146,7 +146,7 @@ func charmStatsKey(url *charm.Reference, kind string) []string {
 
 var errNotFound = fmt.Errorf("entry not found")
 
-func (h *Handler) serveCharmInfo(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (h *Handler) serveCharmInfo(_ http.Header, req *http.Request) (interface{}, error) {
 	response := make(map[string]*charm.InfoResponse)
 	for _, url := range req.Form["charms"] {
 		c := &charm.InfoResponse{}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -44,7 +44,7 @@ var routerGetTests = []struct {
 	about: "global handler",
 	handlers: Handlers{
 		Global: map[string]http.Handler{
-			"foo": HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+			"foo": HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 				return ReqInfo{
 					Method: req.Method,
 					Path:   req.URL.Path,
@@ -63,7 +63,7 @@ var routerGetTests = []struct {
 	about: "global handler with sub-path and flags",
 	handlers: Handlers{
 		Global: map[string]http.Handler{
-			"foo/bar/": HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+			"foo/bar/": HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 				return ReqInfo{
 					Method: req.Method,
 					Path:   req.URL.Path,
@@ -751,7 +751,7 @@ var routerPutTests = []struct {
 	about: "global handler",
 	handlers: Handlers{
 		Global: map[string]http.Handler{
-			"foo": HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+			"foo": HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 				return ReqInfo{
 					Method: req.Method,
 					Path:   req.URL.Path,
@@ -1616,7 +1616,7 @@ func (s *RouterSuite) TestWriteError(c *gc.C) {
 
 func (s *RouterSuite) TestServeMux(c *gc.C) {
 	mux := NewServeMux()
-	mux.Handle("/data", HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+	mux.Handle("/data", HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 		return Foo{"hello"}, nil
 	}))
 	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
@@ -1715,14 +1715,14 @@ var handlerTests = []struct {
 	},
 }, {
 	about: "handleJSON, normal case",
-	handler: HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+	handler: HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 		return Foo{"hello"}, nil
 	}),
 	expectStatus: http.StatusOK,
 	expectBody:   Foo{"hello"},
 }, {
 	about: "handleJSON, error case",
-	handler: HandleJSON(func(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+	handler: HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 		return nil, errgo.Newf("an error")
 	}),
 	expectStatus: http.StatusInternalServerError,

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/loggo"
 	"github.com/juju/utils/jsonhttp"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
@@ -24,6 +25,8 @@ import (
 	"github.com/juju/charmstore/internal/router"
 	"github.com/juju/charmstore/params"
 )
+
+var logger = loggo.GetLogger("charmstore.internal.v4")
 
 type Handler struct {
 	*router.Router
@@ -518,7 +521,7 @@ type PublishedResponse struct {
 
 // GET changes/published[?limit=$count][&from=$fromdate][&to=$todate]
 // http://tinyurl.com/qx5zdee
-func (h *Handler) serveChangesPublished(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+func (h *Handler) serveChangesPublished(_ http.Header, r *http.Request) (interface{}, error) {
 	start, stop, err := parseDateRange(r.Form)
 	if err != nil {
 		return nil, errgo.Mask(err, errgo.Is(params.ErrBadRequest))

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -65,7 +65,7 @@ func parseDateRange(form url.Values) (start, stop time.Time, err error) {
 
 // GET stats/counter/key[:key]...?[by=unit]&start=date][&stop=date][&list=1]
 // http://tinyurl.com/nkdovcf
-func (s *Handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+func (h *Handler) serveStatsCounter(_ http.Header, r *http.Request) (interface{}, error) {
 	base := strings.TrimPrefix(r.URL.Path, "/")
 	if strings.Index(base, "/") > 0 {
 		return nil, errgo.WithCausef(nil, params.ErrNotFound, "invalid key")
@@ -101,7 +101,7 @@ func (s *Handler) serveStatsCounter(w http.ResponseWriter, r *http.Request) (int
 			return nil, errgo.WithCausef(nil, params.ErrForbidden, "unknown key")
 		}
 	}
-	entries, err := s.store.Counters(&req)
+	entries, err := h.store.Counters(&req)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot query counters")
 	}

--- a/internal/v4/status.go
+++ b/internal/v4/status.go
@@ -38,7 +38,7 @@ var statusChecks = map[string]struct {
 
 // GET /debug/status
 // http://tinyurl.com/qdm5yg7
-func (h *Handler) serveDebugStatus(w http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (h *Handler) serveDebugStatus(_ http.Header, req *http.Request) (interface{}, error) {
 	status := make(map[string]params.DebugStatus)
 	for key, check := range statusChecks {
 		value, ok := check.check(h)


### PR DESCRIPTION
We use the new HandleJSON API which doesn't give a ResponseWriter
to use.
