### PR TITLE
internal/router: provide http request to meta handlers

### DIFF
--- a/internal/router/singleinclude.go
+++ b/internal/router/singleinclude.go
@@ -5,6 +5,7 @@ package router
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/url"
 
 	"gopkg.in/errgo.v1"
@@ -15,7 +16,7 @@ var _ BulkIncludeHandler = SingleIncludeHandler(nil)
 
 // SingleIncludeHandler implements BulkMetaHander for a non-batching
 // metadata retrieval function that can perform a GET only.
-type SingleIncludeHandler func(id *charm.Reference, path string, flags url.Values) (interface{}, error)
+type SingleIncludeHandler func(id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error)
 
 // Key implements BulkMetadataHander.Key.
 func (h SingleIncludeHandler) Key() interface{} {
@@ -26,11 +27,11 @@ func (h SingleIncludeHandler) Key() interface{} {
 }
 
 // HandleGet implements BulkMetadataHander.HandleGet.
-func (h SingleIncludeHandler) HandleGet(hs []BulkIncludeHandler, id *charm.Reference, paths []string, flags url.Values) ([]interface{}, error) {
+func (h SingleIncludeHandler) HandleGet(hs []BulkIncludeHandler, id *charm.Reference, paths []string, flags url.Values, req *http.Request) ([]interface{}, error) {
 	results := make([]interface{}, len(hs))
 	for i, h := range hs {
 		h := h.(SingleIncludeHandler)
-		result, err := h(id, paths[i], flags)
+		result, err := h(id, paths[i], flags, req)
 		if err != nil {
 			// TODO(rog) include index of failed handler.
 			return nil, errgo.Mask(err, errgo.Any)
@@ -43,7 +44,7 @@ func (h SingleIncludeHandler) HandleGet(hs []BulkIncludeHandler, id *charm.Refer
 var errPutNotImplemented = errgo.New("PUT not implemented")
 
 // HandlePut implements BulkMetadataHander.HandlePut.
-func (h SingleIncludeHandler) HandlePut(hs []BulkIncludeHandler, id *charm.Reference, paths []string, values []*json.RawMessage) []error {
+func (h SingleIncludeHandler) HandlePut(hs []BulkIncludeHandler, id *charm.Reference, paths []string, values []*json.RawMessage, req *http.Request) []error {
 	errs := make([]error, len(hs))
 	for i := range hs {
 		errs[i] = errPutNotImplemented

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -40,7 +40,7 @@ func (h *Handler) serveSearch(_ http.Header, req *http.Request) (interface{}, er
 	for i, ref := range results.Results {
 		i, ref := i, ref
 		run.Do(func() error {
-			meta, err := h.Router.GetMetadata(ref, sp.Include)
+			meta, err := h.Router.GetMetadata(ref, sp.Include, req)
 			if err != nil {
 				// Unfortunately it is possible to get errors here due to
 				// internal inconsistency, so rather than throwing away


### PR DESCRIPTION
We need this so that we can make permission checks in the meta query
with respect to HTTP headers.
