### PR TITLE
Include more info in the meta/stats endpoint.

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -421,14 +421,19 @@ func (h *Handler) metaStats(entity *mongodoc.Entity, id *charm.Reference, path s
 
 	// Return the response.
 	return &params.StatsResponse{
-		ArchiveDownloadCount:                      counts.total,
-		ArchiveDownloadCountLastDay:               counts.lastDay,
-		ArchiveDownloadCountLastWeek:              counts.lastWeek,
-		ArchiveDownloadCountLastMonth:             counts.lastMonth,
-		ArchiveDownloadCountAllRevisions:          countsAllRevisions.total,
-		ArchiveDownloadCountLastDayAllRevisions:   countsAllRevisions.lastDay,
-		ArchiveDownloadCountLastWeekAllRevisions:  countsAllRevisions.lastWeek,
-		ArchiveDownloadCountLastMonthAllRevisions: countsAllRevisions.lastMonth,
+		ArchiveDownloadCount: counts.total,
+		ArchiveDownload: params.StatsCount{
+			Total: counts.total,
+			Day:   counts.lastDay,
+			Week:  counts.lastWeek,
+			Month: counts.lastMonth,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: countsAllRevisions.total,
+			Day:   countsAllRevisions.lastDay,
+			Week:  countsAllRevisions.lastWeek,
+			Month: countsAllRevisions.lastMonth,
+		},
 	}, nil
 }
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -1082,14 +1082,19 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {0: 1},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount:                      1,
-		ArchiveDownloadCountLastDay:               1,
-		ArchiveDownloadCountLastWeek:              1,
-		ArchiveDownloadCountLastMonth:             1,
-		ArchiveDownloadCountAllRevisions:          1,
-		ArchiveDownloadCountLastDayAllRevisions:   1,
-		ArchiveDownloadCountLastWeekAllRevisions:  1,
-		ArchiveDownloadCountLastMonthAllRevisions: 1,
+		ArchiveDownloadCount: 1,
+		ArchiveDownload: params.StatsCount{
+			Total: 1,
+			Day:   1,
+			Week:  1,
+			Month: 1,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: 1,
+			Day:   1,
+			Week:  1,
+			Month: 1,
+		},
 	},
 }, {
 	about: "single download a long time ago",
@@ -1098,8 +1103,13 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {100: 1},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount:             1,
-		ArchiveDownloadCountAllRevisions: 1,
+		ArchiveDownloadCount: 1,
+		ArchiveDownload: params.StatsCount{
+			Total: 1,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: 1,
+		},
 	},
 }, {
 	about: "some downloads this month",
@@ -1108,10 +1118,15 @@ var metaStatsTests = []struct {
 		"utopic/wordpress-47": {20: 2, 25: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount:                      2 + 5,
-		ArchiveDownloadCountLastMonth:             2 + 5,
-		ArchiveDownloadCountAllRevisions:          2 + 5,
-		ArchiveDownloadCountLastMonthAllRevisions: 2 + 5,
+		ArchiveDownloadCount: 2 + 5,
+		ArchiveDownload: params.StatsCount{
+			Total: 2 + 5,
+			Month: 2 + 5,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: 2 + 5,
+			Month: 2 + 5,
+		},
 	},
 }, {
 	about: "multiple recent downloads",
@@ -1120,14 +1135,19 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {100: 1, 12: 3, 8: 5, 4: 10, 2: 1, 0: 3},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount:                      1 + 3 + 5 + 10 + 1 + 3,
-		ArchiveDownloadCountLastDay:               3,
-		ArchiveDownloadCountLastWeek:              10 + 1 + 3,
-		ArchiveDownloadCountLastMonth:             3 + 5 + 10 + 1 + 3,
-		ArchiveDownloadCountAllRevisions:          1 + 3 + 5 + 10 + 1 + 3,
-		ArchiveDownloadCountLastDayAllRevisions:   3,
-		ArchiveDownloadCountLastWeekAllRevisions:  10 + 1 + 3,
-		ArchiveDownloadCountLastMonthAllRevisions: 3 + 5 + 10 + 1 + 3,
+		ArchiveDownloadCount: 1 + 3 + 5 + 10 + 1 + 3,
+		ArchiveDownload: params.StatsCount{
+			Total: 1 + 3 + 5 + 10 + 1 + 3,
+			Day:   3,
+			Week:  10 + 1 + 3,
+			Month: 3 + 5 + 10 + 1 + 3,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: 1 + 3 + 5 + 10 + 1 + 3,
+			Day:   3,
+			Week:  10 + 1 + 3,
+			Month: 3 + 5 + 10 + 1 + 3,
+		},
 	},
 }, {
 	about: "sparse downloads",
@@ -1136,12 +1156,17 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {200: 3, 28: 4, 3: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount:                      3 + 4 + 5,
-		ArchiveDownloadCountLastWeek:              5,
-		ArchiveDownloadCountLastMonth:             4 + 5,
-		ArchiveDownloadCountAllRevisions:          3 + 4 + 5,
-		ArchiveDownloadCountLastWeekAllRevisions:  5,
-		ArchiveDownloadCountLastMonthAllRevisions: 4 + 5,
+		ArchiveDownloadCount: 3 + 4 + 5,
+		ArchiveDownload: params.StatsCount{
+			Total: 3 + 4 + 5,
+			Week:  5,
+			Month: 4 + 5,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: 3 + 4 + 5,
+			Week:  5,
+			Month: 4 + 5,
+		},
 	},
 }, {
 	about: "bundle downloads",
@@ -1150,12 +1175,17 @@ var metaStatsTests = []struct {
 		"bundle/django-simple-2": {200: 3, 28: 4, 3: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount:                      3 + 4 + 5,
-		ArchiveDownloadCountLastWeek:              5,
-		ArchiveDownloadCountLastMonth:             4 + 5,
-		ArchiveDownloadCountAllRevisions:          3 + 4 + 5,
-		ArchiveDownloadCountLastWeekAllRevisions:  5,
-		ArchiveDownloadCountLastMonthAllRevisions: 4 + 5,
+		ArchiveDownloadCount: 3 + 4 + 5,
+		ArchiveDownload: params.StatsCount{
+			Total: 3 + 4 + 5,
+			Week:  5,
+			Month: 4 + 5,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: 3 + 4 + 5,
+			Week:  5,
+			Month: 4 + 5,
+		},
 	},
 }, {
 	about: "different charms",
@@ -1166,12 +1196,17 @@ var metaStatsTests = []struct {
 		"trusty/mysql-0":  {200: 1, 14: 2, 1: 7},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount:                      2 + 10,
-		ArchiveDownloadCountLastWeek:              10,
-		ArchiveDownloadCountLastMonth:             2 + 10,
-		ArchiveDownloadCountAllRevisions:          2 + 10,
-		ArchiveDownloadCountLastWeekAllRevisions:  10,
-		ArchiveDownloadCountLastMonthAllRevisions: 2 + 10,
+		ArchiveDownloadCount: 2 + 10,
+		ArchiveDownload: params.StatsCount{
+			Total: 2 + 10,
+			Week:  10,
+			Month: 2 + 10,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: 2 + 10,
+			Week:  10,
+			Month: 2 + 10,
+		},
 	},
 }, {
 	about: "different revisions of the same charm",
@@ -1182,13 +1217,18 @@ var metaStatsTests = []struct {
 		"precise/rails-2": {6: 10, 0: 9},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount:                      5 + 3 + 7,
-		ArchiveDownloadCountLastWeek:              7,
-		ArchiveDownloadCountLastMonth:             3 + 7,
-		ArchiveDownloadCountAllRevisions:          (1 + 2) + (5 + 3 + 7) + (10 + 9),
-		ArchiveDownloadCountLastDayAllRevisions:   0 + 0 + 9,
-		ArchiveDownloadCountLastWeekAllRevisions:  0 + 7 + (10 + 9),
-		ArchiveDownloadCountLastMonthAllRevisions: 0 + (3 + 7) + (10 + 9),
+		ArchiveDownloadCount: 5 + 3 + 7,
+		ArchiveDownload: params.StatsCount{
+			Total: 5 + 3 + 7,
+			Week:  7,
+			Month: 3 + 7,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: (1 + 2) + (5 + 3 + 7) + (10 + 9),
+			Day:   0 + 0 + 9,
+			Week:  0 + 7 + (10 + 9),
+			Month: 0 + (3 + 7) + (10 + 9),
+		},
 	},
 }, {
 	about: "downloads only in an old revision",
@@ -1199,7 +1239,9 @@ var metaStatsTests = []struct {
 		"trusty/wordpress-2":  {},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCountAllRevisions: 10,
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: 10,
+		},
 	},
 }, {
 	about: "downloads only in newer revision",
@@ -1210,10 +1252,12 @@ var metaStatsTests = []struct {
 		"utopic/wordpress-2": {6: 9, 0: 2},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCountAllRevisions:          (7 + 1 + 2 + 1) + (9 + 2),
-		ArchiveDownloadCountLastDayAllRevisions:   1 + 2,
-		ArchiveDownloadCountLastWeekAllRevisions:  (2 + 1) + (9 + 2),
-		ArchiveDownloadCountLastMonthAllRevisions: (1 + 2 + 1) + (9 + 2),
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: (7 + 1 + 2 + 1) + (9 + 2),
+			Day:   1 + 2,
+			Week:  (2 + 1) + (9 + 2),
+			Month: (1 + 2 + 1) + (9 + 2),
+		},
 	},
 }, {
 	about: "non promulgated charms",
@@ -1223,12 +1267,17 @@ var metaStatsTests = []struct {
 		"~who/utopic/django-0": {2: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount:                      5,
-		ArchiveDownloadCountLastWeek:              5,
-		ArchiveDownloadCountLastMonth:             5,
-		ArchiveDownloadCountAllRevisions:          5,
-		ArchiveDownloadCountLastWeekAllRevisions:  5,
-		ArchiveDownloadCountLastMonthAllRevisions: 5,
+		ArchiveDownloadCount: 5,
+		ArchiveDownload: params.StatsCount{
+			Total: 5,
+			Week:  5,
+			Month: 5,
+		},
+		ArchiveDownloadAllRevisions: params.StatsCount{
+			Total: 5,
+			Week:  5,
+			Month: 5,
+		},
 	},
 }}
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -1130,7 +1130,7 @@ var metaStatsTests = []struct {
 		ArchiveDownloadCountLastMonthAllRevisions: 3 + 5 + 10 + 1 + 3,
 	},
 }, {
-	about: "sparse donwloads",
+	about: "sparse downloads",
 	url:   "utopic/django-42",
 	downloads: map[string]map[int]int{
 		"utopic/django-42": {200: 3, 28: 4, 3: 5},
@@ -1144,7 +1144,7 @@ var metaStatsTests = []struct {
 		ArchiveDownloadCountLastMonthAllRevisions: 4 + 5,
 	},
 }, {
-	about: "bundle donwloads",
+	about: "bundle downloads",
 	url:   "bundle/django-simple-2",
 	downloads: map[string]map[int]int{
 		"bundle/django-simple-2": {200: 3, 28: 4, 3: 5},
@@ -1214,6 +1214,21 @@ var metaStatsTests = []struct {
 		ArchiveDownloadCountLastDayAllRevisions:   1 + 2,
 		ArchiveDownloadCountLastWeekAllRevisions:  (2 + 1) + (9 + 2),
 		ArchiveDownloadCountLastMonthAllRevisions: (1 + 2 + 1) + (9 + 2),
+	},
+}, {
+	about: "non promulgated charms",
+	url:   "~who/utopic/django-0",
+	downloads: map[string]map[int]int{
+		"utopic/django-0":      {100: 1, 10: 2, 1: 3, 0: 4},
+		"~who/utopic/django-0": {2: 5},
+	},
+	expectResponse: params.StatsResponse{
+		ArchiveDownloadCount:                      5,
+		ArchiveDownloadCountLastWeek:              5,
+		ArchiveDownloadCountLastMonth:             5,
+		ArchiveDownloadCountAllRevisions:          5,
+		ArchiveDownloadCountLastWeekAllRevisions:  5,
+		ArchiveDownloadCountLastMonthAllRevisions: 5,
 	},
 }}
 

--- a/params/stats.go
+++ b/params/stats.go
@@ -22,31 +22,24 @@ type Statistic struct {
 	Count int64
 }
 
-// StatsResponse holds the result of an
-// id/meta/stats GET request. See http://tinyurl.com/lvyp2l5
+// StatsResponse holds the result of an id/meta/stats GET request.
+// See http://tinyurl.com/lvyp2l5
 type StatsResponse struct {
-	// ArchiveDownloadCount is the global downloads count for a specific
-	// revision of the entity.
+	// ArchiveDownloadCount is superceded by ArchiveDownload but maintained for
+	// backward compatibility.
 	ArchiveDownloadCount int64
-	// ArchiveDownloadCountLastDay is the download count in the last 24 hours
-	// for a specific revision of the entity.
-	ArchiveDownloadCountLastDay int64
-	// ArchiveDownloadCountLastWeek is the download count in the last week for
-	// a specific revision of the entity.
-	ArchiveDownloadCountLastWeek int64
-	// ArchiveDownloadCountLastMonth is the download count in the last month
-	// for a specific revision of the entity.
-	ArchiveDownloadCountLastMonth int64
-	// ArchiveDownloadCountAllRevisions is the global downloads count for all
-	// revisions of the entity.
-	ArchiveDownloadCountAllRevisions int64
-	// ArchiveDownloadCountLastDayAllRevisions is the download count in the
-	// last 24 hours for all revisions of the entity.
-	ArchiveDownloadCountLastDayAllRevisions int64
-	// ArchiveDownloadCountLastWeekAllRevisions is the download count in the
-	// last week for all revisions of the entity.
-	ArchiveDownloadCountLastWeekAllRevisions int64
-	// ArchiveDownloadCountLastMonthAllRevisions is the download count in the
-	// last month for all revisions of the entity.
-	ArchiveDownloadCountLastMonthAllRevisions int64
+	// ArchiveDownload holds the downloads count for a specific revision of the
+	// entity.
+	ArchiveDownload StatsCount
+	// ArchiveDownloadAllRevisions holds the downloads count for all revisions
+	// of the entity.
+	ArchiveDownloadAllRevisions StatsCount
+}
+
+// StatsCount holds stats counts and is used as part of StatsResponse.
+type StatsCount struct {
+	Total int64 // Total count over all time.
+	Day   int64 // Count over the last day.
+	Week  int64 // Count over the last week.
+	Month int64 // Count over the last month.
 }

--- a/params/stats.go
+++ b/params/stats.go
@@ -25,6 +25,28 @@ type Statistic struct {
 // StatsResponse holds the result of an
 // id/meta/stats GET request. See http://tinyurl.com/lvyp2l5
 type StatsResponse struct {
-	// ArchiveDownloadCount is the downloads count for the entity.
+	// ArchiveDownloadCount is the global downloads count for a specific
+	// revision of the entity.
 	ArchiveDownloadCount int64
+	// ArchiveDownloadCountLastDay is the download count in the last 24 hours
+	// for a specific revision of the entity.
+	ArchiveDownloadCountLastDay int64
+	// ArchiveDownloadCountLastWeek is the download count in the last week for
+	// a specific revision of the entity.
+	ArchiveDownloadCountLastWeek int64
+	// ArchiveDownloadCountLastMonth is the download count in the last month
+	// for a specific revision of the entity.
+	ArchiveDownloadCountLastMonth int64
+	// ArchiveDownloadCountAllRevisions is the global downloads count for all
+	// revisions of the entity.
+	ArchiveDownloadCountAllRevisions int64
+	// ArchiveDownloadCountLastDayAllRevisions is the download count in the
+	// last 24 hours for all revisions of the entity.
+	ArchiveDownloadCountLastDayAllRevisions int64
+	// ArchiveDownloadCountLastWeekAllRevisions is the download count in the
+	// last week for all revisions of the entity.
+	ArchiveDownloadCountLastWeekAllRevisions int64
+	// ArchiveDownloadCountLastMonthAllRevisions is the download count in the
+	// last month for all revisions of the entity.
+	ArchiveDownloadCountLastMonthAllRevisions int64
 }


### PR DESCRIPTION
The meta/stats endpoint returns aggregated downloads
count for the last day, week and month.
It also includes both the stats for the specific
entity revisions and the stats for all revisions of the
requested entity.
