### PR TITLE
internal/charmstore: do not allow charms and bundles to have the same names

### DIFF
--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -774,8 +774,8 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 	s.addCharm(c, "wordpress", "cs:utopic/wordpress-10")
 	s.addCharm(c, "wordpress", "cs:saucy/bigdata-99")
 	s.addCharm(c, "wordpress", "cs:utopic/bigdata-10")
-	s.addCharm(c, "wordpress", "cs:bundle/bundlelovin-10")
-	s.addCharm(c, "wordpress", "cs:bundle/wordpress-10")
+	s.addBundle(c, "wordpress-simple", "cs:bundle/bundlelovin-10")
+	s.addBundle(c, "wordpress-simple", "cs:bundle/wordpress-simple-10")
 
 	for i, test := range resolveURLTests {
 		c.Logf("test %d: %s", i, test.url)
@@ -802,7 +802,6 @@ var serveExpandIdTests = []struct {
 	expect: []params.ExpandedId{
 		{Id: "cs:utopic/wordpress-42"},
 		{Id: "cs:trusty/wordpress-47"},
-		{Id: "cs:bundle/wordpress-0"},
 	},
 }, {
 	about: "fully qualified URL that does not exist",
@@ -810,7 +809,6 @@ var serveExpandIdTests = []struct {
 	expect: []params.ExpandedId{
 		{Id: "cs:utopic/wordpress-42"},
 		{Id: "cs:trusty/wordpress-47"},
-		{Id: "cs:bundle/wordpress-0"},
 	},
 }, {
 	about: "partial URL",
@@ -844,8 +842,8 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	s.addCharm(c, "wordpress", "cs:trusty/wordpress-47")
 	s.addCharm(c, "wordpress", "cs:precise/haproxy-1")
 	s.addCharm(c, "wordpress", "cs:trusty/haproxy-1")
-	s.addCharm(c, "wordpress", "cs:bundle/mongo-0")
-	s.addCharm(c, "wordpress", "cs:bundle/wordpress-0")
+	s.addBundle(c, "wordpress-simple", "cs:bundle/mongo-0")
+	s.addBundle(c, "wordpress-simple", "cs:bundle/wordpress-simple-0")
 
 	for i, test := range serveExpandIdTests {
 		c.Logf("test %d: %s", i, test.about)

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -37,7 +37,7 @@ var exportTestCharms = map[string]string{
 }
 
 var exportTestBundles = map[string]string{
-	"wordpress-simple": "cs:bundle/wordpress-4",
+	"wordpress-simple": "cs:bundle/wordpress-simple-4",
 }
 
 func (s *SearchSuite) SetUpTest(c *gc.C) {
@@ -422,19 +422,19 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		},
 	}, {
 		about: "bundle-metadata",
-		query: "name=wordpress&type=bundle&include=bundle-metadata",
+		query: "name=wordpress-simple&type=bundle&include=bundle-metadata",
 		meta: map[string]interface{}{
 			"bundle-metadata": getBundle("wordpress-simple").Data(),
 		},
 	}, {
 		about: "bundle-machine-count",
-		query: "name=wordpress&type=bundle&include=bundle-machine-count",
+		query: "name=wordpress-simple&type=bundle&include=bundle-machine-count",
 		meta: map[string]interface{}{
 			"bundle-machine-count": params.BundleCount{2},
 		},
 	}, {
 		about: "bundle-unit-count",
-		query: "name=wordpress&type=bundle&include=bundle-unit-count",
+		query: "name=wordpress-simple&type=bundle&include=bundle-unit-count",
 		meta: map[string]interface{}{
 			"bundle-unit-count": params.BundleCount{2},
 		},


### PR DESCRIPTION
This enforces (with high probability) the flat name space we want for the future.
