### PR TITLE
Use the default store URL if none is provided.

### DIFF
--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"unicode"
@@ -25,20 +24,14 @@ import (
 	"github.com/juju/charmstore/params"
 )
 
-const (
-	apiVersion = "v4"
+const apiVersion = "v4"
 
-	// JujuCharmstoreEnvVar holds the name of the environment variable used
-	// to override the default charm store URL.
-	JujuCharmstoreEnvVar = "JUJU_CHARMSTORE"
-)
-
-// serverURL holds the default location of the global charm store.
+// ServerURL holds the default location of the global charm store.
 // An alternate location can be configured by changing the URL field in the
-// Params struct or by setting the JujuCharmstoreEnvVar environment variable.
+// Params struct.
 // For live testing or QAing the application, a different charm store
 // location should be used, for instance "https://api.staging.jujucharms.com".
-var serverURL = "https://api.jujucharms.com/charmstore"
+var ServerURL = "https://api.jujucharms.com/charmstore"
 
 // Client represents the client side of a charm store.
 type Client struct {
@@ -73,7 +66,7 @@ type Params struct {
 // New returns a new charm store client.
 func New(p Params) *Client {
 	if p.URL == "" {
-		p.URL = ServerURL()
+		p.URL = ServerURL
 	}
 	if p.VisitWebPage == nil {
 		p.VisitWebPage = noVisit
@@ -84,16 +77,6 @@ func New(p Params) *Client {
 	return &Client{
 		params: p,
 	}
-}
-
-// GetServerURL returns the charm store server URL.
-// The returned value can be overridden by setting the JujuCharmstoreEnvVar
-// environment variable.
-func ServerURL() string {
-	if url := os.Getenv(JujuCharmstoreEnvVar); url != "" {
-		return url
-	}
-	return serverURL
 }
 
 func noVisit(url *url.URL) error {

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -94,16 +94,6 @@ func (s *suite) TearDownTest(c *gc.C) {
 	s.IsolatedMgoSuite.TearDownTest(c)
 }
 
-func (s *suite) TestServerURL(c *gc.C) {
-	// The default server URL is returned.
-	c.Assert(csclient.ServerURL(), gc.Equals, *csclient.DefaultServerURL)
-
-	// It is possible to override the default value with the JUJU_CHARMSTORE
-	// environment variable.
-	s.PatchEnvironment(csclient.JujuCharmstoreEnvVar, "https://1.2.3.4")
-	c.Assert(csclient.ServerURL(), gc.Equals, "https://1.2.3.4")
-}
-
 func (s *suite) TestDefaultServerURL(c *gc.C) {
 	// Add a charm used for tests.
 	err := s.store.AddCharmWithArchive(
@@ -112,37 +102,13 @@ func (s *suite) TestDefaultServerURL(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Patch the default server URL.
-	s.PatchValue(csclient.DefaultServerURL, s.srv.URL)
+	s.PatchValue(&csclient.ServerURL, s.srv.URL)
 
 	// Instantiate a client using the default server URL.
 	client := csclient.New(csclient.Params{})
 	c.Assert(client.ServerURL(), gc.Equals, s.srv.URL)
 
 	// Check that the request succeeds.
-	err = client.Get("/vivid/testing-wordpress-42/expand-id", nil)
-	c.Assert(err, gc.IsNil)
-}
-
-func (s *suite) TestServerURLFromEnvVar(c *gc.C) {
-	// Add a charm used for tests.
-	err := s.store.AddCharmWithArchive(
-		charm.MustParseReference("vivid/testing-wordpress-42"),
-		storetesting.Charms.CharmDir("wordpress"))
-	c.Assert(err, gc.IsNil)
-
-	// Point the default server URL to an invalid URL.
-	s.PatchValue(csclient.DefaultServerURL, "invalid-url")
-
-	// Check that the request returns an error.
-	client := csclient.New(csclient.Params{})
-	c.Assert(client.ServerURL(), gc.Equals, "invalid-url")
-	err = client.Get("/vivid/testing-wordpress-42/expand-id", nil)
-	c.Assert(err, gc.ErrorMatches, "Get invalid-url/v4/vivid/testing-wordpress-42/expand-id: .*")
-
-	// After setting the JUJU_CHARMSTORE variable, the call succeeds.
-	s.PatchEnvironment(csclient.JujuCharmstoreEnvVar, s.srv.URL)
-	client = csclient.New(csclient.Params{})
-	c.Assert(client.ServerURL(), gc.Equals, s.srv.URL)
 	err = client.Get("/vivid/testing-wordpress-42/expand-id", nil)
 	c.Assert(err, gc.IsNil)
 }

--- a/csclient/export_test.go
+++ b/csclient/export_test.go
@@ -4,7 +4,6 @@
 package csclient
 
 var (
-	Hyphenate        = hyphenate
-	UploadArchive    = (*Client).uploadArchive
-	DefaultServerURL = &serverURL
+	Hyphenate     = hyphenate
+	UploadArchive = (*Client).uploadArchive
 )

--- a/csclient/export_test.go
+++ b/csclient/export_test.go
@@ -4,6 +4,7 @@
 package csclient
 
 var (
-	Hyphenate     = hyphenate
-	UploadArchive = (*Client).uploadArchive
+	Hyphenate        = hyphenate
+	UploadArchive    = (*Client).uploadArchive
+	DefaultServerURL = &serverURL
 )


### PR DESCRIPTION
When calling New without passing the URL param, the global charm store is used.
Add the possibility to override this value by setting the JUJU_CHARMSTORE env var.
