### PR TITLE
Support ACLs in search.

### DIFF
--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -10,7 +10,7 @@ var (
 	esMapping = mustParseJSON(esMappingJSON)
 )
 
-const esSettingsVersion = 3
+const esSettingsVersion = 4
 
 func mustParseJSON(s string) interface{} {
 	var j json.RawMessage
@@ -308,6 +308,21 @@ const esMappingJSON = `
       },
       "BundleUnitCount": {
         "type": "integer"
+      },
+      "TotalDownloads": {
+        "type": "long"
+      },
+      "Public": {
+        "type": "boolean",
+        "index" : "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+      "ReadACLs" : {
+        "type" : "string",
+        "index": "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
       }
     }
   }

--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -165,8 +165,8 @@ func populateReadACL(db StoreDatabase) error {
 	var entity mongodoc.BaseEntity
 	iter := baseEntities.Find(bson.D{{
 		"$or", []bson.D{
-			bson.D{{"acls", bson.D{{"$exists", false}}}},
-			bson.D{{"acls.read", bson.D{{"$size", 0}}}},
+			{{"acls", bson.D{{"$exists", false}}}},
+			{{"acls.read", bson.D{{"$size", 0}}}},
 		},
 	}}).Select(bson.D{{"_id", 1}}).Iter()
 


### PR DESCRIPTION
Search result will include results from charms in groups that are provided by
a valid discharged macaroon cookie.
