### PR TITLE
Update deps to the latest charm.v4.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -3,12 +3,12 @@ github.com/ajstarks/svgo	git	89e3ac64b5b3e403a5e7c35ea4f98d45db7b4518	2014-10-04
 github.com/juju/blobstore	git	3aa294463f563d40f3722a00a4c2de72dbbe3f76	2014-11-14T04:26:36Z
 github.com/juju/errors	git	c3aaee403f140e8ab35eca129eb0a514bed780eb	2015-01-08T02:04:25Z
 github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	2014-07-18T03:59:30Z
-github.com/juju/gojsonreference	git	0673d58f64bacac2db34c7d1e87a599d58923981	2014-07-18T03:57:39Z
-github.com/juju/gojsonschema	git	33fa79718fa9b24e2a04122f91a75496c0f77098	2014-07-17T16:12:25Z
+github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
+github.com/juju/gojsonschema	git	995b906ce18b2726e9d284efbfa79bd7070ec8c8	2015-02-19T20:49:45Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/jujusvg	git	223e0e5a15113b2bd7dcc1bc286372e78491a1a5	2015-03-05T18:18:32Z
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
-github.com/juju/names	git	e7394f4ce9389fb57cfb7cbe9fa30790d01a8875	2014-12-17T04:05:00Z
+github.com/juju/names	git	ce4ecb2967822062fc606e733919c677c584ab7e	2015-02-20T07:57:36Z
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T04:23:18Z
 github.com/juju/testing	git	006244fdb8dc686679d221bc720562a0155ebb5f	2015-01-20T14:33:09Z
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	2014-09-25T11:49:22Z
@@ -17,7 +17,7 @@ github.com/juju/xml	git	91535ba18a6afd756e38a40c91fea0ed8e5dbaa6	2014-12-04T14:5
 golang.org/x/crypto	git	4ed45ec682102c643324fae5dff8dab085b6c300	2015-01-12T22:01:33Z
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
-gopkg.in/juju/charm.v4	git	7ef31c485ccfd7f1f9571d42ef4395bd04dc1006	2014-11-17T17:46:04Z
+gopkg.in/juju/charm.v4	git	c9dacb8f7647108fd1837666145fc3ea05eb9e26	2015-03-03T11:49:15Z
 gopkg.in/macaroon-bakery.v0	git	4c0e0fae424e8d1bc71c0b0caca3cd2c32381dca	2015-01-27T17:01:29Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	c6a7dce14133ccac2dcac3793f1d6e2ef048503a	2015-01-24T11:37:54Z

--- a/internal/storetesting/charm-repo/quantal/dummy/actions.yaml
+++ b/internal/storetesting/charm-repo/quantal/dummy/actions.yaml
@@ -1,8 +1,7 @@
-actions:
-   snapshot:
-      description: Take a snapshot of the database.
-      params:
-         outfile:
-            description: The file to write out to.
-            type: string
-            default: foo.bz2
+snapshot:
+  description: Take a snapshot of the database.
+  params:
+    outfile:
+      description: The file to write out to.
+      type: string
+      default: foo.bz2


### PR DESCRIPTION
Update the example charm actions used for
tests so that it conforms to the new syntax.
