### PR TITLE
Re-implement the charm-event legacy API endpoint.

### DIFF
--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -258,7 +258,7 @@ func (h *Handler) serveCharmEvent(_ http.Header, req *http.Request) (interface{}
 		// Retrieve the charm.
 		entity, err := h.store.FindEntity(id, "_id", "uploadtime", "extrainfo")
 		if err != nil {
-			if err == params.ErrNotFound {
+			if errgo.Cause(err) == params.ErrNotFound {
 				// The old API actually returned "entry not found"
 				// on *any* error, but it seems reasonable to be
 				// a little more descriptive for other errors.

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -224,6 +224,9 @@ func (h *Handler) updateEntitySHA256(curl *charm.Reference) (string, error) {
 	return sum256, nil
 }
 
+// serveCharmEvent returns events related to the charms specified in the
+// "charms" query. In this implementation, the only supported event is
+// "published", required by the "juju publish" command.
 func (h *Handler) serveCharmEvent(_ http.Header, req *http.Request) (interface{}, error) {
 	response := make(map[string]*charm.EventResponse)
 	for _, url := range req.Form["charms"] {
@@ -233,8 +236,8 @@ func (h *Handler) serveCharmEvent(_ http.Header, req *http.Request) (interface{}
 		if i := strings.Index(url, "@"); i != -1 {
 			url = url[:i]
 		}
-		// Intentionally not supporting long_keys query parameter which
-		// previous charm store supported as "juju publish" does not use it.
+		// We intentionally do not implement the long_keys query parameter that
+		// the legacy charm store supported, as "juju publish" does not use it.
 		response[url] = c
 
 		// Validate the charm URL.

--- a/params/stats.go
+++ b/params/stats.go
@@ -12,6 +12,7 @@ const (
 	// The following kinds are in use in the legacy API.
 	StatsCharmInfo    = "charm-info"
 	StatsCharmMissing = "charm-missing"
+	StatsCharmEvent   = "charm-event"
 )
 
 // Statistic holds one element of a stats/counter


### PR DESCRIPTION
Only support what strictly required by "juju publish".
This is based on Jay's work.
