### PR TITLE
all: use bundle/wordpress-simple in tests

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -15,6 +15,6 @@ github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc
 github.com/juju/utils	git	28f1fcf3aec9e481fa9fd7020d0b64c62fb30baf	
 gopkg.in/check.v1	git	f74cd4712c294b0b898bc694214563d14caf3b76	
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	
-gopkg.in/juju/charm.v4	git	3de66780d713611ccc906fe906c2696dac1f8f5e	
+gopkg.in/juju/charm.v4	git	5d3f0a3beddb43d776fc792528287a5fe0eef2ff	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/yaml.v1	git	1b9791953ba4027efaeb728c7355e542a203be5e	

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -779,13 +779,13 @@ func (s *StoreSuite) TestAddCharmArchive(c *gc.C) {
 }
 
 func (s *StoreSuite) TestAddBundleDir(c *gc.C) {
-	bundleDir := testing.Charms.BundleDir("wordpress")
+	bundleDir := testing.Charms.BundleDir("wordpress-simple")
 	s.checkAddBundle(c, bundleDir, false)
 }
 
 func (s *StoreSuite) TestAddBundleArchive(c *gc.C) {
 	bundleArchive, err := charm.ReadBundleArchive(
-		testing.Charms.BundleArchivePath(c.MkDir(), "wordpress"),
+		testing.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
 	)
 	c.Assert(err, gc.IsNil)
 	s.checkAddBundle(c, bundleArchive, false)
@@ -1056,13 +1056,13 @@ func (s *StoreSuite) TestAddCharmArchiveIndexed(c *gc.C) {
 }
 
 func (s *StoreSuite) TestAddBundleDirIndexed(c *gc.C) {
-	bundleDir := testing.Charms.BundleDir("wordpress")
+	bundleDir := testing.Charms.BundleDir("wordpress-simple")
 	s.checkAddBundle(c, bundleDir, true)
 }
 
 func (s *StoreSuite) TestAddBundleArchiveIndexed(c *gc.C) {
 	bundleArchive, err := charm.ReadBundleArchive(
-		testing.Charms.BundleArchivePath(c.MkDir(), "wordpress"),
+		testing.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
 	)
 	c.Assert(err, gc.IsNil)
 	s.checkAddBundle(c, bundleArchive, true)

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -112,7 +112,7 @@ var metaEndpoints = []metaEndpoint{{
 	name:      "bundle-metadata",
 	exclusive: bundleOnly,
 	get:       entityFieldGetter("BundleData"),
-	checkURL:  "cs:bundle/wordpress-42",
+	checkURL:  "cs:bundle/wordpress-simple-42",
 	assertCheckData: func(c *gc.C, data interface{}) {
 		c.Assert(data.(*charm.BundleData).Services["wordpress"].Charm, gc.Equals, "wordpress")
 	},
@@ -125,7 +125,7 @@ var metaEndpoints = []metaEndpoint{{
 		}
 		return params.BundleCount{*entity.BundleUnitCount}
 	}),
-	checkURL: "cs:bundle/wordpress-42",
+	checkURL: "cs:bundle/wordpress-simple-42",
 	assertCheckData: func(c *gc.C, data interface{}) {
 		c.Assert(data.(params.BundleCount).Count, gc.Equals, 2)
 	},
@@ -138,7 +138,7 @@ var metaEndpoints = []metaEndpoint{{
 		}
 		return params.BundleCount{*entity.BundleMachineCount}
 	}),
-	checkURL: "cs:bundle/wordpress-42",
+	checkURL: "cs:bundle/wordpress-simple-42",
 	assertCheckData: func(c *gc.C, data interface{}) {
 		c.Assert(data.(params.BundleCount).Count, gc.Equals, 2)
 	},
@@ -174,7 +174,7 @@ var metaEndpoints = []metaEndpoint{{
 		}
 		return manifest
 	}),
-	checkURL: "cs:bundle/wordpress-42",
+	checkURL: "cs:bundle/wordpress-simple-42",
 	assertCheckData: func(c *gc.C, data interface{}) {
 		c.Assert(data.([]params.ManifestFile), gc.Not(gc.HasLen), 0)
 	},
@@ -331,7 +331,7 @@ var testEntities = []string{
 	// A stock charm.
 	"cs:precise/wordpress-23",
 	// A stock bundle.
-	"cs:bundle/wordpress-42",
+	"cs:bundle/wordpress-simple-42",
 	// A charm with some actions.
 	"cs:precise/dummy-10",
 	// A charm with some tags
@@ -674,7 +674,7 @@ func (s *APISuite) TestMetaCharmTags(c *gc.C) {
 }
 
 func (s *APISuite) TestBundleTags(c *gc.C) {
-	b := charmtesting.Charms.BundleDir("wordpress")
+	b := charmtesting.Charms.BundleDir("wordpress-simple")
 	data := b.Data()
 	data.Tags = []string{"foo", "bar"}
 	err := s.store.AddBundle(&testingBundle{data}, charmstore.AddParams{
@@ -1011,7 +1011,7 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 	s.addCharm(c, "wordpress", "cs:utopic/django-42")
 	s.addCharm(c, "wordpress", "cs:utopic/django-47")
 	s.addCharm(c, "wordpress", "cs:~who/utopic/django-42")
-	s.addBundle(c, "wordpress", "cs:bundle/wordpress-simple-42")
+	s.addBundle(c, "wordpress-simple", "cs:bundle/wordpress-simple-42")
 
 	for i, test := range metaStatsTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -1183,7 +1183,7 @@ func (s *APISuite) TestStatus(c *gc.C) {
 		"cs:~bar/bundle/oflaughs-4",
 	} {
 		if strings.Contains(id, "bundle") {
-			s.addBundle(c, "wordpress", id)
+			s.addBundle(c, "wordpress-simple", id)
 		} else {
 			s.addCharm(c, "wordpress", id)
 		}

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -356,17 +356,17 @@ func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// A bundle that did not exist before should get revision 0.
-	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-0"), "wordpress")
+	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-simple-0"), "wordpress-simple")
 
 	// Subsequent bundle uploads should increment the
 	// revision by 1.
-	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-1"), "wordpress-with-logging")
+	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-simple-1"), "wordpress-with-logging")
 
 	// Uploading the same archive twice should not increment the revision...
-	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-1"), "wordpress-with-logging")
+	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-simple-1"), "wordpress-with-logging")
 
 	// ... but uploading an archive used by a previous revision should.
-	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-2"), "wordpress")
+	s.assertUploadBundle(c, "POST", charm.MustParseReference("bundle/wordpress-simple-2"), "wordpress-simple")
 }
 
 func (s *ArchiveSuite) TestPostHashMismatch(c *gc.C) {

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -52,7 +52,7 @@ var serveDiagramErrorsTests = []struct {
 
 func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
 	s.addCharm(c, "wordpress", "cs:trusty/wordpress-42")
-	s.addBundle(c, "wordpress", "cs:bundle/nopositionbundle-42")
+	s.addBundle(c, "wordpress-simple", "cs:bundle/nopositionbundle-42")
 	for i, test := range serveDiagramErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
 		storetesting.AssertJSONCall(c, storetesting.JSONCallParams{


### PR DESCRIPTION
Also update dependencies to use wordpress-simple bundle
from the updated charm.v4 package.
