### PR TITLE
internal/router: return 404 on meta/any with no includes

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -92,7 +92,7 @@ func New(store *charmstore.Store, config charmstore.ServerParams) *Handler {
 			// endpoints not yet implemented:
 			// "color": router.SingleIncludeHandler(h.metaColor),
 		},
-	}, h.resolveURL)
+	}, h.resolveURL, h.entityExists)
 	return h
 }
 
@@ -169,6 +169,17 @@ func (h *Handler) updateEntity(id *charm.Reference, fields map[string]interface{
 		return errgo.Notef(err, "cannot update %q", id)
 	}
 	return nil
+}
+
+func (h *Handler) entityExists(id *charm.Reference) (bool, error) {
+	_, err := h.entityQuery(id, nil)
+	if errgo.Cause(err) == params.ErrNotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, errgo.Mask(err)
+	}
+	return true, nil
 }
 
 func (h *Handler) entityQuery(id *charm.Reference, selector map[string]int) (interface{}, error) {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -602,6 +602,37 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 	}
 }
 
+func (s *APISuite) TestMetaAnyWithNoIncludesAndNoEntity(c *gc.C) {
+	wordpressURL, _ := s.addCharm(c, "wordpress", "cs:precise/wordpress-23")
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:      s.srv,
+		URL:          storeURL("precise/wordpress-1/meta/any"),
+		ExpectStatus: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Code:    params.ErrNotFound,
+			Message: "not found",
+		},
+	})
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:      s.srv,
+		URL:          storeURL("meta/any?id=precise/wordpress-23&id=precise/wordpress-1"),
+		ExpectStatus: http.StatusOK,
+		ExpectBody: map[string]interface{}{
+			"precise/wordpress-23": params.MetaAnyResponse{
+				Id: wordpressURL,
+			},
+		},
+	})
+	storetesting.AssertJSONCall(c, storetesting.JSONCallParams{
+		Handler:      s.srv,
+		URL:          storeURL("precise/wordpress-23/meta/any"),
+		ExpectStatus: http.StatusOK,
+		ExpectBody: params.MetaAnyResponse{
+			Id: wordpressURL,
+		},
+	})
+}
+
 // In this test we rely on the charm.v2 testing repo package and
 // dummy charm that has actions included.
 func (s *APISuite) TestMetaCharmActions(c *gc.C) {


### PR DESCRIPTION
When we requested metadata on a fully qualified id using meta/any
with no includes, it would succeed unconditionally.

A better fix would be to make meta/any with no includes return an
error, but we can't do that without compromising the existing GUI client.

As drive-by fixes, we make the bulk id handler work correctly when
there are some ids are not found, and the error message from
the any handler return the full name of the meta endpoint requested.
