### PR TITLE
Denormalize entity ids in Mongo.

### DIFF
--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -52,24 +52,6 @@ const esMappingJSON = `
   "entity" : {
     "dynamic" : "false",
     "properties" : {
-      "Name" : {
-        "type" : "string",
-        "index" : "not_analyzed",
-        "omit_norms" : true,
-        "index_options" : "docs"
-      },
-      "Series" : {
-        "type" : "string",
-        "index" : "not_analyzed",
-        "omit_norms" : true,
-        "index_options" : "docs"
-      },
-      "User" : {
-        "type" : "string",
-        "index" : "not_analyzed",
-        "omit_norms" : true,
-        "index_options" : "docs"
-      },  
       "URL" : {
         "type" : "multi_field",
         "fields" : {
@@ -89,6 +71,28 @@ const esMappingJSON = `
       "BaseURL" : {
         "type" : "string",
         "index": "not_analyzed",
+        "index_options" : "docs"
+      },
+      "User" : {
+        "type" : "string",
+        "index" : "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+      "Name" : {
+        "type" : "string",
+        "index" : "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+      "Revision" : {
+        "type" : "integer",
+        "index" : "not_analyzed"
+      },
+      "Series" : {
+        "type" : "string",
+        "index" : "not_analyzed",
+        "omit_norms" : true,
         "index_options" : "docs"
       },
       "BlobHash" : {

--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -10,7 +10,7 @@ var (
 	esMapping = mustParseJSON(esMappingJSON)
 )
 
-const esSettingsVersion = 1
+const esSettingsVersion = 2
 
 func mustParseJSON(s string) interface{} {
 	var j json.RawMessage

--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -5,25 +5,85 @@ package charmstore
 
 import (
 	"gopkg.in/errgo.v1"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/charmstore/internal/mongodoc"
 )
 
 // migrations holds all the migration functions that are executed in the order
-// they are defined when the charm store server is started.
-// To introduce a new database migration, just add the corresponding migration
-// function to this list.
-var migrations = []func(db StoreDatabase) error{
-	denormalizeEntityIds,
+// they are defined when the charm store server is started. Each migration is
+// associated with a name that is used to check whether the migration has been
+// already run. To introduce a new database migration, just add the
+// corresponding migration name and function to this list. Note that names must
+// be unique across the list.
+var migrations = []migration{{
+	name:    "entity ids denormalization",
+	migrate: denormalizeEntityIds,
+}}
+
+type migration struct {
+	name    string
+	migrate func(StoreDatabase) error
 }
 
 // Migrate starts the migration process using the given database.
 func migrate(db StoreDatabase) error {
-	for _, f := range migrations {
-		if err := f(db); err != nil {
+	// Retrieve already executed migrations.
+	executed, err := getExecuted(db)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+
+	// Execute required migrations.
+	for _, m := range migrations {
+		if executed[m.name] {
+			logger.Debugf("skipping already executed migration: %s", m.name)
+			continue
+		}
+		logger.Infof("starting migration: %s", m.name)
+		if err := m.migrate(db); err != nil {
+			return errgo.Notef(err, "error executing migration: %s", m.name)
+		}
+		if err := setExecuted(db, m.name); err != nil {
 			return errgo.Mask(err)
 		}
+		logger.Infof("migration completed: %s", m.name)
+	}
+	return nil
+}
+
+func getExecuted(db StoreDatabase) (map[string]bool, error) {
+	// Retrieve the already executed migration names.
+	executed := make(map[string]bool)
+	var doc mongodoc.Migration
+	if err := db.Migrations().Find(nil).Select(bson.D{{"executed", 1}}).One(&doc); err != nil {
+		if err == mgo.ErrNotFound {
+			return executed, nil
+		}
+		return nil, errgo.Notef(err, "cannot retrieve executed migrations")
+	}
+
+	names := make(map[string]bool, len(migrations))
+	for _, m := range migrations {
+		names[m.name] = true
+	}
+	for _, name := range doc.Executed {
+		// Check that the already executed migrations are known.
+		if !names[name] {
+			return nil, errgo.Newf("unexpected already executed migration: %s", name)
+		}
+		// Collect the name of the executed migration.
+		executed[name] = true
+	}
+	return executed, nil
+}
+
+func setExecuted(db StoreDatabase, name string) error {
+	if _, err := db.Migrations().Upsert(nil, bson.D{{
+		"$addToSet", bson.D{{"executed", name}},
+	}}); err != nil {
+		return errgo.Notef(err, "cannot add %s to executed migrations", name)
 	}
 	return nil
 }
@@ -32,7 +92,6 @@ func migrate(db StoreDatabase) error {
 // entities where those fields are missing.
 // This function is not supposed to be called directly.
 func denormalizeEntityIds(db StoreDatabase) error {
-	logger.Debugf("starting entity ids migration")
 	entities := db.Entities()
 	var entity mongodoc.Entity
 	iter := entities.Find(bson.D{{
@@ -56,7 +115,5 @@ func denormalizeEntityIds(db StoreDatabase) error {
 	if err := iter.Close(); err != nil {
 		return errgo.Notef(err, "cannot denormalize entity ids")
 	}
-
-	logger.Debugf("entity ids migration successfully completed")
 	return nil
 }

--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -15,13 +15,15 @@ import (
 // they are defined when the charm store server is started. Each migration is
 // associated with a name that is used to check whether the migration has been
 // already run. To introduce a new database migration, just add the
-// corresponding migration name and function to this list. Note that names must
-// be unique across the list.
+// corresponding migration name and function to this list, and update the
+// TestMigrateMigrationList test in migration_test.go adding the new name(s).
+// Note that migration names must be unique across the list.
 var migrations = []migration{{
 	name:    "entity ids denormalization",
 	migrate: denormalizeEntityIds,
 }}
 
+// migration holds a migration function with its corresponding name.
 type migration struct {
 	name    string
 	migrate func(StoreDatabase) error

--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -1,0 +1,62 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmstore
+
+import (
+	"gopkg.in/errgo.v1"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/charmstore/internal/mongodoc"
+)
+
+// migrations holds all the migration functions that are executed in the order
+// they are defined when the charm store server is started.
+// To introduce a new database migration, just add the corresponding migration
+// function to this list.
+var migrations = []func(db StoreDatabase) error{
+	denormalizeEntityIds,
+}
+
+// Migrate starts the migration process using the given database.
+func migrate(db StoreDatabase) error {
+	for _, f := range migrations {
+		if err := f(db); err != nil {
+			return errgo.Mask(err)
+		}
+	}
+	return nil
+}
+
+// denormalizeEntityIds adds the user, name, revision and series fields to
+// entities where those fields are missing.
+// This function is not supposed to be called directly.
+func denormalizeEntityIds(db StoreDatabase) error {
+	logger.Debugf("starting entity ids migration")
+	entities := db.Entities()
+	var entity mongodoc.Entity
+	iter := entities.Find(bson.D{{
+		// Use the name field to collect not migrated entities.
+		"name", bson.D{{"$exists", false}},
+	}}).Select(bson.D{{"_id", 1}}).Iter()
+
+	for iter.Next(&entity) {
+		logger.Debugf("updating %s", entity.URL)
+		if err := entities.UpdateId(entity.URL, bson.D{{
+			"$set", bson.D{
+				{"user", entity.URL.User},
+				{"name", entity.URL.Name},
+				{"revision", entity.URL.Revision},
+				{"series", entity.URL.Series},
+			},
+		}}); err != nil {
+			return errgo.Notef(err, "cannot denormalize entity id %s", entity.URL)
+		}
+	}
+	if err := iter.Close(); err != nil {
+		return errgo.Notef(err, "cannot denormalize entity ids")
+	}
+
+	logger.Debugf("entity ids migration successfully completed")
+	return nil
+}

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -134,7 +134,7 @@ func (s *migrationsSuite) TestMigrateErrorUnknownMigration(c *gc.C) {
 
 	// Start the server.
 	err = s.newServer(c)
-	c.Assert(err, gc.ErrorMatches, "database migration failed: unexpected already executed migration: migr-1")
+	c.Assert(err, gc.ErrorMatches, `database migration failed: found unknown migration "migr-1"; running old charm store code on newer charm store database\?`)
 
 	// No new migrations were executed.
 	c.Assert(s.executed, gc.HasLen, 0)

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -1,0 +1,183 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package charmstore
+
+import (
+	"net/http"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v4"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/juju/charmstore/internal/mongodoc"
+	"github.com/juju/charmstore/internal/storetesting"
+)
+
+type migrationsSuite struct {
+	storetesting.IsolatedMgoSuite
+	db StoreDatabase
+}
+
+var _ = gc.Suite(&migrationsSuite{})
+
+func (s *migrationsSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	s.db = StoreDatabase{s.Session.DB("migration-testing")}
+}
+
+func (s *migrationsSuite) newServer(c *gc.C) {
+	apiHandler := func(store *Store, config ServerParams) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})
+	}
+	_, err := NewServer(s.db.Database, nil, serverParams, map[string]NewAPIHandlerFunc{
+		"version1": apiHandler,
+	})
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *migrationsSuite) TestDenormalizeEntityIds(c *gc.C) {
+	// Store entities with missing name in the db.
+	id1 := charm.MustParseReference("trusty/django-42")
+	id2 := charm.MustParseReference("~who/utopic/rails-47")
+	s.insertEntity(c, id1, "", 12)
+	s.insertEntity(c, id2, "", 13)
+
+	// Start the server.
+	s.newServer(c)
+
+	// Ensure entities have been updated correctly.
+	s.checkCount(c, 2)
+	s.checkEntity(c, &mongodoc.Entity{
+		URL:      id1,
+		User:     "",
+		Name:     "django",
+		Revision: 42,
+		Series:   "trusty",
+		Size:     12,
+	})
+	s.checkEntity(c, &mongodoc.Entity{
+		URL:      id2,
+		User:     "who",
+		Name:     "rails",
+		Revision: 47,
+		Series:   "utopic",
+		Size:     13,
+	})
+}
+
+func (s *migrationsSuite) TestDenormalizeEntityIdsNoEntities(c *gc.C) {
+	// Start the server.
+	s.newServer(c)
+
+	// Ensure no new entities are added in the process.
+	s.checkCount(c, 0)
+}
+
+func (s *migrationsSuite) TestDenormalizeEntityIdsNoUpdates(c *gc.C) {
+	// Store entities with a name in the db.
+	id1 := charm.MustParseReference("trusty/django-42")
+	id2 := charm.MustParseReference("~who/utopic/rails-47")
+	s.insertEntity(c, id1, "django", 21)
+	s.insertEntity(c, id2, "rails2", 22)
+
+	// Start the server.
+	s.newServer(c)
+
+	// Ensure entities have been updated correctly.
+	s.checkCount(c, 2)
+	s.checkEntity(c, &mongodoc.Entity{
+		URL:  id1,
+		User: "",
+		Name: "django",
+		// Since the name field already existed, the Revision and Series fields
+		// have not been populated.
+		Size: 21,
+	})
+	s.checkEntity(c, &mongodoc.Entity{
+		URL: id2,
+		// The name is left untouched (even if it's obviously wrong).
+		Name: "rails2",
+		// Since the name field already existed, the User, Revision and Series
+		// fields have not been populated.
+		Size: 22,
+	})
+}
+
+func (s *migrationsSuite) TestDenormalizeEntityIdsSomeUpdates(c *gc.C) {
+	// Store entities with and without names in the db
+	id1 := charm.MustParseReference("~dalek/utopic/django-42")
+	id2 := charm.MustParseReference("~dalek/utopic/django-47")
+	id3 := charm.MustParseReference("precise/postgres-0")
+	s.insertEntity(c, id1, "", 1)
+	s.insertEntity(c, id2, "django", 2)
+	s.insertEntity(c, id3, "", 3)
+
+	// Start the server.
+	s.newServer(c)
+
+	// Ensure entities have been updated correctly.
+	s.checkCount(c, 3)
+	s.checkEntity(c, &mongodoc.Entity{
+		URL:      id1,
+		User:     "dalek",
+		Name:     "django",
+		Revision: 42,
+		Series:   "utopic",
+		Size:     1,
+	})
+	s.checkEntity(c, &mongodoc.Entity{
+		URL:  id2,
+		Name: "django",
+		Size: 2,
+	})
+	s.checkEntity(c, &mongodoc.Entity{
+		URL:      id3,
+		User:     "",
+		Name:     "postgres",
+		Revision: 0,
+		Series:   "precise",
+		Size:     3,
+	})
+}
+
+func (s *migrationsSuite) checkEntity(c *gc.C, expectEntity *mongodoc.Entity) {
+	var entity mongodoc.Entity
+	err := s.db.Entities().FindId(expectEntity.URL).One(&entity)
+	c.Assert(err, gc.IsNil)
+
+	// Ensure that the denormalized fields are now present, and the previously
+	// existing fields are still there.
+	c.Assert(&entity, jc.DeepEquals, expectEntity)
+}
+
+func (s *migrationsSuite) checkCount(c *gc.C, expectCount int) {
+	count, err := s.db.Entities().Count()
+	c.Assert(err, gc.IsNil)
+	c.Assert(count, gc.Equals, expectCount)
+}
+
+func (s *migrationsSuite) insertEntity(c *gc.C, id *charm.Reference, name string, size int64) {
+	entity := &mongodoc.Entity{
+		URL:  id,
+		Name: name,
+		Size: size,
+	}
+	err := s.db.Entities().Insert(entity)
+	c.Assert(err, gc.IsNil)
+
+	// Remove the denormalized fields if required.
+	if name != "" {
+		return
+	}
+	err = s.db.Entities().UpdateId(id, bson.D{{
+		"$unset", bson.D{
+			{"user", true},
+			{"name", true},
+			{"revision", true},
+			{"series", true},
+		},
+	}})
+	c.Assert(err, gc.IsNil)
+}

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -176,7 +176,7 @@ func (s *migrationsSuite) TestMigrateMigrationNames(c *gc.C) {
 	}
 }
 
-func (s *migrationsSuite) TestMigrateMigrationNotRemoved(c *gc.C) {
+func (s *migrationsSuite) TestMigrateMigrationList(c *gc.C) {
 	// When adding migration, update the list below, but never remove existing
 	// migrations.
 	existing := []string{

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -5,10 +5,13 @@ package charmstore
 
 import (
 	"net/http"
+	"sort"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/juju/charmstore/internal/mongodoc"
@@ -17,7 +20,8 @@ import (
 
 type migrationsSuite struct {
 	storetesting.IsolatedMgoSuite
-	db StoreDatabase
+	db       StoreDatabase
+	executed []string
 }
 
 var _ = gc.Suite(&migrationsSuite{})
@@ -25,16 +29,175 @@ var _ = gc.Suite(&migrationsSuite{})
 func (s *migrationsSuite) SetUpTest(c *gc.C) {
 	s.IsolatedMgoSuite.SetUpTest(c)
 	s.db = StoreDatabase{s.Session.DB("migration-testing")}
+	s.executed = []string{}
 }
 
-func (s *migrationsSuite) newServer(c *gc.C) {
+func (s *migrationsSuite) newServer(c *gc.C) error {
 	apiHandler := func(store *Store, config ServerParams) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})
 	}
 	_, err := NewServer(s.db.Database, nil, serverParams, map[string]NewAPIHandlerFunc{
 		"version1": apiHandler,
 	})
+	return err
+}
+
+// patchMigrations patches the charm store migration list with the given ms.
+func (s *migrationsSuite) patchMigrations(c *gc.C, ms []migration) {
+	original := migrations
+	s.AddCleanup(func(*gc.C) {
+		migrations = original
+	})
+	migrations = ms
+}
+
+// makeMigrations generates default migrations using the given names, and then
+// patches the charm store migration list with the generated ones.
+func (s *migrationsSuite) makeMigrations(c *gc.C, names ...string) {
+	ms := make([]migration, len(names))
+	for i, name := range names {
+		name := name
+		ms[i] = migration{
+			name: name,
+			migrate: func(StoreDatabase) error {
+				s.executed = append(s.executed, name)
+				return nil
+			},
+		}
+	}
+	s.patchMigrations(c, ms)
+}
+
+func (s *migrationsSuite) TestMigrate(c *gc.C) {
+	// Create migrations.
+	names := []string{"migr-1", "migr-2"}
+	s.makeMigrations(c, names...)
+
+	// Start the server.
+	err := s.newServer(c)
 	c.Assert(err, gc.IsNil)
+
+	// The two migrations have been correctly executed in order.
+	c.Assert(s.executed, jc.DeepEquals, names)
+
+	// The migration document in the db reports that the execution is done.
+	s.checkExecuted(c, names...)
+
+	// Restart the server again and check migrations this time are not run.
+	err = s.newServer(c)
+	c.Assert(err, gc.IsNil)
+	c.Assert(s.executed, jc.DeepEquals, names)
+	s.checkExecuted(c, names...)
+}
+
+func (s *migrationsSuite) TestMigrateNoMigrations(c *gc.C) {
+	// Empty the list of migrations.
+	s.makeMigrations(c)
+
+	// Start the server.
+	err := s.newServer(c)
+	c.Assert(err, gc.IsNil)
+
+	// No migrations were executed.
+	c.Assert(s.executed, gc.HasLen, 0)
+	s.checkExecuted(c)
+}
+
+func (s *migrationsSuite) TestMigrateNewMigration(c *gc.C) {
+	// Simulate two migrations were already run.
+	err := setExecuted(s.db, "migr-1")
+	c.Assert(err, gc.IsNil)
+	err = setExecuted(s.db, "migr-2")
+	c.Assert(err, gc.IsNil)
+
+	// Create migrations.
+	s.makeMigrations(c, "migr-1", "migr-2", "migr-3")
+
+	// Start the server.
+	err = s.newServer(c)
+	c.Assert(err, gc.IsNil)
+
+	// Only one migration has been executed.
+	c.Assert(s.executed, jc.DeepEquals, []string{"migr-3"})
+
+	// The migration document in the db reports that the execution is done.
+	s.checkExecuted(c, "migr-1", "migr-2", "migr-3")
+}
+
+func (s *migrationsSuite) TestMigrateErrorUnknownMigration(c *gc.C) {
+	// Simulate that a migration was already run.
+	err := setExecuted(s.db, "migr-1")
+	c.Assert(err, gc.IsNil)
+
+	// Create migrations, without including the already executed one.
+	s.makeMigrations(c, "migr-2", "migr-3")
+
+	// Start the server.
+	err = s.newServer(c)
+	c.Assert(err, gc.ErrorMatches, "database migration failed: unexpected already executed migration: migr-1")
+
+	// No new migrations were executed.
+	c.Assert(s.executed, gc.HasLen, 0)
+	s.checkExecuted(c, "migr-1")
+}
+
+func (s *migrationsSuite) TestMigrateErrorExecutingMigration(c *gc.C) {
+	ms := []migration{{
+		name: "migr-1",
+		migrate: func(StoreDatabase) error {
+			return nil
+		},
+	}, {
+		name: "migr-2",
+		migrate: func(StoreDatabase) error {
+			return errgo.New("bad wolf")
+		},
+	}, {
+		name: "migr-3",
+		migrate: func(StoreDatabase) error {
+			return nil
+		},
+	}}
+	s.patchMigrations(c, ms)
+
+	// Start the server.
+	err := s.newServer(c)
+	c.Assert(err, gc.ErrorMatches, "database migration failed: error executing migration: migr-2: bad wolf")
+
+	// Only one migration has been executed.
+	s.checkExecuted(c, "migr-1")
+}
+
+func (s *migrationsSuite) TestMigrateMigrationNames(c *gc.C) {
+	names := make(map[string]bool, len(migrations))
+	for _, m := range migrations {
+		c.Assert(names[m.name], jc.IsFalse, gc.Commentf("multiple migrations named %q", m.name))
+		names[m.name] = true
+	}
+}
+
+func (s *migrationsSuite) TestMigrateMigrationNotRemoved(c *gc.C) {
+	// When adding migration, update the list below, but never remove existing
+	// migrations.
+	existing := []string{
+		"entity ids denormalization",
+	}
+	for i, name := range existing {
+		m := migrations[i]
+		c.Assert(m.name, gc.Equals, name)
+	}
+}
+
+func (s *migrationsSuite) checkExecuted(c *gc.C, expected ...string) {
+	var obtained []string
+	var doc mongodoc.Migration
+	if err := s.db.Migrations().Find(nil).One(&doc); err != mgo.ErrNotFound {
+		c.Assert(err, gc.IsNil)
+		obtained = doc.Executed
+		sort.Strings(obtained)
+	}
+	sort.Strings(expected)
+	c.Assert(obtained, jc.DeepEquals, expected)
 }
 
 func (s *migrationsSuite) TestDenormalizeEntityIds(c *gc.C) {
@@ -45,7 +208,8 @@ func (s *migrationsSuite) TestDenormalizeEntityIds(c *gc.C) {
 	s.insertEntity(c, id2, "", 13)
 
 	// Start the server.
-	s.newServer(c)
+	err := s.newServer(c)
+	c.Assert(err, gc.IsNil)
 
 	// Ensure entities have been updated correctly.
 	s.checkCount(c, 2)
@@ -69,7 +233,8 @@ func (s *migrationsSuite) TestDenormalizeEntityIds(c *gc.C) {
 
 func (s *migrationsSuite) TestDenormalizeEntityIdsNoEntities(c *gc.C) {
 	// Start the server.
-	s.newServer(c)
+	err := s.newServer(c)
+	c.Assert(err, gc.IsNil)
 
 	// Ensure no new entities are added in the process.
 	s.checkCount(c, 0)
@@ -83,7 +248,8 @@ func (s *migrationsSuite) TestDenormalizeEntityIdsNoUpdates(c *gc.C) {
 	s.insertEntity(c, id2, "rails2", 22)
 
 	// Start the server.
-	s.newServer(c)
+	err := s.newServer(c)
+	c.Assert(err, gc.IsNil)
 
 	// Ensure entities have been updated correctly.
 	s.checkCount(c, 2)
@@ -115,7 +281,8 @@ func (s *migrationsSuite) TestDenormalizeEntityIdsSomeUpdates(c *gc.C) {
 	s.insertEntity(c, id3, "", 3)
 
 	// Start the server.
-	s.newServer(c)
+	err := s.newServer(c)
+	c.Assert(err, gc.IsNil)
 
 	// Ensure entities have been updated correctly.
 	s.checkCount(c, 3)

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -37,14 +37,6 @@ type storeElasticSearch struct {
 
 const typeName = "entity"
 
-// esDoc is a mongodoc.Entity that has denormalised values for use in searching.
-type esDoc struct {
-	*mongodoc.Entity
-	Name   string
-	User   string
-	Series string
-}
-
 // seriesBoost defines how much the results for each
 // series will be boosted. Series are currently ranked in
 // reverse order of LTS releases, followed by the latest
@@ -82,19 +74,13 @@ func (ses *storeElasticSearch) put(r *charm.Reference) error {
 		}
 		return errgo.Notef(err, "cannot get %s", r)
 	}
-	doc := esDoc{
-		Entity: &entity,
-		Name:   entity.URL.Name,
-		User:   entity.URL.User,
-		Series: entity.URL.Series,
-	}
 	err := ses.PutDocumentVersionWithType(
 		ses.Index,
 		typeName,
 		ses.getID(entity.URL),
 		int64(entity.URL.Revision),
 		elasticsearch.ExternalGTE,
-		doc)
+		&entity)
 	if err != nil && err != elasticsearch.ErrConflict {
 		return errgo.Mask(err)
 	}
@@ -324,7 +310,7 @@ type sortParam struct {
 	Order sortOrder
 }
 
-// sortFields contains a mapping from api fieldnames to the esdoc fields to search.
+// sortFields contains a mapping from api fieldnames to the entity fields to search.
 var sortFields = map[string]string{
 	"name":   "Name",
 	"owner":  "User",

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -53,7 +53,7 @@ func (s *StoreSearchSuite) TestSuccessfulExport(c *gc.C) {
 		var actual json.RawMessage
 		err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL), &actual)
 		c.Assert(err, gc.IsNil)
-		c.Assert([]byte(actual), storetesting.JSONEquals, esDocForEntity(entity))
+		c.Assert([]byte(actual), storetesting.JSONEquals, entity)
 	}
 }
 
@@ -90,7 +90,7 @@ func (s *StoreSearchSuite) TestExportOnlyLatest(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(old.URL), &actual)
 	c.Assert(err, gc.IsNil)
-	c.Assert([]byte(actual), storetesting.JSONEquals, esDocForEntity(expected))
+	c.Assert([]byte(actual), storetesting.JSONEquals, expected)
 }
 
 func (s *StoreSearchSuite) addCharmsToStore(c *gc.C, store *Store) {
@@ -607,14 +607,5 @@ func assertSearchResults(c *gc.C, obtained SearchResult, expected []string) {
 	sort.Strings(ids)
 	for i, v := range expected {
 		c.Assert(ids[i], gc.Equals, v)
-	}
-}
-
-func esDocForEntity(e *mongodoc.Entity) esDoc {
-	return esDoc{
-		Entity: e,
-		Name:   e.URL.Name,
-		User:   e.URL.User,
-		Series: e.URL.Series,
 	}
 }

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -39,6 +39,9 @@ func NewServer(db *mgo.Database, si *SearchIndex, config ServerParams, versions 
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot make store")
 	}
+	if err := migrate(store.DB); err != nil {
+		return nil, errgo.Notef(err, "database migration failed")
+	}
 	mux := router.NewServeMux()
 	for vers, newAPI := range versions {
 		handle(mux, "/"+vers, newAPI(store, config))

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -183,6 +183,10 @@ func (s *Store) AddCharm(c charm.Charm, p AddParams) (err error) {
 	entity := &mongodoc.Entity{
 		URL:                     p.URL,
 		BaseURL:                 baseURL(p.URL),
+		User:                    p.URL.User,
+		Name:                    p.URL.Name,
+		Revision:                p.URL.Revision,
+		Series:                  p.URL.Series,
 		BlobHash:                p.BlobHash,
 		BlobName:                p.BlobName,
 		Size:                    p.BlobSize,
@@ -354,6 +358,10 @@ func (s *Store) AddBundle(b charm.Bundle, p AddParams) error {
 	entity := &mongodoc.Entity{
 		URL:                p.URL,
 		BaseURL:            baseURL(p.URL),
+		User:               p.URL.User,
+		Name:               p.URL.Name,
+		Revision:           p.URL.Revision,
+		Series:             p.URL.Series,
 		BlobHash:           p.BlobHash,
 		BlobName:           p.BlobName,
 		Size:               p.BlobSize,

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -84,6 +84,9 @@ func (s *Store) ensureIndexes() error {
 	}, {
 		s.DB.Logs(),
 		mgo.Index{Key: []string{"urls"}},
+	}, {
+		s.DB.Migrations(),
+		mgo.Index{Key: []string{"executed"}},
 	}}
 	for _, idx := range indexes {
 		err := idx.c.EnsureIndex(idx.i)
@@ -650,6 +653,11 @@ func (s StoreDatabase) Logs() *mgo.Collection {
 	return s.C("logs")
 }
 
+// Migrations returns the Mongo collection where the migration info is stored.
+func (s StoreDatabase) Migrations() *mgo.Collection {
+	return s.C("migrations")
+}
+
 // allCollections holds for each collection used by the charm store a
 // function returns that collection.
 var allCollections = []func(StoreDatabase) *mgo.Collection{
@@ -657,6 +665,7 @@ var allCollections = []func(StoreDatabase) *mgo.Collection{
 	StoreDatabase.StatTokens,
 	StoreDatabase.Entities,
 	StoreDatabase.Logs,
+	StoreDatabase.Migrations,
 }
 
 // Collections returns a slice of all the collections used

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -84,9 +84,6 @@ func (s *Store) ensureIndexes() error {
 	}, {
 		s.DB.Logs(),
 		mgo.Index{Key: []string{"urls"}},
-	}, {
-		s.DB.Migrations(),
-		mgo.Index{Key: []string{"executed"}},
 	}}
 	for _, idx := range indexes {
 		err := idx.c.EnsureIndex(idx.i)

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -1073,11 +1073,15 @@ func (s *StoreSuite) TestCollections(c *gc.C) {
 	colls := store.DB.Collections()
 	names, err := store.DB.CollectionNames()
 	c.Assert(err, gc.IsNil)
+	// Some collections don't have indexes so they are created only when used.
+	createdOnUse := map[string]bool{
+		"migrations": true,
+	}
 	// Check that all collections mentioned by Collections are actually created.
 	for _, coll := range colls {
 		found := false
 		for _, name := range names {
-			if name == coll.Name {
+			if name == coll.Name || createdOnUse[coll.Name] {
 				found = true
 			}
 		}

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -92,6 +92,34 @@ type Entity struct {
 	Contents map[FileId]ZipFile `json:",omitempty" bson:",omitempty"`
 }
 
+type FileId string
+
+const (
+	FileReadMe FileId = "readme"
+	FileIcon   FileId = "icon"
+)
+
+// ZipFile refers to a specific file in the uploaded archive blob.
+type ZipFile struct {
+	// Compressed specifies whether the file is compressed or not.
+	Compressed bool
+
+	// Offset holds the offset into the zip archive of the start of
+	// the file's data.
+	Offset int64
+
+	// Size holds the size of the file before decompression.
+	Size int64
+}
+
+// Valid reports whether f is a valid (non-zero) reference to
+// a zip file.
+func (f ZipFile) IsValid() bool {
+	// Note that no valid zip files can start at offset zero,
+	// because that's where the zip header lives.
+	return f != ZipFile{}
+}
+
 // Log holds the in-database representation of a log message sent to the charm
 // store.
 type Log struct {
@@ -139,30 +167,8 @@ const (
 	IngestionType
 )
 
-type FileId string
-
-const (
-	FileReadMe FileId = "readme"
-	FileIcon   FileId = "icon"
-)
-
-// ZipFile refers to a specific file in the uploaded archive blob.
-type ZipFile struct {
-	// Compressed specifies whether the file is compressed or not.
-	Compressed bool
-
-	// Offset holds the offset into the zip archive of the start of
-	// the file's data.
-	Offset int64
-
-	// Size holds the size of the file before decompression.
-	Size int64
-}
-
-// Valid reports whether f is a valid (non-zero) reference to
-// a zip file.
-func (f ZipFile) IsValid() bool {
-	// Note that no valid zip files can start at offset zero,
-	// because that's where the zip header lives.
-	return f != ZipFile{}
+// Migration holds information about the database migration.
+type Migration struct {
+	// Executed holds the migration names for migrations already executed.
+	Executed []string
 }

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -18,6 +18,18 @@ type Entity struct {
 	// e.g. cs:wordpress, cs:~user/foo
 	BaseURL *charm.Reference
 
+	// User holds the user part of the entity URL (for instance, "joe").
+	User string `bson:",omitempty" json:",omitempty"`
+
+	// Name holds the name of the entity (for instance "wordpress").
+	Name string
+
+	// Revision holds the entity revision (it cannot be -1/unset).
+	Revision int
+
+	// Series holds the entity series (for instance "trusty" or "bundle").
+	Series string
+
 	// BlobHash holds the hash checksum of the blob, in hexadecimal format,
 	// as created by blobstore.NewHash.
 	BlobHash string

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -19,7 +19,7 @@ type Entity struct {
 	BaseURL *charm.Reference
 
 	// User holds the user part of the entity URL (for instance, "joe").
-	User string `bson:",omitempty" json:",omitempty"`
+	User string
 
 	// Name holds the name of the entity (for instance "wordpress").
 	Name string

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -374,7 +374,7 @@ func (h *Handler) bundleCharms(ids []string) (map[string]charm.Charm, error) {
 
 	entityCharms := make(map[charm.Reference]charm.Charm, len(entities))
 	for i, entity := range entities {
-		entityCharms[*entity.URL] = (*entityCharm)(&entities[i])
+		entityCharms[*entity.URL] = &entityCharm{entities[i]}
 	}
 	charms := make(map[string]charm.Charm, len(urls))
 	for i, url := range urls {
@@ -386,7 +386,9 @@ func (h *Handler) bundleCharms(ids []string) (map[string]charm.Charm, error) {
 }
 
 // entityCharm implements charm.Charm.
-type entityCharm mongodoc.Entity
+type entityCharm struct {
+	mongodoc.Entity
+}
 
 func (e *entityCharm) Meta() *charm.Meta {
 	return e.CharmMeta


### PR DESCRIPTION
When adding charms or bundles, store their URL parts
in separate fields.
Also implement a simple migration strategy.
