### PR TITLE
internal/router: add fullySpecified parameter to IdHandler

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -242,13 +242,13 @@ func (h *Handler) serveDebug(w http.ResponseWriter, req *http.Request) {
 //
 // PUT id/resources/[~user/]series/name.stream-revision/arch?sha256=hash
 // http://tinyurl.com/k8l8kdg
-func (h *Handler) serveResources(charmId *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveResources(charmId *charm.Reference, _ bool, w http.ResponseWriter, req *http.Request) error {
 	return errNotImplemented
 }
 
 // GET id/expand-id
 // https://docs.google.com/a/canonical.com/document/d/1TgRA7jW_mmXoKH3JiwBbtPvQu7WiM6XMrz1wSrhTMXw/edit#bookmark=id.4xdnvxphb2si
-func (h *Handler) serveExpandId(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveExpandId(id *charm.Reference, _ bool, w http.ResponseWriter, req *http.Request) error {
 	// Mutate the given id so that it represents a base URL.
 	id.Revision = -1
 	id.Series = ""

--- a/internal/v4/content.go
+++ b/internal/v4/content.go
@@ -21,7 +21,7 @@ import (
 
 // GET id/diagram.svg
 // http://tinyurl.com/nqjvxov
-func (h *Handler) serveDiagram(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveDiagram(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
 	if id.Series != "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "diagrams not supported for charms")
 	}
@@ -48,7 +48,7 @@ func (h *Handler) serveDiagram(id *charm.Reference, w http.ResponseWriter, req *
 	if urlErr != nil {
 		return urlErr
 	}
-	setCacheControl(w.Header(), archiveCacheMaxAge)
+	setArchiveCacheControl(w.Header(), fullySpecified)
 	w.Header().Set("Content-Type", "image/svg+xml")
 	canvas.Marshal(w)
 	return nil
@@ -67,7 +67,7 @@ var allowedReadMe = map[string]bool{
 
 // GET id/readme
 // http://tinyurl.com/kygyvot
-func (h *Handler) serveReadMe(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveReadMe(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
 	entity, err := h.store.FindEntity(id, "_id", "contents", "blobname")
 	if err != nil {
 		return errgo.NoteMask(err, "cannot get README", errgo.Is(params.ErrNotFound))
@@ -83,14 +83,14 @@ func (h *Handler) serveReadMe(id *charm.Reference, w http.ResponseWriter, req *h
 		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
 	defer r.Close()
-	setCacheControl(w.Header(), archiveCacheMaxAge)
+	setArchiveCacheControl(w.Header(), fullySpecified)
 	io.Copy(w, r)
 	return nil
 }
 
 // GET id/icon.svg
 // http://tinyurl.com/lhodocb
-func (h *Handler) serveIcon(id *charm.Reference, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveIcon(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
 	if id.Series == "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "icons not supported for bundles")
 	}
@@ -107,14 +107,14 @@ func (h *Handler) serveIcon(id *charm.Reference, w http.ResponseWriter, req *htt
 		if errgo.Cause(err) != params.ErrNotFound {
 			return errgo.Mask(err)
 		}
-		setCacheControl(w.Header(), archiveCacheMaxAge)
+		setArchiveCacheControl(w.Header(), fullySpecified)
 		w.Header().Set("Content-Type", "image/svg+xml")
 		io.Copy(w, strings.NewReader(defaultIcon))
 		return nil
 	}
 	defer r.Close()
 	w.Header().Set("Content-Type", "image/svg+xml")
-	setCacheControl(w.Header(), archiveCacheMaxAge)
+	setArchiveCacheControl(w.Header(), fullySpecified)
 	io.Copy(w, r)
 	return nil
 }

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -4,9 +4,10 @@
 package v4
 
 var (
-	BundleCharms       = (*Handler).bundleCharms
-	ParseSearchParams  = parseSearchParams
-	StartTime          = &startTime
-	DefaultIcon        = defaultIcon
-	ArchiveCacheMaxAge = &archiveCacheMaxAge
+	BundleCharms                   = (*Handler).bundleCharms
+	ParseSearchParams              = parseSearchParams
+	StartTime                      = &startTime
+	DefaultIcon                    = defaultIcon
+	ArchiveCacheVersionedMaxAge    = &archiveCacheVersionedMaxAge
+	ArchiveCacheNonVersionedMaxAge = &archiveCacheNonVersionedMaxAge
 )


### PR DESCRIPTION
We also change internal/v4 so that the Cache-Control header is only added when the id is fully specified.
