### PR TITLE
internal/v4: add debug/pprof endpoint

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -43,6 +43,7 @@ func New(store *charmstore.Store, config charmstore.ServerParams) *Handler {
 		Global: map[string]http.Handler{
 			"changes/published":  router.HandleJSON(h.serveChangesPublished),
 			"debug":              http.HandlerFunc(h.serveDebug),
+			"debug/pprof/":       newPprofHandler(h),
 			"debug/status":       router.HandleJSON(h.serveDebugStatus),
 			"log":                router.HandleErrors(h.serveLog),
 			"search":             router.HandleJSON(h.serveSearch),

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/xml"
 	"github.com/juju/testing/httptesting"
+	"github.com/juju/xml"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v4"
 

--- a/internal/v4/pprof.go
+++ b/internal/v4/pprof.go
@@ -1,0 +1,73 @@
+package v4
+
+import (
+	"net/http"
+	"net/http/pprof"
+	runtimepprof "runtime/pprof"
+	"strings"
+	"text/template"
+
+	"github.com/juju/charmstore/internal/router"
+)
+
+type pprofHandler struct {
+	mux  *http.ServeMux
+	auth authenticator
+}
+
+type authenticator interface {
+	authenticate(w http.ResponseWriter, req *http.Request) error
+}
+
+func newPprofHandler(auth authenticator) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/profile", pprof.Profile)
+	mux.HandleFunc("/symbol", pprof.Symbol)
+	mux.HandleFunc("/", pprofIndex)
+	return &pprofHandler{
+		mux:  mux,
+		auth: auth,
+	}
+}
+
+func (h *pprofHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if err := h.auth.authenticate(w, req); err != nil {
+		router.WriteError(w, err)
+		return
+	}
+	h.mux.ServeHTTP(w, req)
+}
+
+// pprofIndex is copied from pprof.Index with minor modifications
+// to make it work using a relative path.
+func pprofIndex(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == "/" {
+		profiles := runtimepprof.Profiles()
+		if err := indexTmpl.Execute(w, profiles); err != nil {
+			logger.Errorf("cannot execute pprof template: %v", err)
+		}
+		return
+	}
+	name := strings.TrimPrefix(req.URL.Path, "/")
+	pprof.Handler(name).ServeHTTP(w, req)
+}
+
+var indexTmpl = template.Must(template.New("index").Parse(`<html>
+<head>
+<title>pprof</title>
+</head>
+pprof<br>
+<br>
+<body>
+profiles:<br>
+<table>
+{{range .}}
+<tr><td align=right>{{.Count}}<td><a href="{{.Name}}?debug=1">{{.Name}}</a>
+{{end}}
+</table>
+<br>
+<a href="goroutine?debug=2">full goroutine stack dump</a><br>
+</body>
+</html>
+`))


### PR DESCRIPTION
This will make it possible to gain insight into how the server is behaving at runtime.

I've added a test for the endpoint that's most straightforward to test.
The others will need to be QA'd.

To QA, run the charmstore, then:

```
go tool pprof http://$charmstorehost/v4/debug/pprof/heap
```
