### PR TITLE
internal/v4: serve default icon when we find bad XML

### DIFF
--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -12,6 +12,7 @@ var (
 	ParamsLogLevels                = paramsLogLevels
 	ParamsLogTypes                 = paramsLogTypes
 	ProcessIcon                    = processIcon
+	ErrProbablyNotXML              = errProbablyNotXML
 	UsernameAttr                   = usernameAttr
 	GroupsAttr                     = groupsAttr
 	GetPromulgatedURL              = (*Handler).getPromulgatedURL


### PR DESCRIPTION
We want to protect the user from seeing any potentially dubious SVGs,
so we return the default icon for any SVGs that we cannot process. This
has the side effect of disallowing some valid SVGs but that is considered
a reasonable trade-off.
