### PR TITLE
internal/v4: cookies for all!

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -17,7 +17,7 @@ golang.org/x/crypto	git	4ed45ec682102c643324fae5dff8dab085b6c300	2015-01-12T22:0
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
 gopkg.in/juju/charm.v4	git	7ef31c485ccfd7f1f9571d42ef4395bd04dc1006	2014-11-17T17:46:04Z
-gopkg.in/macaroon-bakery.v0	git	79e18c4d0c712f04b517425bddb64490d4ca60c8	2015-01-26T16:07:15Z
+gopkg.in/macaroon-bakery.v0	git	4c0e0fae424e8d1bc71c0b0caca3cd2c32381dca	2015-01-27T17:01:29Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	c6a7dce14133ccac2dcac3793f1d6e2ef048503a	2015-01-24T11:37:54Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -75,7 +75,11 @@ func (h *Handler) authorize(req *http.Request, acl []string) error {
 	if err != nil {
 		return errgo.Notef(err, "cannot mint macaroon")
 	}
-	return httpbakery.NewDischargeRequiredError(m, verr)
+	// Request that this macaroon be supplied for all requests
+	// to the whole handler.
+	// TODO use a relative URL here: router.RelativeURLPath(req.RequestURI, "/")
+	cookiePath := "/"
+	return httpbakery.NewDischargeRequiredError(m, cookiePath, verr)
 }
 
 func (h *Handler) authorizeEntity(id *charm.Reference, req *http.Request) error {


### PR DESCRIPTION
Previously, macaroon cookies would be stored only for the
URL they were originally issued for. This change asks
the client to make the macaroons available for all URLs
in the charm store.
