### PR TITLE
Update endpoints' docstrings to point to the API doc in th repo.

### DIFF
--- a/csclient/csclient.go
+++ b/csclient/csclient.go
@@ -221,7 +221,8 @@ func (c *Client) PutExtraInfo(id *charm.Reference, info map[string]interface{}) 
 // given id. The result value provides a value
 // to be filled in with the result, which must be
 // a pointer to a struct containing members corresponding
-// to possible metadata include parameters (see http://tinyurl.com/nysdjly).
+// to possible metadata include parameters
+// (see https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmeta).
 //
 // It returns the fully qualified id of the entity.
 //
@@ -305,7 +306,7 @@ func (c *Client) Meta(id *charm.Reference, result interface{}) (*charm.Reference
 	// Note that the server is not required to send back values
 	// for all fields. "If there is no metadata for the given meta path, the
 	// element will be omitted"
-	// See http://tinyurl.com/q5vcjpk
+	// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaany
 	for name, r := range rawResult.Meta {
 		v, ok := results[name]
 		if !ok {

--- a/docs/API.md
+++ b/docs/API.md
@@ -410,12 +410,12 @@ Example: `GET /meta/any?include=archive-size&include=extra-info/featured&id=word
 #### PUT meta/*endpoint*
 
 A PUT to this endpoint allows the metadata endpoint of several ids to be
-updated. The body is as specified in the result of the above GET request. The
-ids in the body specify the ids that will be updated. If there is a failure,
-the error code will be "multiple errors", and the Info field will holds one
-entry for each id in the request body that failed, holding the error for that
-id. If there are no errors, PUT endpoints usually return an empty body in the
-response.
+updated. The request body is as specified in the result of the above GET
+request. The ids in the body specify the ids that will be updated. If there is
+a failure, the error code will be "multiple errors", and the Info field will
+holds one entry for each id in the request body that failed, holding the error
+for that id. If there are no errors, PUT endpoints usually return an empty body
+in the response.
 
 Example: `PUT meta/extra-info/featured`
 
@@ -467,6 +467,9 @@ Response body (with HTTP status 500):
     }
 }
 ```
+
+If the request succeeds, a 200 OK status code is returned with an empty
+response body.
 
 #### GET *id*/meta
 

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -499,13 +499,14 @@ func createSearchDSL(sp SearchParams) elasticsearch.QueryDSL {
 	return qdsl
 }
 
-// createFilters converts the filters requested with the serch API into
-// filters in the elasticsearch query DSL. Please see http://tinyurl.com/qzobc69
-// for details of how filters are specified in the API. For each key in f a filter is
-// created that matches any one of the set of values specified for that key.
-// The created filter will only match when at least one of the requested values
-// matches for all of the requested keys. Any filter names that are not defined
-// in the filters map will be silently skipped.
+// createFilters converts the filters requested with the search API into
+// filters in the elasticsearch query DSL.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-search
+// for details of how filters are specified in the API. For each key in f a
+// filter is created that matches any one of the set of values specified for
+// that key. The created filter will only match when at least one of the
+// requested values matches for all of the requested keys. Any filter names
+// that are not defined in the filters map will be silently skipped.
 func createFilters(f map[string][]string, admin bool, groups []string) elasticsearch.Filter {
 	af := make(elasticsearch.AndFilter, 0, len(f)+1)
 	for k, vals := range f {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -304,12 +304,12 @@ func (r *Router) serveMetaGet(id *charm.Reference, req *http.Request) (interface
 	key, path := handlerKey(req.URL.Path)
 	if key == "" {
 		// GET id/meta
-		// http://tinyurl.com/nysdjly
+		// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmeta
 		return r.metaNames(), nil
 	}
 	if key == "any" {
 		// GET id/meta/any?[include=meta[&include=meta...]]
-		// http://tinyurl.com/q5vcjpk
+		// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaany
 		includes := req.Form["include"]
 		// If there are no includes, we have no handlers to generate
 		// a "not found" error when the id doesn't exist, so we need
@@ -449,7 +449,7 @@ func (r *Router) serveBulkMeta(w http.ResponseWriter, req *http.Request) error {
 	switch req.Method {
 	case "GET", "HEAD":
 		// A bare meta returns all endpoints.
-		// See http://tinyurl.com/q2qd9nn
+		// See https://github.com/juju/charmstore/blob/v4/docs/API.md#bulk-requests-and-missing-metadata
 		if req.URL.Path == "/" || req.URL.Path == "" {
 			jsonhttp.WriteJSON(w, http.StatusOK, r.metaNames())
 			return nil
@@ -471,7 +471,7 @@ func (r *Router) serveBulkMeta(w http.ResponseWriter, req *http.Request) error {
 // that can return information on several ids at once.
 //
 // GET meta/$endpoint?id=$id0[&id=$id1...][$otherflags]
-// http://tinyurl.com/kdrly9f
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-metaendpoint
 func (r *Router) serveBulkMetaGet(req *http.Request) (interface{}, error) {
 	// TODO get the metadata concurrently for each id.
 	ids := req.Form["id"]
@@ -488,7 +488,7 @@ func (r *Router) serveBulkMetaGet(req *http.Request) (interface{}, error) {
 		if err := r.resolveURL(url); err != nil {
 			if errgo.Cause(err) == params.ErrNotFound {
 				// URLs not found will be omitted from the result.
-				// http://tinyurl.com/o5ptfkk
+				// https://github.com/juju/charmstore/blob/v4/docs/API.md#bulk-requests-and-missing-metadata
 				continue
 			}
 			// Note: preserve error cause from resolveURL.
@@ -497,7 +497,7 @@ func (r *Router) serveBulkMetaGet(req *http.Request) (interface{}, error) {
 		meta, err := r.serveMetaGet(url, req)
 		if cause := errgo.Cause(err); cause == params.ErrNotFound || cause == params.ErrMetadataNotFound {
 			// The relevant data does not exist.
-			// http://tinyurl.com/o5ptfkk
+			// https://github.com/juju/charmstore/blob/v4/docs/API.md#bulk-requests-and-missing-metadata
 			continue
 		}
 		if err != nil {
@@ -510,7 +510,7 @@ func (r *Router) serveBulkMetaGet(req *http.Request) (interface{}, error) {
 
 // serveBulkMetaPut serves a bulk PUT request to several ids.
 // PUT /meta/$endpoint
-// http://tinyurl.com/na83nta
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#put-metaendpoint
 func (r *Router) serveBulkMetaPut(req *http.Request) error {
 	if len(req.Form["id"]) > 0 {
 		return fmt.Errorf("ids may not be specified in meta PUT request")
@@ -615,7 +615,7 @@ func (r *Router) GetMetadata(id *charm.Reference, includes []string, req *http.R
 				// Omit nil results from map. Note: omit statically typed
 				// nil results too to make it easy for handlers to return
 				// possibly nil data with a static type.
-				// http://tinyurl.com/o5ptfkk
+				// https://github.com/juju/charmstore/blob/v4/docs/API.md#bulk-requests-and-missing-metadata
 				if !isNull(result) {
 					results[groupIncludes[i]] = result
 				}

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -343,19 +343,19 @@ func parseBool(value string) (bool, error) {
 var errNotImplemented = errgo.Newf("method not implemented")
 
 // GET /debug
-// http://tinyurl.com/m63xhz8
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-debug
 func (h *Handler) serveDebug(w http.ResponseWriter, req *http.Request) {
 	router.WriteError(w, errNotImplemented)
 }
 
 // POST id/resources/name.stream
-// http://tinyurl.com/pnmwvy4
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#post-idresourcesnamestream
 //
 // GET  id/resources/name.stream[-revision]/arch/filename
-// http://tinyurl.com/pydbn3u
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idresourcesnamestream-revisionarchfilename
 //
 // PUT id/resources/[~user/]series/name.stream-revision/arch?sha256=hash
-// http://tinyurl.com/k8l8kdg
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#put-idresourcesuserseriesnamestream-revisionarchsha256hash
 func (h *Handler) serveResources(charmId *charm.Reference, _ bool, w http.ResponseWriter, req *http.Request) error {
 	return errNotImplemented
 }
@@ -397,25 +397,25 @@ func badRequestf(underlying error, f string, a ...interface{}) error {
 }
 
 // GET id/meta/charm-metadata
-// http://tinyurl.com/poeoulw
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetacharm-metadata
 func (h *Handler) metaCharmMetadata(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return entity.CharmMeta, nil
 }
 
 // GET id/meta/bundle-metadata
-// http://tinyurl.com/ozshbtb
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetabundle-metadata
 func (h *Handler) metaBundleMetadata(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return entity.BundleData, nil
 }
 
 // GET id/meta/bundle-unit-count
-// http://tinyurl.com/mkvowub
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetabundle-unit-count
 func (h *Handler) metaBundleUnitCount(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return bundleCount(entity.BundleUnitCount), nil
 }
 
 // GET id/meta/bundle-machine-count
-// http://tinyurl.com/qfuubrv
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetabundle-machine-count
 func (h *Handler) metaBundleMachineCount(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return bundleCount(entity.BundleMachineCount), nil
 }
@@ -430,7 +430,7 @@ func bundleCount(x *int) interface{} {
 }
 
 // GET id/meta/manifest
-// http://tinyurl.com/p3xdcto
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetamanifest
 func (h *Handler) metaManifest(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	r, size, err := h.store.BlobStore.Open(entity.BlobName)
 	if err != nil {
@@ -457,25 +457,24 @@ func (h *Handler) metaManifest(entity *mongodoc.Entity, id *charm.Reference, pat
 }
 
 // GET id/meta/charm-actions
-// http://tinyurl.com/kfd2h34
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetacharm-actions
 func (h *Handler) metaCharmActions(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return entity.CharmActions, nil
 }
 
 // GET id/meta/charm-config
-// http://tinyurl.com/oxxyujx
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetacharm-config
 func (h *Handler) metaCharmConfig(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return entity.CharmConfig, nil
 }
 
 // GET id/meta/color
-// http://tinyurl.com/o2t3j4p
 func (h *Handler) metaColor(id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return nil, errNotImplemented
 }
 
 // GET id/meta/archive-size
-// http://tinyurl.com/m8b9geq
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaarchive-size
 func (h *Handler) metaArchiveSize(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return &params.ArchiveSizeResponse{
 		Size: entity.Size,
@@ -483,7 +482,7 @@ func (h *Handler) metaArchiveSize(entity *mongodoc.Entity, id *charm.Reference, 
 }
 
 // GET id/meta/tags
-// http://tinyurl.com/njyqwj2
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetatags
 func (h *Handler) metaTags(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	var tags []string
 	switch {
@@ -501,7 +500,7 @@ func (h *Handler) metaTags(entity *mongodoc.Entity, id *charm.Reference, path st
 }
 
 // GET id/meta/stats/
-// http://tinyurl.com/lvyp2l5
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetastats
 func (h *Handler) metaStats(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	// Retrieve the aggregated downloads count for the specific revision.
 	counts, countsAllRevisions, err := h.store.ArchiveDownloadCounts(id)
@@ -527,7 +526,7 @@ func (h *Handler) metaStats(entity *mongodoc.Entity, id *charm.Reference, path s
 }
 
 // GET id/meta/revision-info
-// http://tinyurl.com/q6xos7f
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetarevision-info
 func (h *Handler) metaRevisionInfo(id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	baseURL := *id
 	baseURL.Revision = -1
@@ -556,7 +555,7 @@ func (h *Handler) metaRevisionInfo(id *charm.Reference, path string, flags url.V
 }
 
 // GET id/meta/id-user
-// http://tinyurl.com/o7xmhz2
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid-user
 func (h *Handler) metaIdUser(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return params.IdUserResponse{
 		User: id.User,
@@ -564,15 +563,15 @@ func (h *Handler) metaIdUser(entity *mongodoc.Entity, id *charm.Reference, path 
 }
 
 // GET id/meta/id-series
-// http://tinyurl.com/pnwmr6j
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid-series
 func (h *Handler) metaIdSeries(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return params.IdSeriesResponse{
 		Series: id.Series,
 	}, nil
 }
 
-// GET id/meta/id-name
-// http://tinyurl.com/lnqwbsp
+// GET id/meta/id
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid
 func (h *Handler) metaId(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return params.IdResponse{
 		Id:       id,
@@ -584,7 +583,7 @@ func (h *Handler) metaId(entity *mongodoc.Entity, id *charm.Reference, path stri
 }
 
 // GET id/meta/id-name
-// http://tinyurl.com/m5q8gcy
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid-name
 func (h *Handler) metaIdName(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return params.IdNameResponse{
 		Name: id.Name,
@@ -592,7 +591,7 @@ func (h *Handler) metaIdName(entity *mongodoc.Entity, id *charm.Reference, path 
 }
 
 // GET id/meta/id-revision
-// http://tinyurl.com/ntd3coz
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid-revision
 func (h *Handler) metaIdRevision(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return params.IdRevisionResponse{
 		Revision: id.Revision,
@@ -600,7 +599,7 @@ func (h *Handler) metaIdRevision(entity *mongodoc.Entity, id *charm.Reference, p
 }
 
 // GET id/meta/extra-info
-// http://tinyurl.com/keos7wd
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaextra-info
 func (h *Handler) metaExtraInfo(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	// The extra-info is stored in mongo as simple byte
 	// slices, so convert the values to json.RawMessages
@@ -614,7 +613,7 @@ func (h *Handler) metaExtraInfo(entity *mongodoc.Entity, id *charm.Reference, pa
 }
 
 // GET id/meta/extra-info/key
-// http://tinyurl.com/polrbn7
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaextra-infokey
 func (h *Handler) metaExtraInfoWithKey(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	path = strings.TrimPrefix(path, "/")
 	var data json.RawMessage = entity.ExtraInfo[path]
@@ -624,6 +623,8 @@ func (h *Handler) metaExtraInfoWithKey(entity *mongodoc.Entity, id *charm.Refere
 	return &data, nil
 }
 
+// PUT id/meta/extra-info
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#put-idmetaextra-info
 func (h *Handler) putMetaExtraInfo(id *charm.Reference, path string, val *json.RawMessage, updater *router.FieldUpdater, req *http.Request) error {
 	var fields map[string]*json.RawMessage
 	if err := json.Unmarshal(*val, &fields); err != nil {
@@ -641,6 +642,8 @@ func (h *Handler) putMetaExtraInfo(id *charm.Reference, path string, val *json.R
 	return nil
 }
 
+// PUT id/meta/extra-info/key
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#put-idmetaextra-infokey
 func (h *Handler) putMetaExtraInfoWithKey(id *charm.Reference, path string, val *json.RawMessage, updater *router.FieldUpdater, req *http.Request) error {
 	key := strings.TrimPrefix(path, "/")
 	if err := checkExtraInfoKey(key); err != nil {
@@ -657,6 +660,8 @@ func checkExtraInfoKey(key string) error {
 	return nil
 }
 
+// GET id/meta/perm
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaperm
 func (h *Handler) metaPerm(entity *mongodoc.BaseEntity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return params.PermResponse{
 		Read:  entity.ACLs.Read,
@@ -664,6 +669,8 @@ func (h *Handler) metaPerm(entity *mongodoc.BaseEntity, id *charm.Reference, pat
 	}, nil
 }
 
+// GET id/meta/perm/key
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetapermkey
 func (h *Handler) metaPermWithKey(entity *mongodoc.BaseEntity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	switch path {
 	case "/read":
@@ -674,6 +681,8 @@ func (h *Handler) metaPermWithKey(entity *mongodoc.BaseEntity, id *charm.Referen
 	return nil, errgo.WithCausef(nil, params.ErrNotFound, "unknown permission")
 }
 
+// PUT id/meta/perm/key
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#put-idmetapermkey
 func (h *Handler) putMetaPermWithKey(id *charm.Reference, path string, val *json.RawMessage, updater *router.FieldUpdater, req *http.Request) error {
 	var perms []string
 	if err := json.Unmarshal(*val, &perms); err != nil {
@@ -699,7 +708,7 @@ func (h *Handler) putMetaPermWithKey(id *charm.Reference, path string, val *json
 }
 
 // GET id/meta/archive-upload-time
-// http://tinyurl.com/nmujuqk
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaarchive-upload-time
 func (h *Handler) metaArchiveUploadTime(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return &params.ArchiveUploadTimeResponse{
 		UploadTime: entity.UploadTime.UTC(),
@@ -712,7 +721,7 @@ type PublishedResponse struct {
 }
 
 // GET changes/published[?limit=$count][&from=$fromdate][&to=$todate]
-// http://tinyurl.com/qx5zdee
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-changespublished
 func (h *Handler) serveChangesPublished(_ http.Header, r *http.Request) (interface{}, error) {
 	start, stop, err := parseDateRange(r.Form)
 	if err != nil {
@@ -762,6 +771,8 @@ func (h *Handler) serveChangesPublished(_ http.Header, r *http.Request) (interfa
 	return results, nil
 }
 
+// GET /macaroon
+// TODO: document macaroon endpoint in the API doc.
 func (h *Handler) serveMacaroon(_ http.Header, _ *http.Request) (interface{}, error) {
 	return h.newMacaroon()
 }

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -28,13 +28,13 @@ import (
 )
 
 // GET id/archive
-// http://tinyurl.com/qjrwq53
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idarchive
 //
 // POST id/archive?hash=sha384hash
-// http://tinyurl.com/lzrzrgb
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#post-idarchive
 //
 // DELETE id/archive
-// http://tinyurl.com/ojmlwos
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#delete-idarchive
 //
 // PUT id/archive?hash=sha384hash
 // This is like POST except that it puts the archive to a known revision
@@ -290,8 +290,8 @@ func verifyConstraints(s string) error {
 	return nil
 }
 
-// GET id/archive/…
-// http://tinyurl.com/lampm24
+// GET id/archive/path
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idarchivepath
 func (h *Handler) serveArchiveFile(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
 	r, size, _, err := h.store.OpenBlob(id)
 	if err != nil {

--- a/internal/v4/content.go
+++ b/internal/v4/content.go
@@ -22,7 +22,7 @@ import (
 )
 
 // GET id/diagram.svg
-// http://tinyurl.com/nqjvxov
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-iddiagramsvg
 func (h *Handler) serveDiagram(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
 	if id.Series != "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "diagrams not supported for charms")
@@ -68,7 +68,7 @@ var allowedReadMe = map[string]bool{
 }
 
 // GET id/readme
-// http://tinyurl.com/kygyvot
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idreadme
 func (h *Handler) serveReadMe(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
 	entity, err := h.store.FindEntity(id, "_id", "contents", "blobname")
 	if err != nil {
@@ -91,7 +91,7 @@ func (h *Handler) serveReadMe(id *charm.Reference, fullySpecified bool, w http.R
 }
 
 // GET id/icon.svg
-// http://tinyurl.com/lhodocb
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idiconsvg
 func (h *Handler) serveIcon(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
 	if id.Series == "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "icons not supported for bundles")

--- a/internal/v4/log.go
+++ b/internal/v4/log.go
@@ -18,10 +18,10 @@ import (
 )
 
 // GET /log
-// http://tinyurl.com/nj77rcr
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-log
 //
 // POST /log
-// http://tinyurl.com/o27hqxe
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#post-log
 func (h *Handler) serveLog(w http.ResponseWriter, req *http.Request) error {
 	if err := h.authorize(req, nil); err != nil {
 		return err

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GET id/meta/charm-related[?include=meta[&include=meta…]]
-// http://tinyurl.com/q7vdmzl
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetacharm-related
 func (h *Handler) metaCharmRelated(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	if id.Series == "bundle" {
 		return nil, nil
@@ -145,7 +145,7 @@ func (h *Handler) getRelatedIfaceResponses(
 }
 
 // GET id/meta/bundles-containing[?include=meta[&include=meta…]][&any-series=1][&any-revision=1][&all-results=1]
-// http://tinyurl.com/oqc386r
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetabundles-containing
 func (h *Handler) metaBundlesContaining(entity *mongodoc.Entity, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	if id.Series == "bundle" {
 		return nil, nil

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -19,7 +19,7 @@ import (
 const maxConcurrency = 20
 
 // GET search[?text=text][&autocomplete=1][&filter=value…][&limit=limit][&include=meta][&skip=count][&sort=field[+dir]]
-// http://tinyurl.com/qzobc69
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-search
 func (h *Handler) serveSearch(_ http.Header, req *http.Request) (interface{}, error) {
 	sp, err := parseSearchParams(req)
 	if err != nil {
@@ -85,7 +85,7 @@ func (h *Handler) serveSearch(_ http.Header, req *http.Request) (interface{}, er
 }
 
 // GET search/interesting[?limit=limit][&include=meta]
-// http://tinyurl.com/ntmdrg8
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-searchinteresting
 func (h *Handler) serveSearchInteresting(w http.ResponseWriter, req *http.Request) {
 	router.WriteError(w, errNotImplemented)
 }

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -40,7 +40,7 @@ func parseDateRange(form url.Values) (start, stop time.Time, err error) {
 }
 
 // GET stats/counter/key[:key]...?[by=unit]&start=date][&stop=date][&list=1]
-// http://tinyurl.com/nkdovcf
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-statscounter
 func (h *Handler) serveStatsCounter(_ http.Header, r *http.Request) (interface{}, error) {
 	base := strings.TrimPrefix(r.URL.Path, "/")
 	if strings.Index(base, "/") > 0 {

--- a/internal/v4/status.go
+++ b/internal/v4/status.go
@@ -19,7 +19,7 @@ import (
 )
 
 // GET /debug/status
-// http://tinyurl.com/qdm5yg7
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-debugstatus
 func (h *Handler) serveDebugStatus(_ http.Header, req *http.Request) (interface{}, error) {
 	return debugstatus.Check(
 		debugstatus.ServerStartTime,

--- a/params/error.go
+++ b/params/error.go
@@ -36,9 +36,8 @@ const (
 	// which needs to share the message too.
 )
 
-// Error represents an error - it is returned for any response
-// that fails.
-// See http://tinyurl.com/knr3csp .
+// Error represents an error - it is returned for any response that fails.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#errors
 type Error struct {
 	Message string
 	Code    ErrorCode

--- a/params/params.go
+++ b/params/params.go
@@ -30,15 +30,15 @@ const (
 	Admin    = "admin"
 )
 
-// MetaAnyResponse holds the result of a meta/any
-// request. See http://tinyurl.com/q5vcjpk
+// MetaAnyResponse holds the result of a meta/any request.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaany
 type MetaAnyResponse struct {
 	Id   *charm.Reference
 	Meta map[string]interface{} `json:",omitempty"`
 }
 
-// ArchiveUploadResponse holds the result of
-// a post or a put to /$id/archive. See http://tinyurl.com/lzrzrgb
+// ArchiveUploadResponse holds the result of a post or a put to /id/archive.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#post-idarchive
 type ArchiveUploadResponse struct {
 	Id *charm.Reference
 }
@@ -51,27 +51,29 @@ type ExpandedId struct {
 }
 
 // ArchiveSizeResponse holds the result of an
-// id/meta/archive-size GET request. See http://tinyurl.com/m8b9geq
+// id/meta/archive-size GET request.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaarchive-size
 type ArchiveSizeResponse struct {
 	Size int64
 }
 
 // ManifestFile holds information about a charm or bundle file.
 // A slice of ManifestFile is used as response for
-// id/meta/manifest GET requests. See http://tinyurl.com/p3xdcto
+// id/meta/manifest GET requests.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetamanifest
 type ManifestFile struct {
 	Name string
 	Size int64
 }
 
-// ArchiveUploadTimeResponse holds the result of an
-// id/meta/archive-upload-time GET request. See http://tinyurl.com/nmujuqk
+// ArchiveUploadTimeResponse holds the result of an id/meta/archive-upload-time
+// GET request. See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaarchive-upload-time
 type ArchiveUploadTimeResponse struct {
 	UploadTime time.Time
 }
 
-// RelatedResponse holds the result of an
-// id/meta/charm-related GET request. See http://tinyurl.com/q7vdmzl
+// RelatedResponse holds the result of an id/meta/charm-related GET request.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetacharm-related
 type RelatedResponse struct {
 	// Requires holds an entry for each interface provided by
 	// the charm, containing all charms that require that interface.
@@ -82,25 +84,28 @@ type RelatedResponse struct {
 	Provides map[string][]MetaAnyResponse `json:",omitempty"`
 }
 
-// RevisionInfoResponse holds the result of an
-// id/meta/revision-info GET request. See http://tinyurl.com/q6xos7f
+// RevisionInfoResponse holds the result of an id/meta/revision-info GET
+// request. See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetarevision-info
 type RevisionInfoResponse struct {
 	Revisions []*charm.Reference
 }
 
 // BundleCount holds the result of an id/meta/bundle-unit-count
-// or bundle-machine-count GET request. See http://tinyurl.com/mkvowub
-// and http://tinyurl.com/qfuubrv
+// or bundle-machine-count GET request.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetabundle-unit-count
+// and https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetabundle-machine-count
 type BundleCount struct {
 	Count int
 }
 
-// TagsResponse holds the result of an
-// id/meta/tags GET request. See http://tinyurl.com/njyqwj2
+// TagsResponse holds the result of an id/meta/tags GET request.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetatags
 type TagsResponse struct {
 	Tags []string
 }
 
+// Published holds the result of a changes/published GET request.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-changespublished
 type Published struct {
 	Id          *charm.Reference
 	PublishTime time.Time
@@ -130,31 +135,31 @@ type SearchResponse struct {
 }
 
 // IdUserResponse holds the result of an id/meta/id-user GET request.
-// See http://tinyurl.com/o7xmhz2
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid-user
 type IdUserResponse struct {
 	User string
 }
 
 // IdSeriesResponse holds the result of an id/meta/id-series GET request.
-// See http://tinyurl.com/pnwmr6j
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid-series
 type IdSeriesResponse struct {
 	Series string
 }
 
 // IdNameResponse holds the result of an id/meta/id-name GET request.
-// See http://tinyurl.com/m5q8gcy
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid-name
 type IdNameResponse struct {
 	Name string
 }
 
 // IdRevisionResponse holds the result of an id/meta/id-revision GET request.
-// See http://tinyurl.com/ntd3coz
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid-revision
 type IdRevisionResponse struct {
 	Revision int
 }
 
 // IdResponse holds the result of an id/meta/id GET request.
-// See http://tinyurl.com/lnqwbsp
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaid
 type IdResponse struct {
 	Id       *charm.Reference
 	User     string `json:",omitempty"`
@@ -163,8 +168,8 @@ type IdResponse struct {
 	Revision int
 }
 
-// PermResponse holds the result of an id/meta/perm GET
-// request. See tinyurl TODO.
+// PermResponse holds the result of an id/meta/perm GET request.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaperm
 type PermResponse struct {
 	Read  []string
 	Write []string
@@ -200,7 +205,7 @@ type Log struct {
 
 // LogResponse represents a single log message and is used in the responses
 // to /log GET requests.
-// See http://tinyurl.com/nj77rcr
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-log
 type LogResponse struct {
 	// Data holds the log message as a JSON-encoded value.
 	Data json.RawMessage

--- a/params/stats.go
+++ b/params/stats.go
@@ -15,8 +15,8 @@ const (
 	StatsCharmEvent   = "charm-event"
 )
 
-// Statistic holds one element of a stats/counter
-// response. See http://tinyurl.com/nkdovcf
+// Statistic holds one element of a stats/counter response.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-statscounter
 type Statistic struct {
 	Key   string `json:",omitempty"`
 	Date  string `json:",omitempty"`
@@ -24,7 +24,7 @@ type Statistic struct {
 }
 
 // StatsResponse holds the result of an id/meta/stats GET request.
-// See http://tinyurl.com/lvyp2l5
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetastats
 type StatsResponse struct {
 	// ArchiveDownloadCount is superceded by ArchiveDownload but maintained for
 	// backward compatibility.


### PR DESCRIPTION
Remove all references to the old google drive documentation.
Add missing endpoints documentation (for instance, archive/path and meta/perm)
and fix some outdated/wrong bits (like meta/archive-upload-time).
