### PR TITLE
internal/v4: add viewbox to icons that do not have one

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -12,6 +12,7 @@ github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T0
 github.com/juju/testing	git	d0fb1a32e1702bda28711881f27c3a255e46ed0d	2014-12-03T16:55:57Z
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	2014-09-25T11:49:22Z
 github.com/juju/utils	git	a2a4ba970472d7f55382941ab1d38cc270ae4a0e	2014-11-13T04:39:48Z
+github.com/juju/xml	git	91535ba18a6afd756e38a40c91fea0ed8e5dbaa6	2014-12-04T14:59:31Z
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
 gopkg.in/juju/charm.v4	git	7ef31c485ccfd7f1f9571d42ef4395bd04dc1006	2014-11-17T17:46:04Z

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -7,9 +7,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"reflect"
@@ -963,47 +961,6 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 			ExpectStatus: expectStatus,
 			ExpectBody:   expectBody,
 		})
-	}
-}
-
-// assertXMLContains asserts that the XML in body is well formed, and
-// contains at least one token that satisfies each of the functions in need.
-func assertXMLContains(c *gc.C, body []byte, need map[string]func(xml.Token) bool) {
-	dec := xml.NewDecoder(bytes.NewReader(body))
-	for {
-		tok, err := dec.Token()
-		if err == io.EOF {
-			break
-		}
-		c.Assert(err, gc.IsNil)
-		for what, f := range need {
-			if f(tok) {
-				delete(need, what)
-			}
-		}
-	}
-	c.Assert(need, gc.HasLen, 0, gc.Commentf("body:\n%s", body))
-}
-
-func isStartElementWithName(name string) func(xml.Token) bool {
-	return func(tok xml.Token) bool {
-		startElem, ok := tok.(xml.StartElement)
-		return ok && startElem.Name.Local == name
-	}
-}
-
-func isStartElementWithAttr(name, attr, val string) func(xml.Token) bool {
-	return func(tok xml.Token) bool {
-		startElem, ok := tok.(xml.StartElement)
-		if !ok {
-			return false
-		}
-		for _, a := range startElem.Attr {
-			if a.Name.Local == attr && a.Value == val {
-				return true
-			}
-		}
-		return false
 	}
 }
 

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -12,4 +12,5 @@ var (
 	ArchiveCacheNonVersionedMaxAge = &archiveCacheNonVersionedMaxAge
 	ParamsLogLevels                = paramsLogLevels
 	ParamsLogTypes                 = paramsLogTypes
+	ProcessIcon                    = processIcon
 )


### PR DESCRIPTION
Some web browsers require a viewbox, but not all icon.svg
files have one. The standard library's encoding/xml package
does not cope well with name spaces, so we use a temporarily
forked version with fixes.

We could be more efficient when processing icon.svg files
that already have a viewbox, but since icons will be cached
anyway and it's reasonably efficient, we use the simplest approach.

This is an updated version of PR #235
