### PR TITLE
Add HTTP Basic Authorisation to search.

### DIFF
--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -384,6 +384,18 @@ var searchTests = []struct {
 			exportTestCharms["varnish"],
 			exportTestBundles["wordpress-simple"],
 		},
+	}, {
+		about: "admin search",
+		sp: SearchParams{
+			Admin: true,
+		},
+		results: []string{
+			exportTestCharms["riak"],
+			exportTestCharms["wordpress"],
+			exportTestCharms["mysql"],
+			exportTestCharms["varnish"],
+			exportTestBundles["wordpress-simple"],
+		},
 	},
 }
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -23,6 +23,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v4"
+	"gopkg.in/macaroon-bakery.v0/bakery"
 	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v0/bakerytest"
 	"gopkg.in/macaroon-bakery.v0/httpbakery"
@@ -78,7 +79,7 @@ func (s *APISuite) SetUpTest(c *gc.C) {
 
 func newServer(c *gc.C, session *mgo.Session, si *charmstore.SearchIndex, config charmstore.ServerParams) (http.Handler, *charmstore.Store) {
 	db := session.DB("charmstore")
-	store, err := charmstore.NewStore(db, si, nil)
+	store, err := charmstore.NewStore(db, si, &bakery.NewServiceParams{})
 	c.Assert(err, gc.IsNil)
 	srv, err := charmstore.NewServer(db, si, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
If a search call is performed with valid Basic Authorisation credentials then
the search will be in admin mode and will not check ACLs.
