### PR TITLE
docs: trivial changes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# Charm store API proposal
+# Charm store API
 
 ## Intro
 The charm store stores and indexes charms and bundles. A charm or bundle is referred to by a charm store id which can take one of the following two forms:


### PR DESCRIPTION
The charm store API is no longer a "proposal".
Also removed all carriage-return characters from the
ends of lines.

I'd quite like to rename the "docs" directory to "doc"
to fit in with existing Go conventions (e.g. $GOROOT/doc)
but don't want to bikeshed too much. Thoughts?
