### PR TITLE
API endpoint to set promulgated flag.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -10,7 +10,7 @@ github.com/juju/jujusvg	git	99cc8e38406a692203d6a4673199e1683f6e8d82	2015-03-12T
 github.com/juju/loggo	git	dc8e19f7c70a62a59c69c40f85b8df09ff20742c	2014-11-17T04:05:26Z
 github.com/juju/names	git	ce4ecb2967822062fc606e733919c677c584ab7e	2015-02-20T07:57:36Z
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T04:23:18Z
-github.com/juju/testing	git	59acbfa640360b9df5d5f9806e0be976f2e44951	2015-03-04T15:30:15Z
+github.com/juju/testing	git	b93c38205ac2e3817b7b1d9d60e89e69c99a6362	2015-03-16T13:08:43Z
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	2014-09-25T11:49:22Z
 github.com/juju/utils	git	a90aa2e02b9e7fe354ab816e05b1e0a77f27242d	2015-02-23T16:02:32Z
 github.com/juju/xml	git	91535ba18a6afd756e38a40c91fea0ed8e5dbaa6	2014-12-04T14:59:31Z

--- a/docs/API.md
+++ b/docs/API.md
@@ -220,6 +220,43 @@ icon does not exist, this endpoint returns the default icon.
 
 This returns the README.
 
+### Promulgation
+
+#### PUT *id*/promulgate
+
+A PUT to ~*user*/*anyseries*/*name*-*anyrevision* sets whether entities
+with the id *x*/*name* are considered to be aliases
+for ~*user*/*x*/*name* for all series *x*. The series
+and revision in the id are ignored (except that an
+entity must exist that matches the id).
+
+If Promulgate is true, it means that any new charms published
+to ~*user*/*x*/*name* will also be given the alias
+*x*/*name*. The latest revision for all ids ~*user*/*anyseries*/*name* 
+will also be aliased likewise.
+
+If Promulgate is false, any new charms published
+to ~*user*/*anyseries*/*name* will not be given a promulgated
+alias, but no change is made to any existing aliases.
+
+The promulgated status can be retrieved from the
+promulgated meta endpoint.
+
+```go
+type PromulgateRequest struct {
+	Promulgate bool
+}
+```
+
+Example: `PUT ~charmers/precise/wordpress-23/promulgate`
+
+Request body:
+```json
+{
+    "Promulgate" : true,
+}
+```
+
 ### Stats
 
 #### GET stats/counter/...
@@ -347,6 +384,7 @@ Example: `GET /meta`
     "id-series",
     "id-user",
     "manifest",
+    "promulgated",
     "revision-info",
     "stats",
     "tags"
@@ -499,6 +537,7 @@ Example: `GET foo/meta`
     "id-series",
     "id-user",
     "manifest",
+    "promulgated",
     "revision-info",
     "stats",
     "tags"
