### PR TITLE
Add download counts into elasticsearch

### DIFF
--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -10,7 +10,7 @@ var (
 	esMapping = mustParseJSON(esMappingJSON)
 )
 
-const esSettingsVersion = 2
+const esSettingsVersion = 3
 
 func mustParseJSON(s string) interface{} {
 	var j json.RawMessage
@@ -94,6 +94,9 @@ const esMappingJSON = `
         "index" : "not_analyzed",
         "omit_norms" : true,
         "index_options" : "docs"
+      },
+      "TotalDownloads": {
+        "type": "long"
       },
       "BlobHash" : {
         "type" : "string",

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -53,7 +53,8 @@ func (s *StoreSearchSuite) TestSuccessfulExport(c *gc.C) {
 		var actual json.RawMessage
 		err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL), &actual)
 		c.Assert(err, gc.IsNil)
-		c.Assert(string(actual), jc.JSONEquals, entity)
+		doc := SearchDoc{Entity: entity}
+		c.Assert(string(actual), jc.JSONEquals, doc)
 	}
 }
 
@@ -90,7 +91,21 @@ func (s *StoreSearchSuite) TestExportOnlyLatest(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(old.URL), &actual)
 	c.Assert(err, gc.IsNil)
-	c.Assert(string(actual), jc.JSONEquals, expected)
+	doc := SearchDoc{Entity: expected}
+	c.Assert(string(actual), jc.JSONEquals, doc)
+}
+
+func (s *StoreSearchSuite) TestExportSearchDocument(c *gc.C) {
+	var entity *mongodoc.Entity
+	var actual json.RawMessage
+	err := s.store.DB.Entities().FindId("cs:precise/wordpress-23").One(&entity)
+	c.Assert(err, gc.IsNil)
+	doc := SearchDoc{Entity: entity, TotalDownloads: 4000}
+	err = s.store.ES.update(&doc)
+	c.Assert(err, gc.IsNil)
+	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL), &actual)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(actual), jc.JSONEquals, doc)
 }
 
 func (s *StoreSearchSuite) addCharmsToStore(c *gc.C, store *Store) {

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -341,10 +341,7 @@ func (s *StoreSuite) TestAddCharmWithFailedESInsert(c *gc.C) {
 	}
 
 	store, err := NewStore(s.Session.DB("juju_test"), nil)
-	es := &storeElasticSearch{
-		SearchIndex: &SearchIndex{esdb, "no-index"},
-		DB:          store.DB,
-	}
+	es := &SearchIndex{esdb, "no-index"}
 	store.ES = es
 	c.Assert(err, gc.IsNil)
 
@@ -1268,7 +1265,7 @@ func (s *StoreSuite) TestSESPutDoesNotErrorWithNoESConfigured(c *gc.C) {
 	store, err := NewStore(s.Session.DB("mongodoctoelasticsearch"), nil)
 	c.Assert(err, gc.IsNil)
 	var entity mongodoc.Entity
-	err = store.ES.put(entity.URL)
+	err = store.UpdateSearch(entity.URL)
 	c.Assert(err, gc.IsNil)
 }
 

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -6,38 +6,14 @@ package v4
 import (
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/juju/charm.v4"
 
 	"github.com/juju/charmstore/internal/charmstore"
 	"github.com/juju/charmstore/params"
 )
-
-// entityStatsKey returns a stats key for the given charm or bundle
-// reference and the given kind.
-// Entity stats keys are generated using the following schema:
-//   kind:series:name:user:revision
-// where user can be empty (for promulgated charms/bundles) and revision is
-// optional (e.g. when uploading an entity the revision is not specified).
-// For instance, entities' stats can then be retrieved like the following:
-//   - kind:utopic:* -> all charms of a specific series;
-//   - kind:trusty:django:* -> all revisions and user variations of a charm;
-//   - kind:trusty:django::* -> all revisions of a promulgated charm;
-//   - kind:trusty:django::42 -> a specific promulgated charm;
-//   - kind:trusty:django:who:* -> all revisions of a user owned charm;
-//   - kind:trusty:django:who:42 -> a specific user owned charm;
-// The above also applies to bundles (where the series is "bundle").
-func entityStatsKey(url *charm.Reference, kind string) []string {
-	key := []string{kind, url.Series, url.Name, url.User}
-	if url.Revision != -1 {
-		key = append(key, strconv.Itoa(url.Revision))
-	}
-	return key
-}
 
 const dateFormat = "2006-01-02"
 


### PR DESCRIPTION
Total download counts are now in elasticsearch. Along with some changes to the integration that made things simpler. It will be possible to implement sorting and boosting on download counts.
