### PR TITLE
internal/v4, internal/router: use concurrency

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -12,9 +12,10 @@ github.com/juju/names	git	cfcf5a79106d26fce039a35ffca277def4496f4b
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	
 github.com/juju/testing	git	f31a00bb9066ec19667dd0aa65121ed5d4b1949d	
 github.com/juju/txn	git	ee0346875f2ae9a21442f3ff64409f750f37afbc	
-github.com/juju/utils	git	28f1fcf3aec9e481fa9fd7020d0b64c62fb30baf	
+github.com/juju/utils	git	d39e19a993cc03bb5b99e9718c2fcf889c524a6b	
 gopkg.in/check.v1	git	f74cd4712c294b0b898bc694214563d14caf3b76	
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	
 gopkg.in/juju/charm.v4	git	f7e5613ff75457d2700d1c3269546cc903ea0471	
 gopkg.in/mgo.v2	git	dc255bb679efa273b6544a03261c4053505498a4	
 gopkg.in/yaml.v1	git	1b9791953ba4027efaeb728c7355e542a203be5e	
+launchpad.net/tomb	bzr	gustavo@niemeyer.net-20130531003818-70ikdgklbxopn8x4	17

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -383,6 +383,7 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
 		c.Assert(err, gc.IsNil)
 		c.Assert(sr.Results, gc.HasLen, len(test.results))
+		c.Logf("results: %s", rec.Body.Bytes())
 	OUTER:
 		for _, res := range sr.Results {
 			for i, r := range test.results {


### PR DESCRIPTION
This might speed up search results considerably.
