### PR TITLE
charmstore: add CORS headers to all requests

### DIFF
--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -33,6 +33,10 @@ func errToResp(err error) (int, interface{}) {
 	case params.ErrUnauthorized:
 		status = http.StatusUnauthorized
 	case params.ErrMethodNotAllowed:
+		// TODO(rog) from RFC 2616, section 4.7: An Allow header
+		// field MUST be present in a 405 (Method Not Allowed)
+		// response.
+		// Perhaps we should not ever return StatusMethodNotAllowed.
 		status = http.StatusMethodNotAllowed
 	}
 	return status, errorBody

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -69,10 +69,6 @@ func (h *Handler) serveArchive(id *charm.Reference, w http.ResponseWriter, req *
 	header := w.Header()
 	header.Set(params.ContentHashHeader, hash)
 	header.Set(params.EntityIdHeader, id.String())
-	// Storefront is linking to icon.svg directly, so we need CORS support.
-	// http://www.w3.org/TR/cors/
-	header.Set("Access-Control-Allow-Origin", "*")
-	header.Set("Access-Control-Allow-Headers", "X-Requested-With")
 	h.store.IncCounterAsync(entityStatsKey(id, params.StatsArchiveDownload))
 	// TODO(rog) should we set connection=close here?
 	// See https://codereview.appspot.com/5958045
@@ -307,10 +303,6 @@ func (h *Handler) serveArchiveFile(id *charm.Reference, w http.ResponseWriter, r
 			w.Header().Set("Content-Type", ctype)
 		}
 		w.Header().Set("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))
-		// Storefront is linking to icon.svg directly, so we need CORS support.
-		// http://www.w3.org/TR/cors/
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Headers", "X-Requested-With")
 		w.WriteHeader(http.StatusOK)
 		io.Copy(w, content)
 		return nil


### PR DESCRIPTION
To QA this, we need to create a web page that contains some javascript
that makes an AJAX request to the charm store, and check that it
succeeds.
