### PR TITLE
Introduce write ACL for entities.

### DIFF
--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -236,8 +236,10 @@ var everyonePerm = []string{params.Everyone}
 
 func (s *Store) insertEntity(entity *mongodoc.Entity) (err error) {
 	readPerm := everyonePerm
+	var writePerm []string
 	if entity.User != "" {
 		readPerm = []string{params.Everyone, entity.User}
+		writePerm = []string{entity.User}
 	}
 	// Add the base entity to the database.
 	baseEntity := &mongodoc.BaseEntity{
@@ -247,7 +249,8 @@ func (s *Store) insertEntity(entity *mongodoc.Entity) (err error) {
 		// TODO frankban: allow specifying non-public charms on initial upload.
 		Public: true,
 		ACLs: mongodoc.ACL{
-			Read: readPerm,
+			Read:  readPerm,
+			Write: writePerm,
 		},
 	}
 	err = s.DB.BaseEntities().Insert(baseEntity)

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -201,10 +201,12 @@ func assertBaseEntity(c *gc.C, store *Store, url *charm.Reference) {
 	baseEntity, err := store.FindBaseEntity(url)
 	c.Assert(err, gc.IsNil)
 	expectACLs := mongodoc.ACL{
-		Read: []string{params.Everyone},
+		Read:  []string{params.Everyone},
+		Write: []string{},
 	}
 	if url.User != "" {
 		expectACLs.Read = append(expectACLs.Read, url.User)
+		expectACLs.Write = append(expectACLs.Write, url.User)
 	}
 	c.Assert(baseEntity, jc.DeepEquals, &mongodoc.BaseEntity{
 		URL:    url,
@@ -393,7 +395,8 @@ var findBaseEntityTests = []struct {
 	expect: &mongodoc.BaseEntity{
 		URL: charm.MustParseReference("~who/django"),
 		ACLs: mongodoc.ACL{
-			Read: []string{"everyone", "who"},
+			Read:  []string{"everyone", "who"},
+			Write: []string{"who"},
 		},
 	},
 }, {

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -132,6 +132,9 @@ type ACL struct {
 	// Read holds users and groups that are allowed to read the charm
 	// or bundle.
 	Read []string
+	// Write holds users and groups that are allowed to upload/modify the charm
+	// or bundle.
+	Write []string
 }
 
 type FileId string

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -659,7 +659,8 @@ func checkExtraInfoKey(key string) error {
 
 func (h *Handler) metaPerm(entity *mongodoc.BaseEntity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return params.PermResponse{
-		Read: entity.ACLs.Read,
+		Read:  entity.ACLs.Read,
+		Write: entity.ACLs.Write,
 	}, nil
 }
 
@@ -667,6 +668,8 @@ func (h *Handler) metaPermWithKey(entity *mongodoc.BaseEntity, id *charm.Referen
 	switch path {
 	case "/read":
 		return entity.ACLs.Read, nil
+	case "/write":
+		return entity.ACLs.Write, nil
 	}
 	return nil, errgo.WithCausef(nil, params.ErrNotFound, "unknown permission")
 }
@@ -687,6 +690,9 @@ func (h *Handler) putMetaPermWithKey(id *charm.Reference, path string, val *json
 		updater.UpdateField("acls.read", perms)
 		updater.UpdateField("public", isPublic)
 		updater.UpdateSearch()
+		return nil
+	case "/write":
+		updater.UpdateField("acls.write", perms)
 		return nil
 	}
 	return errgo.WithCausef(nil, params.ErrNotFound, "unknown permission")

--- a/params/params.go
+++ b/params/params.go
@@ -166,7 +166,8 @@ type IdResponse struct {
 // PermResponse holds the result of an id/meta/perm GET
 // request. See tinyurl TODO.
 type PermResponse struct {
-	Read []string
+	Read  []string
+	Write []string
 }
 
 const (


### PR DESCRIPTION
An entity can be written only by the user/group who
uploaded it.

Write the corresponding database migration.

Also update the meta/perm API endpoints accordingly.
