### PR TITLE
Enable legacy download counts.

### DIFF
--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -27,6 +27,17 @@ var _ = gc.Suite(&StoreSearchSuite{})
 
 func (s *StoreSearchSuite) SetUpTest(c *gc.C) {
 	s.IsolatedMgoESSuite.SetUpTest(c)
+
+	// Temporarily set LegacyDownloadCountsEnabled to false, so that the real
+	// code path can be reached by tests in this suite.
+	// TODO (frankban): remove this block when removing the legacy counts
+	// logic.
+	original := LegacyDownloadCountsEnabled
+	LegacyDownloadCountsEnabled = false
+	s.AddCleanup(func(*gc.C) {
+		LegacyDownloadCountsEnabled = original
+	})
+
 	s.index = SearchIndex{s.ES, s.TestIndex}
 	s.ES.RefreshIndex(".versions")
 	store, err := NewStore(s.Session.DB("foo"), &s.index)

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1158,6 +1158,9 @@ var _ = gc.Suite(&ArchiveSearchSuite{})
 
 func (s *ArchiveSearchSuite) SetUpTest(c *gc.C) {
 	s.IsolatedMgoESSuite.SetUpTest(c)
+	// TODO (frankban): remove this call when removing the legacy counts logic.
+	patchLegacyDownloadCountsEnabled(s.AddCleanup, false)
+
 	si := charmstore.SearchIndex{s.ES, s.TestIndex}
 	s.srv, s.store = newServer(c, s.Session, &si, serverParams)
 }

--- a/params/params.go
+++ b/params/params.go
@@ -158,8 +158,17 @@ type IdResponse struct {
 	Revision int
 }
 
-// BzrDigestKey is the extra-info key used to store the Bazaar digest
-const BzrDigestKey = "bzr-digest"
+const (
+	// BzrDigestKey is the extra-info key used to store the Bazaar digest
+	BzrDigestKey = "bzr-digest"
+
+	// LegacyDownloadStats is the extra-info key used to store the legacy
+	// download counts, and to retrieve them when
+	// charmstore.LegacyDownloadCountsEnabled is set to true.
+	// TODO (frankban): remove this constant when removing the legacy counts
+	// logic.
+	LegacyDownloadStats = "legacy-download-stats"
+)
 
 // Log holds the representation of a log message.
 // This is used by clients to store log events in the charm store.


### PR DESCRIPTION
Those values are stored in the extra-info for the entity.
This is basically a hack, and will be removed soon.
