### PR TITLE
denormalise name in elasticsearch; add id endpoints

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -26,14 +26,27 @@ type StoreElasticSearch struct {
 
 const typeName = "entity"
 
+type esDoc struct {
+	*mongodoc.Entity
+	Name   string
+	User   string
+	Series string
+}
+
 // Put inserts the mongodoc.Entity into elasticsearch if elasticsearch
 // is configured.
 func (ses *StoreElasticSearch) put(entity *mongodoc.Entity) error {
 	if ses == nil || ses.Index == nil {
 		return nil
 	}
-	_, err := ses.PutDocumentVersion(typeName, ses.getID(entity), int64(entity.URL.Revision), entity)
-	return err
+	doc := esDoc{
+		Entity: entity,
+		Name:   entity.URL.Name,
+		User:   entity.URL.User,
+		Series: entity.URL.Series,
+	}
+	_, err := ses.PutDocumentVersion(typeName, ses.getID(entity), int64(entity.URL.Revision), doc)
+	return errgo.Mask(err)
 }
 
 // getID returns an ID for the elasticsearch document based on the contents of the

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -80,6 +80,10 @@ func New(store *charmstore.Store, config charmstore.ServerParams) *Handler {
 				h.putMetaExtraInfoWithKey,
 				"extrainfo",
 			),
+			"id-name":       h.entityHandler(h.metaIdName, "_id"),
+			"id-user":       h.entityHandler(h.metaIdUser, "_id"),
+			"id-revision":   h.entityHandler(h.metaIdRevision, "_id"),
+			"id-series":     h.entityHandler(h.metaIdSeries, "_id"),
 			"manifest":      h.entityHandler(h.metaManifest, "blobname"),
 			"revision-info": router.SingleIncludeHandler(h.metaRevisionInfo),
 			"stats":         h.entityHandler(h.metaStats),
@@ -437,6 +441,38 @@ func (h *Handler) metaRevisionInfo(id *charm.Reference, path string, flags url.V
 
 	// Write the response in JSON format.
 	return response, nil
+}
+
+// GET id/meta/id-user
+// http://tinyurl.com/o7xmhz2
+func (h *Handler) metaIdUser(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+	return params.IdUserResponse{
+		User: id.User,
+	}, nil
+}
+
+// GET id/meta/id-series
+// http://tinyurl.com/pnwmr6j
+func (h *Handler) metaIdSeries(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+	return params.IdSeriesResponse{
+		Series: id.Series,
+	}, nil
+}
+
+// GET id/meta/id-name
+// http://tinyurl.com/m5q8gcy
+func (h *Handler) metaIdName(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+	return params.IdNameResponse{
+		Name: id.Name,
+	}, nil
+}
+
+// GET id/meta/id-revision
+// http://tinyurl.com/ntd3coz
+func (h *Handler) metaIdRevision(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values) (interface{}, error) {
+	return params.IdRevisionResponse{
+		Revision: id.Revision,
+	}, nil
 }
 
 type entitiesByRevision []mongodoc.Entity

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -285,6 +285,42 @@ var metaEndpoints = []metaEndpoint{{
 			Tags: []string{"openstack", "storage"},
 		})
 	},
+}, {
+	name: "id-user",
+	get: func(store *charmstore.Store, url *charm.Reference) (interface{}, error) {
+		return params.IdUserResponse{url.User}, nil
+	},
+	checkURL: "cs:~bob/utopic/wordpress-2",
+	assertCheckData: func(c *gc.C, data interface{}) {
+		c.Assert(data, gc.Equals, params.IdUserResponse{"bob"})
+	},
+}, {
+	name: "id-series",
+	get: func(store *charmstore.Store, url *charm.Reference) (interface{}, error) {
+		return params.IdSeriesResponse{url.Series}, nil
+	},
+	checkURL: "cs:utopic/category-2",
+	assertCheckData: func(c *gc.C, data interface{}) {
+		c.Assert(data, gc.Equals, params.IdSeriesResponse{"utopic"})
+	},
+}, {
+	name: "id-name",
+	get: func(store *charmstore.Store, url *charm.Reference) (interface{}, error) {
+		return params.IdNameResponse{url.Name}, nil
+	},
+	checkURL: "cs:utopic/category-2",
+	assertCheckData: func(c *gc.C, data interface{}) {
+		c.Assert(data, gc.Equals, params.IdNameResponse{"category"})
+	},
+}, {
+	name: "id-revision",
+	get: func(store *charmstore.Store, url *charm.Reference) (interface{}, error) {
+		return params.IdRevisionResponse{url.Revision}, nil
+	},
+	checkURL: "cs:utopic/category-2",
+	assertCheckData: func(c *gc.C, data interface{}) {
+		c.Assert(data, gc.Equals, params.IdRevisionResponse{2})
+	},
 }}
 
 // TestEndpointGet tries to ensure that the endpoint
@@ -333,8 +369,10 @@ var testEntities = []string{
 	"cs:bundle/wordpress-simple-42",
 	// A charm with some actions.
 	"cs:precise/dummy-10",
-	// A charm with some tags
+	// A charm with some tags.
 	"cs:utopic/category-2",
+	// A charm with a user.
+	"cs:~bob/utopic/wordpress-2",
 }
 
 func (s *APISuite) addTestEntities(c *gc.C) []*charm.Reference {

--- a/params/params.go
+++ b/params/params.go
@@ -123,5 +123,29 @@ type SearchResponse struct {
 	Results    []SearchResult
 }
 
+// IdUserResponse holds the result of an id/meta/id-user GET request.
+// See http://tinyurl.com/o7xmhz2
+type IdUserResponse struct {
+	User string
+}
+
+// IdSeriesResponse holds the result of an id/meta/id-series GET request.
+// See http://tinyurl.com/pnwmr6j
+type IdSeriesResponse struct {
+	Series string
+}
+
+// IdNameResponse holds the result of an id/meta/id-name GET request.
+// See http://tinyurl.com/m5q8gcy
+type IdNameResponse struct {
+	Name string
+}
+
+// IdRevisionResponse holds the result of an id/meta/id-revision GET request.
+// See http://tinyurl.com/ntd3coz
+type IdRevisionResponse struct {
+	Revision int
+}
+
 // BzrDigestKey is the extra-info key used to store the Bazaar digest
 const BzrDigestKey = "bzr-digest"


### PR DESCRIPTION
We don't need to denormalise the id-related data in the entity mongo doc
yet, although that will be easy to add later if/when required.
