### PR TITLE
internal/v4: add support for storage of read ACLs

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -123,7 +123,7 @@ type BaseEntity struct {
 	// ACLs holds permission information relevant to
 	// the base entity. The permissions apply to all
 	// revisions.
-	ACLs *ACL `bson:",omitempty"`
+	ACLs ACL
 }
 
 // ACL holds lists of users and groups that are

--- a/params/params.go
+++ b/params/params.go
@@ -24,6 +24,12 @@ const (
 	EntityIdHeader = "Entity-Id"
 )
 
+// Special user/group names.
+const (
+	Everyone = "everyone"
+	Admin = "admin"
+)
+
 // MetaAnyResponse holds the result of a meta/any
 // request. See http://tinyurl.com/q5vcjpk
 type MetaAnyResponse struct {
@@ -155,6 +161,12 @@ type IdResponse struct {
 	Series   string `json:",omitempty"`
 	Name     string
 	Revision int
+}
+
+// PermResponse holds the result of an id/meta/perm GET
+// request. See tinyurl TODO.
+type PermResponse struct {
+	Read []string
 }
 
 const (


### PR DESCRIPTION
When adding a new charm, we set the read ACLs to allow everyone.
Still to do: migration and actual ACL checking.