@@ -1214,6 +1253,25 @@ Example: `GET trusty/wordpress-42/meta/archive-upload-time`
 ```json
 {
     "UploadTime": "2014-07-04T13:53:57.403506102Z"
+}
+```
+
+#### GET *id*/meta/promulgated
+
+The `promulgated` path reports whether the entity with the given ID is promulgated.
+Promulgated charms do not require the user portion of the ID to be specified.
+
+```go
+type PromulgatedResponse struct {
+	Promulgated bool
+}
+```
+
+Example: `GET trusty/wordpress-42/meta/promulgated`
+
+```json
+{
+	"Promulgated": true
 }
 ```
 

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -1820,6 +1820,7 @@ var promulgateTests = []struct {
 	entities           []*mongodoc.Entity
 	baseEntities       []*mongodoc.BaseEntity
 	url                string
+	promulgate         bool
 	expectErr          string
 	expectEntities     []*mongodoc.Entity
 	expectBaseEntities []*mongodoc.BaseEntity
@@ -1831,7 +1832,8 @@ var promulgateTests = []struct {
 	baseEntities: []*mongodoc.BaseEntity{
 		baseEntity("~charmers/wordpress", false),
 	},
-	url: "~charmers/trusty/wordpress-0",
+	url:        "~charmers/trusty/wordpress-0",
+	promulgate: true,
 	expectEntities: []*mongodoc.Entity{
 		entity("~charmers/trusty/wordpress-0", "trusty/wordpress-0"),
 	},
@@ -1847,7 +1849,8 @@ var promulgateTests = []struct {
 	baseEntities: []*mongodoc.BaseEntity{
 		baseEntity("~charmers/wordpress", false),
 	},
-	url: "~charmers/trusty/wordpress-0",
+	url:        "~charmers/trusty/wordpress-0",
+	promulgate: true,
 	expectEntities: []*mongodoc.Entity{
 		entity("~charmers/trusty/wordpress-0", "trusty/wordpress-0"),
 		entity("~charmers/precise/wordpress-0", "precise/wordpress-0"),
@@ -1865,7 +1868,8 @@ var promulgateTests = []struct {
 		baseEntity("~charmers/wordpress", true),
 		baseEntity("~test-charmers/wordpress", false),
 	},
-	url: "~test-charmers/trusty/wordpress-0",
+	url:        "~test-charmers/trusty/wordpress-0",
+	promulgate: true,
 	expectEntities: []*mongodoc.Entity{
 		entity("~charmers/trusty/wordpress-0", "trusty/wordpress-0"),
 		entity("~test-charmers/trusty/wordpress-0", "trusty/wordpress-1"),
@@ -1882,7 +1886,8 @@ var promulgateTests = []struct {
 	baseEntities: []*mongodoc.BaseEntity{
 		baseEntity("~charmers/wordpress", true),
 	},
-	url: "~charmers/trusty/wordpress-0",
+	url:        "~charmers/trusty/wordpress-0",
+	promulgate: true,
 	expectEntities: []*mongodoc.Entity{
 		entity("~charmers/trusty/wordpress-0", "trusty/wordpress-0"),
 	},
@@ -1899,7 +1904,8 @@ var promulgateTests = []struct {
 		baseEntity("~charmers/wordpress", false),
 		baseEntity("~test-charmers/mysql", true),
 	},
-	url: "~charmers/trusty/wordpress-0",
+	url:        "~charmers/trusty/wordpress-0",
+	promulgate: true,
 	expectEntities: []*mongodoc.Entity{
 		entity("~charmers/trusty/wordpress-0", "trusty/wordpress-0"),
 		entity("~test-charmers/trusty/mysql-0", "trusty/mysql-0"),
@@ -1920,7 +1926,8 @@ var promulgateTests = []struct {
 		baseEntity("~test-charmers/wordpress", false),
 		baseEntity("~test2-charmers/wordpress", true),
 	},
-	url: "~charmers/trusty/wordpress-0",
+	url:        "~charmers/trusty/wordpress-0",
+	promulgate: true,
 	expectEntities: []*mongodoc.Entity{
 		entity("~charmers/trusty/wordpress-0", "trusty/wordpress-2"),
 		entity("~test-charmers/trusty/wordpress-0", "trusty/wordpress-0"),
@@ -1943,8 +1950,9 @@ var promulgateTests = []struct {
 		baseEntity("~test-charmers/wordpress", false),
 		baseEntity("~test2-charmers/wordpress", true),
 	},
-	url:       "~charmers/trusty/wordpress-2",
-	expectErr: "entity not found",
+	url:        "~charmers/trusty/wordpress-2",
+	promulgate: true,
+	expectErr:  "entity not found",
 }, {
 	about: "promulgate owner of previously promulgated charm",
 	entities: []*mongodoc.Entity{
@@ -1958,7 +1966,8 @@ var promulgateTests = []struct {
 		baseEntity("~test-charmers/wordpress", false),
 		baseEntity("~test2-charmers/wordpress", true),
 	},
-	url: "trusty/wordpress-0",
+	url:        "trusty/wordpress-0",
+	promulgate: true,
 	expectEntities: []*mongodoc.Entity{
 		entity("~charmers/trusty/wordpress-0", ""),
 		entity("~test-charmers/trusty/wordpress-0", "trusty/wordpress-0"),
@@ -1983,7 +1992,8 @@ var promulgateTests = []struct {
 		baseEntity("~test-charmers/wordpress", true),
 		baseEntity("~test2-charmers/wordpress", true),
 	},
-	url: "~test2-charmers/trusty/wordpress-0",
+	url:        "~test2-charmers/trusty/wordpress-0",
+	promulgate: true,
 	expectEntities: []*mongodoc.Entity{
 		entity("~charmers/trusty/wordpress-0", ""),
 		entity("~test-charmers/trusty/wordpress-0", "trusty/wordpress-0"),
@@ -2007,7 +2017,8 @@ var promulgateTests = []struct {
 		baseEntity("~charmers/wordpress", true),
 		baseEntity("~test-charmers/wordpress", false),
 	},
-	url: "~test-charmers/trusty/wordpress-0",
+	url:        "~test-charmers/trusty/wordpress-0",
+	promulgate: true,
 	expectEntities: []*mongodoc.Entity{
 		entity("~charmers/trusty/wordpress-0", "trusty/wordpress-2"),
 		entity("~charmers/precise/wordpress-0", "precise/wordpress-1"),
@@ -2017,6 +2028,38 @@ var promulgateTests = []struct {
 	expectBaseEntities: []*mongodoc.BaseEntity{
 		baseEntity("~charmers/wordpress", false),
 		baseEntity("~test-charmers/wordpress", true),
+	},
+}, {
+	about: "unpromulgate single promulgated charm ",
+	entities: []*mongodoc.Entity{
+		entity("~charmers/trusty/wordpress-0", "trusty/wordpress-0"),
+	},
+	baseEntities: []*mongodoc.BaseEntity{
+		baseEntity("~charmers/wordpress", true),
+	},
+	url:        "~charmers/trusty/wordpress-0",
+	promulgate: false,
+	expectEntities: []*mongodoc.Entity{
+		entity("~charmers/trusty/wordpress-0", "trusty/wordpress-0"),
+	},
+	expectBaseEntities: []*mongodoc.BaseEntity{
+		baseEntity("~charmers/wordpress", false),
+	},
+}, {
+	about: "unpromulgate single unpromulgated charm ",
+	entities: []*mongodoc.Entity{
+		entity("~charmers/trusty/wordpress-0", ""),
+	},
+	baseEntities: []*mongodoc.BaseEntity{
+		baseEntity("~charmers/wordpress", false),
+	},
+	url:        "~charmers/trusty/wordpress-0",
+	promulgate: false,
+	expectEntities: []*mongodoc.Entity{
+		entity("~charmers/trusty/wordpress-0", ""),
+	},
+	expectBaseEntities: []*mongodoc.BaseEntity{
+		baseEntity("~charmers/wordpress", false),
 	},
 }}
 
@@ -2038,7 +2081,7 @@ func (s *StoreSuite) TestPromulgate(c *gc.C) {
 			err := store.DB.BaseEntities().Insert(baseEntity)
 			c.Assert(err, gc.IsNil)
 		}
-		err = store.Promulgate(url)
+		err = store.SetPromulgated(url, test.promulgate)
 		if test.expectErr != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectErr)
 			continue

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -144,9 +144,10 @@ type Router struct {
 // The Cause of the resolveURL error will be left unchanged,
 // as for the handlers.
 //
-// The authorize function will be called to authorize the request.
-// The Cause of the authorize error will be left unchanged,
-// as for the handlers.
+// The authorize function will be called to authorize the request
+// to any BulkIncludeHandlers. All other handlers are expected
+// to handle their own authorization. The Cause of the authorize
+// error will be left unchanged, as for the handlers.
 //
 // The exists function may be called to test whether an entity
 // exists when an API endpoint needs to know that
@@ -241,9 +242,6 @@ func (r *Router) serveIds(w http.ResponseWriter, req *http.Request) error {
 	}
 	if handler != nil {
 		req.URL.Path = path
-		if err := r.authorize(url, req); err != nil {
-			return errgo.Mask(err, errgo.Any)
-		}
 		err := handler(url, fullySpecified, w, req)
 		// Note: preserve error cause from handlers.
 		return errgo.Mask(err, errgo.Any)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -285,20 +285,6 @@ var routerGetTests = []struct {
 		Code:    params.ErrNotFound,
 	},
 }, {
-	about:  "unauthorized id handler",
-	urlStr: "/precise/wordpress-42/foo",
-	handlers: Handlers{
-		Id: map[string]IdHandler{
-			"foo": testIdHandler,
-		},
-	},
-	authorize:    neverAuthorize,
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: "bad wolf",
-	},
-}, {
 	about: "meta list",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -1,0 +1,131 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storetesting
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5-unstable"
+	"gopkg.in/mgo.v2"
+
+	"gopkg.in/juju/charmstore.v4/internal/mongodoc"
+)
+
+// EntityBuilder provides a convenient way to describe a mongodoc.Entity
+// for tests that is correctly formed and contains the desired
+// information.
+type EntityBuilder struct {
+	entity *mongodoc.Entity
+}
+
+// NewEntity creates a new EntityBuilder for the provided URL.
+func NewEntity(url string) EntityBuilder {
+	URL := charm.MustParseReference(url)
+	return EntityBuilder{
+		entity: &mongodoc.Entity{
+			URL:                 URL,
+			Name:                URL.Name,
+			Series:              URL.Series,
+			Revision:            URL.Revision,
+			User:                URL.User,
+			BaseURL:             baseURL(URL),
+			PromulgatedRevision: -1,
+		},
+	}
+}
+
+func copyURL(id *charm.Reference) *charm.Reference {
+	if id == nil {
+		return nil
+	}
+	id1 := *id
+	return &id1
+}
+
+func (b EntityBuilder) copy() EntityBuilder {
+	e := *b.entity
+	e.PromulgatedURL = copyURL(e.PromulgatedURL)
+	e.URL = copyURL(e.URL)
+	e.BaseURL = copyURL(e.BaseURL)
+	return EntityBuilder{&e}
+}
+
+// WithPromulgatedURL sets the PromulgatedURL and PromulgatedRevision of the
+// entity being built.
+func (b EntityBuilder) WithPromulgatedURL(url string) EntityBuilder {
+	b = b.copy()
+	if url == "" {
+		b.entity.PromulgatedURL = nil
+		b.entity.PromulgatedRevision = -1
+	} else {
+		b.entity.PromulgatedURL = charm.MustParseReference(url)
+		b.entity.PromulgatedRevision = b.entity.PromulgatedURL.Revision
+	}
+	return b
+}
+
+// Build creates a mongodoc.Entity from the EntityBuilder.
+func (b EntityBuilder) Build() *mongodoc.Entity {
+	return b.copy().entity
+}
+
+// AssertEntity checks that db contains an entity that matches expect.
+func AssertEntity(c *gc.C, db *mgo.Collection, expect *mongodoc.Entity) {
+	var entity mongodoc.Entity
+	err := db.FindId(expect.URL).One(&entity)
+	c.Assert(err, gc.IsNil)
+	c.Assert(&entity, jc.DeepEquals, expect)
+}
+
+// BaseEntityBuilder provides a convenient way to describe a
+// mongodoc.BaseEntity for tests that is correctly formed and contains the
+// desired information.
+type BaseEntityBuilder struct {
+	baseEntity *mongodoc.BaseEntity
+}
+
+// NewBaseEntity creates a new BaseEntityBuilder for the provided URL.
+func NewBaseEntity(url string) BaseEntityBuilder {
+	URL := charm.MustParseReference(url)
+	return BaseEntityBuilder{
+		baseEntity: &mongodoc.BaseEntity{
+			URL:  URL,
+			Name: URL.Name,
+			User: URL.User,
+		},
+	}
+}
+
+func (b BaseEntityBuilder) copy() BaseEntityBuilder {
+	e := *b.baseEntity
+	e.URL = copyURL(e.URL)
+	return BaseEntityBuilder{&e}
+}
+
+// WithPromulgated sets the promulgated flag on the BaseEntity.
+func (b BaseEntityBuilder) WithPromulgated(promulgated bool) BaseEntityBuilder {
+	b = b.copy()
+	b.baseEntity.Promulgated = mongodoc.IntBool(promulgated)
+	return b
+}
+
+// Build creates a mongodoc.BaseEntity from the BaseEntityBuilder.
+func (b BaseEntityBuilder) Build() *mongodoc.BaseEntity {
+	return b.copy().baseEntity
+}
+
+// AssertBaseEntity checks that db contains a base entity that matches expect.
+func AssertBaseEntity(c *gc.C, db *mgo.Collection, expect *mongodoc.BaseEntity) {
+	var baseEntity mongodoc.BaseEntity
+	err := db.FindId(expect.URL).One(&baseEntity)
+	c.Assert(err, gc.IsNil)
+	c.Assert(&baseEntity, jc.DeepEquals, expect)
+}
+
+func baseURL(url *charm.Reference) *charm.Reference {
+	baseURL := *url
+	baseURL.Series = ""
+	baseURL.Revision = -1
+	return &baseURL
+}

--- a/internal/storetesting/json.go
+++ b/internal/storetesting/json.go
@@ -1,0 +1,26 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storetesting
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// MustMarshalJSON marshals the specified value using json.Marshal and
+// returns the corresponding byte slice. If there is an error marshalling
+// the value then MustMarshalJSON will panic.
+func MustMarshalJSON(v interface{}) []byte {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+// JSONReader creates an io.Reader which can read the Marshalled value of v.
+func JSONReader(v interface{}) io.Reader {
+	return bytes.NewReader(MustMarshalJSON(v))
+}

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -18,7 +18,10 @@ import (
 	"gopkg.in/juju/charmstore.v4/params"
 )
 
-const basicRealm = "CharmStore4"
+const (
+	basicRealm        = "CharmStore4"
+	promulgatorsGroup = "promulgators"
+)
 
 // authorize checks that the current user is authorized based on the provided
 // ACL. If an authenticated user is required, authorize tries to retrieve the
@@ -47,7 +50,7 @@ func (h *Handler) authorize(req *http.Request, acl []string) error {
 
 	auth, verr := h.checkRequest(req)
 	if verr == nil {
-		logger.Infof("authenticated with auth: %q", auth)
+		logger.Infof("authenticated with auth: %#v", auth)
 		if err := h.checkACLMembership(auth, acl); err != nil {
 			return errgo.WithCausef(err, params.ErrUnauthorized, "")
 		}
@@ -95,7 +98,7 @@ func (h *Handler) checkRequest(req *http.Request) (authorization, error) {
 }
 
 func (h *Handler) authorizeEntity(id *charm.Reference, req *http.Request) error {
-	// TThe first time a new charm is published, its corresponding base entity
+	// The first time a new charm is published, its corresponding base entity
 	// is not yet present in the database. For this reason, the check below
 	// must still allow specific users to proceed with the request, even in the
 	// case ACL cannot be retrieved from the base entity.

--- a/params/params.go
+++ b/params/params.go
@@ -190,6 +190,18 @@ type PermRequest struct {
 	Write []string
 }
 
+// PromulgatedResponse holds the result of an id/meta/promulgated GET request.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetapromulgated
+type PromulgatedResponse struct {
+	Promulgated bool
+}
+
+// PromulgateRequest holds the request of an id/promulgate PUT request.
+// See https://github.com/juju/charmstore/blob/v4/docs/API.md#put-idpromulgate
+type PromulgateRequest struct {
+	Promulgated bool
+}
+
 const (
 	// BzrDigestKey is the extra-info key used to store the Bazaar digest
 	BzrDigestKey = "bzr-digest"


### PR DESCRIPTION
Added a new $id/meta/promulgated endpoint to query the promulgated status
of an entity. Also added a $id/restricted/promulgate endpoint that
privileged users can use to promulgate a base entity.
