### PR TITLE
use juju/httpprof

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -5,6 +5,7 @@ github.com/juju/errors	git	c3aaee403f140e8ab35eca129eb0a514bed780eb	2015-01-08T0
 github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	2014-07-18T03:59:30Z
 github.com/juju/gojsonreference	git	0673d58f64bacac2db34c7d1e87a599d58923981	2014-07-18T03:57:39Z
 github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098	2014-07-17T16:12:25Z
+github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/jujusvg	git	0390bca3e396d087ef3a26c0d4a00887e8e5c525	2015-01-14T18:27:48Z
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
 github.com/juju/names	git	e7394f4ce9389fb57cfb7cbe9fa30790d01a8875	2014-12-17T04:05:00Z

--- a/internal/v4/pprof.go
+++ b/internal/v4/pprof.go
@@ -2,10 +2,11 @@ package v4
 
 import (
 	"net/http"
-	"net/http/pprof"
 	runtimepprof "runtime/pprof"
 	"strings"
 	"text/template"
+
+	"github.com/juju/httpprof"
 
 	"github.com/juju/charmstore/internal/router"
 )


### PR DESCRIPTION
It turns out that any binary which imports both net/http/pprof and github.com/juju/httpprof will panic when running because their init() functions both register the same http.Handle paths. There can be only one, and the one is juju/httpprof.
