### PR TITLE
Return a 404 if an entity cannot be found because it has an invalid name

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -221,7 +221,7 @@ func (r *Router) serveIds(w http.ResponseWriter, req *http.Request) error {
 	path := strings.TrimSuffix(req.URL.Path, "/")
 	url, path, err := splitId(path)
 	if err != nil {
-		return errgo.Mask(err)
+		return errgo.WithCausef(err, params.ErrNotFound, "")
 	}
 	key, path := handlerKey(path)
 	if key == "" {
@@ -476,14 +476,14 @@ func (r *Router) serveBulkMetaGet(req *http.Request) (interface{}, error) {
 	// TODO get the metadata concurrently for each id.
 	ids := req.Form["id"]
 	if len(ids) == 0 {
-		return nil, errgo.Newf("no ids specified in meta request")
+		return nil, errgo.WithCausef(nil, params.ErrBadRequest, "no ids specified in meta request")
 	}
 	delete(req.Form, "id")
 	result := make(map[string]interface{})
 	for _, id := range ids {
 		url, err := charm.ParseReference(id)
 		if err != nil {
-			return nil, errgo.Mask(err)
+			return nil, errgo.WithCausef(err, params.ErrBadRequest, "")
 		}
 		if err := r.resolveURL(url); err != nil {
 			if errgo.Cause(err) == params.ErrNotFound {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -716,8 +716,9 @@ var routerGetTests = []struct {
 			"foo/": testMetaHandler(0),
 		},
 	},
-	expectStatus: http.StatusInternalServerError,
+	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
 		Message: "no ids specified in meta request",
 	},
 }, {
@@ -788,6 +789,24 @@ var routerGetTests = []struct {
 	expectStatus: http.StatusOK,
 	expectBody: map[string]string{
 		"bundle/something-24": "something",
+	},
+}, {
+	about:        "meta request with invalid entity reference",
+	urlStr:       "/robots.txt/meta/any",
+	handlers:     Handlers{},
+	expectStatus: http.StatusNotFound,
+	expectBody: params.Error{
+		Code:    params.ErrNotFound,
+		Message: `not found: charm URL has invalid charm name: "robots.txt"`,
+	},
+}, {
+	about:        "bulk meta handler, invalid id",
+	urlStr:       "/meta/foo?id=robots.txt",
+	handlers:     Handlers{},
+	expectStatus: http.StatusBadRequest,
+	expectBody: params.Error{
+		Code:    params.ErrBadRequest,
+		Message: `bad request: charm URL has invalid charm name: "robots.txt"`,
 	},
 }}
 


### PR DESCRIPTION
If the requested charm name doesn't parse we treat it as if it were not found.
