### PR TITLE
internal/router: make ResolveURL return ResolvedURL

### DIFF
--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -633,7 +633,7 @@ func (s *suite) TestDoAuthorization(c *gc.C) {
 
 	// Check that it's now really gone.
 	err = client.Get("/utopic/wordpress-42/expand-id", nil)
-	c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for "cs:wordpress"`)
+	c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for "cs:utopic/wordpress-42"`)
 }
 
 var getWithBadResponseTests = []struct {

--- a/docs/API.md
+++ b/docs/API.md
@@ -1365,7 +1365,7 @@ type Id struct {
 }
 ```
 
-Example: `GET trusty/~bob/wordpress/meta/id`
+Example: `GET ~bob/trusty/wordpress/meta/id`
 
 ```json
 {

--- a/internal/charmstore/hash.go
+++ b/internal/charmstore/hash.go
@@ -13,15 +13,16 @@ import (
 	"io"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/juju/charm.v5-unstable"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
+
+	"gopkg.in/juju/charmstore.v4/internal/router"
 )
 
 // UpdateEntitySHA256 calculates and return the SHA256 hash of the archive of
 // the given entity id. The entity document is then asynchronously updated with
 // the resulting hash. This method will be removed soon.
-func (s *Store) UpdateEntitySHA256(id *charm.Reference) (string, error) {
+func (s *Store) UpdateEntitySHA256(id *router.ResolvedURL) (string, error) {
 	r, _, _, err := s.OpenBlob(id)
 	defer r.Close()
 	hash := sha256.New()
@@ -42,8 +43,8 @@ func (s *Store) UpdateEntitySHA256(id *charm.Reference) (string, error) {
 // UpdateEntitySHA256 updates the BlobHash256 entry for the entity.
 // It is defined as a variable so that it can be mocked in tests.
 // This function will be removed soon.
-var UpdateEntitySHA256 = func(store *Store, id *charm.Reference, sum256 string) {
-	err := store.DB.Entities().UpdateId(id, bson.D{{"$set", bson.D{{"blobhash256", sum256}}}})
+var UpdateEntitySHA256 = func(store *Store, id *router.ResolvedURL, sum256 string) {
+	err := store.DB.Entities().UpdateId(&id.URL, bson.D{{"$set", bson.D{{"blobhash256", sum256}}}})
 	if err != nil && err != mgo.ErrNotFound {
 		logger.Errorf("cannot update sha256 of archive: %v", err)
 	}

--- a/internal/router/fieldinclude.go
+++ b/internal/router/fieldinclude.go
@@ -9,12 +9,11 @@ import (
 	"net/url"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/juju/charm.v5-unstable"
 )
 
 // A FieldQueryFunc is used to retrieve a metadata document for the given URL,
 // selecting only those fields specified in keys of the given selector.
-type FieldQueryFunc func(id *charm.Reference, selector map[string]int, req *http.Request) (interface{}, error)
+type FieldQueryFunc func(id *ResolvedURL, selector map[string]int, req *http.Request) (interface{}, error)
 
 // FieldUpdater records field changes made by a FieldUpdateFunc.
 type FieldUpdater struct {
@@ -36,22 +35,22 @@ func (u *FieldUpdater) UpdateSearch() {
 // A FieldUpdateFunc is used to update a metadata document for the
 // given id. For each field in fields, it should set that field to
 // its corresponding value in the metadata document.
-type FieldUpdateFunc func(id *charm.Reference, fields map[string]interface{}) error
+type FieldUpdateFunc func(id *ResolvedURL, fields map[string]interface{}) error
 
 // A FieldUpdateSearchFunc is used to update a search document for the
 // given id. For each field in fields, it should set that field to
 // its corresponding value in the search document.
-type FieldUpdateSearchFunc func(id *charm.Reference, fields map[string]interface{}) error
+type FieldUpdateSearchFunc func(id *ResolvedURL, fields map[string]interface{}) error
 
 // A FieldGetFunc returns some data from the given document. The
 // document will have been returned from an earlier call to the
 // associated QueryFunc.
-type FieldGetFunc func(doc interface{}, id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error)
+type FieldGetFunc func(doc interface{}, id *ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error)
 
 // FieldPutFunc sets using the given FieldUpdater corresponding to fields to be set
 // in the metadata document for the given id. The path holds the metadata path
 // after the initial prefix has been removed.
-type FieldPutFunc func(id *charm.Reference, path string, val *json.RawMessage, updater *FieldUpdater, req *http.Request) error
+type FieldPutFunc func(id *ResolvedURL, path string, val *json.RawMessage, updater *FieldUpdater, req *http.Request) error
 
 // FieldIncludeHandlerParams specifies the parameters for NewFieldIncludeHandler.
 type FieldIncludeHandlerParams struct {
@@ -102,7 +101,7 @@ func (h *fieldIncludeHandler) Key() interface{} {
 	return h.p.Key
 }
 
-func (h *fieldIncludeHandler) HandlePut(hs []BulkIncludeHandler, id *charm.Reference, paths []string, values []*json.RawMessage, req *http.Request) []error {
+func (h *fieldIncludeHandler) HandlePut(hs []BulkIncludeHandler, id *ResolvedURL, paths []string, values []*json.RawMessage, req *http.Request) []error {
 	updater := &FieldUpdater{
 		fields: make(map[string]interface{}),
 	}
@@ -147,7 +146,7 @@ func (h *fieldIncludeHandler) HandlePut(hs []BulkIncludeHandler, id *charm.Refer
 	return errs
 }
 
-func (h *fieldIncludeHandler) HandleGet(hs []BulkIncludeHandler, id *charm.Reference, paths []string, flags url.Values, req *http.Request) ([]interface{}, error) {
+func (h *fieldIncludeHandler) HandleGet(hs []BulkIncludeHandler, id *ResolvedURL, paths []string, flags url.Values, req *http.Request) ([]interface{}, error) {
 	funcs := make([]FieldGetFunc, len(hs))
 	selector := make(map[string]int)
 	// Extract the handler functions and union all the fields.

--- a/internal/router/singleinclude.go
+++ b/internal/router/singleinclude.go
@@ -9,14 +9,13 @@ import (
 	"net/url"
 
 	"gopkg.in/errgo.v1"
-	"gopkg.in/juju/charm.v5-unstable"
 )
 
 var _ BulkIncludeHandler = SingleIncludeHandler(nil)
 
 // SingleIncludeHandler implements BulkMetaHander for a non-batching
 // metadata retrieval function that can perform a GET only.
-type SingleIncludeHandler func(id *charm.Reference, path string, flags url.Values, req *http.Request) (interface{}, error)
+type SingleIncludeHandler func(id *ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error)
 
 // Key implements BulkMetadataHander.Key.
 func (h SingleIncludeHandler) Key() interface{} {
@@ -27,7 +26,7 @@ func (h SingleIncludeHandler) Key() interface{} {
 }
 
 // HandleGet implements BulkMetadataHander.HandleGet.
-func (h SingleIncludeHandler) HandleGet(hs []BulkIncludeHandler, id *charm.Reference, paths []string, flags url.Values, req *http.Request) ([]interface{}, error) {
+func (h SingleIncludeHandler) HandleGet(hs []BulkIncludeHandler, id *ResolvedURL, paths []string, flags url.Values, req *http.Request) ([]interface{}, error) {
 	results := make([]interface{}, len(hs))
 	for i, h := range hs {
 		h := h.(SingleIncludeHandler)
@@ -44,7 +43,7 @@ func (h SingleIncludeHandler) HandleGet(hs []BulkIncludeHandler, id *charm.Refer
 var errPutNotImplemented = errgo.New("PUT not implemented")
 
 // HandlePut implements BulkMetadataHander.HandlePut.
-func (h SingleIncludeHandler) HandlePut(hs []BulkIncludeHandler, id *charm.Reference, paths []string, values []*json.RawMessage, req *http.Request) []error {
+func (h SingleIncludeHandler) HandlePut(hs []BulkIncludeHandler, id *ResolvedURL, paths []string, values []*json.RawMessage, req *http.Request) []error {
 	errs := make([]error, len(hs))
 	for i := range hs {
 		errs[i] = errPutNotImplemented

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -8,12 +8,15 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/juju/loggo"
 	"github.com/juju/utils/jsonhttp"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v0/httpbakery"
 
 	"gopkg.in/juju/charmstore.v4/params"
 )
+
+var logger = loggo.GetLogger("charmstore.internal.router")
 
 var (
 	HandleErrors = jsonhttp.HandleErrors(errorToResp)
@@ -22,6 +25,12 @@ var (
 )
 
 func errorToResp(err error) (int, interface{}) {
+	status, body := errorToResp1(err)
+	logger.Infof("error response %d; %s", status, errgo.Details(err))
+	return status, body
+}
+
+func errorToResp1(err error) (int, interface{}) {
 	// Allow bakery errors to be returned as the bakery would
 	// like them, so that httpbakery.Client.Do will work.
 	if err, ok := errgo.Cause(err).(*httpbakery.Error); ok {
@@ -51,6 +60,7 @@ func errorToResp(err error) (int, interface{}) {
 // errorResponse returns an appropriate error
 // response for the provided error.
 func errorResponseBody(err error) *params.Error {
+
 	errResp := &params.Error{
 		Message: err.Error(),
 	}

--- a/internal/storetesting/hashtesting/hash.go
+++ b/internal/storetesting/hashtesting/hash.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/mgo.v2/bson"
 
 	"gopkg.in/juju/charmstore.v4/internal/charmstore"
+	"gopkg.in/juju/charmstore.v4/internal/router"
 )
 
 func CheckSHA256Laziness(c *gc.C, store *charmstore.Store, id *charm.Reference, check func()) {
@@ -26,7 +27,7 @@ func CheckSHA256Laziness(c *gc.C, store *charmstore.Store, id *charm.Reference, 
 	original := charmstore.UpdateEntitySHA256
 	restore := jujutesting.PatchValue(
 		&charmstore.UpdateEntitySHA256,
-		func(store *charmstore.Store, id *charm.Reference, sum256 string) {
+		func(store *charmstore.Store, id *router.ResolvedURL, sum256 string) {
 			original(store, id, sum256)
 			updated <- struct{}{}
 		})

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -830,7 +830,7 @@ var archiveFileErrorsTests = []struct {
 	about:         "entity not found",
 	path:          "~charmers/trusty/no-such-42/archive/icon.svg",
 	expectStatus:  http.StatusNotFound,
-	expectMessage: "entity not found",
+	expectMessage: `entity "cs:~charmers/trusty/no-such-42" not found`,
 	expectCode:    params.ErrNotFound,
 }, {
 	about:         "directory listing",
@@ -1088,13 +1088,13 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 	// Try to delete a non existing charm using the API.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
-		URL:          storeURL("utopic/no-such-0/archive"),
+		URL:          storeURL("~charmers/utopic/no-such-0/archive"),
 		Method:       "DELETE",
 		Username:     serverParams.AuthUsername,
 		Password:     serverParams.AuthPassword,
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
-			Message: "entity not found",
+			Message: `entity "cs:~charmers/utopic/no-such-0" not found`,
 			Code:    params.ErrNotFound,
 		},
 	})
@@ -1156,10 +1156,16 @@ func (s *ArchiveSuite) TestDeleteCounters(c *gc.C) {
 }
 
 func (s *ArchiveSuite) TestPostAuthErrors(c *gc.C) {
-	checkAuthErrors(c, s.srv, "POST", "utopic/django/archive")
+	checkAuthErrors(c, s.srv, "POST", "~charmers/utopic/django/archive")
 }
 
 func (s *ArchiveSuite) TestDeleteAuthErrors(c *gc.C) {
+	err := s.store.AddCharmWithArchive(
+		charm.MustParseReference("~charmers/utopic/django-42"),
+		charm.MustParseReference("utopic/django-42"),
+		storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"),
+	)
+	c.Assert(err, gc.IsNil)
 	checkAuthErrors(c, s.srv, "DELETE", "utopic/django-42/archive")
 }
 

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -539,7 +539,7 @@ var uploadEntityAuthorizationTests = []struct {
 	about:        "promulgated entity",
 	username:     "sisko",
 	groups:       []string{"group1", "group2"},
-	id:           "utopic/django",
+	id:           "~charmers/utopic/django",
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
@@ -555,7 +555,7 @@ var uploadEntityAuthorizationTests = []struct {
 	},
 }, {
 	about:        "anonymous user and promulgated entity",
-	id:           "utopic/django",
+	id:           "~charmers/utopic/django",
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
@@ -584,7 +584,7 @@ var uploadEntityAuthorizationTests = []struct {
 	about:        "specific group and promulgated entity",
 	username:     "janeway",
 	groups:       []string{"group1"},
-	id:           "utopic/django",
+	id:           "~charmers/utopic/django",
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,

--- a/internal/v4/content.go
+++ b/internal/v4/content.go
@@ -24,8 +24,8 @@ import (
 
 // GET id/diagram.svg
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-iddiagramsvg
-func (h *Handler) serveDiagram(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
-	if id.Series != "bundle" {
+func (h *Handler) serveDiagram(id *router.ResolvedURL, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
+	if id.URL.Series != "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "diagrams not supported for charms")
 	}
 	entity, err := h.store.FindEntity(id, "bundledata")
@@ -70,7 +70,7 @@ var allowedReadMe = map[string]bool{
 
 // GET id/readme
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idreadme
-func (h *Handler) serveReadMe(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
+func (h *Handler) serveReadMe(id *router.ResolvedURL, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
 	entity, err := h.store.FindEntity(id, "_id", "contents", "blobname")
 	if err != nil {
 		return errgo.NoteMask(err, "cannot get README", errgo.Is(params.ErrNotFound))
@@ -93,8 +93,8 @@ func (h *Handler) serveReadMe(id *charm.Reference, fullySpecified bool, w http.R
 
 // GET id/icon.svg
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idiconsvg
-func (h *Handler) serveIcon(id *charm.Reference, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
-	if id.Series == "bundle" {
+func (h *Handler) serveIcon(id *router.ResolvedURL, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
+	if id.URL.Series == "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "icons not supported for bundles")
 	}
 

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -36,7 +36,7 @@ var serveDiagramErrorsTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: "entity not found",
+		Message: `entity "cs:~charmers/bundle/foo-23" not found`,
 	},
 }, {
 	about:        "diagram for a charm",
@@ -56,8 +56,8 @@ var serveDiagramErrorsTests = []struct {
 }}
 
 func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
-	s.addCharm(c, "wordpress", "cs:~charmers/trusty/wordpress-42")
-	s.addBundle(c, "wordpress-simple", "cs:~charmers/bundle/nopositionbundle-42")
+	s.addCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-42", 42))
+	s.addBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/nopositionbundle-42", 42))
 	for i, test := range serveDiagramErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -208,25 +208,37 @@ func (s *APISuite) TestServeReadMe(c *gc.C) {
 }
 
 func (s *APISuite) TestServeReadMeEntityNotFound(c *gc.C) {
+	// Add another charm so that the base entity exists so we
+	// actually get through to the code we're wanting to test.
+	// (if the base entity does not exist, the authorization code
+	// will fail).
+	s.addCharm(c, "wordpress", newResolvedURL("~charmers/precise/nothingatall-1", -1))
+
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
-		URL:          storeURL("precise/nothingatall-32/readme"),
+		URL:          storeURL("~charmers/precise/nothingatall-32/readme"),
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Code:    params.ErrNotFound,
-			Message: "cannot get README: entity not found",
+			Message: `cannot get README: entity not found`,
 		},
 	})
 }
 
 func (s *APISuite) TestServeIconEntityNotFound(c *gc.C) {
+	// Add another charm so that the base entity exists so we
+	// actually get through to the code we're wanting to test.
+	// (if the base entity does not exist, the authorization code
+	// will fail).
+	s.addCharm(c, "wordpress", newResolvedURL("~charmers/precise/nothingatall-1", -1))
+
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
-		URL:          storeURL("precise/nothingatall-32/icon.svg"),
+		URL:          storeURL("~charmers/precise/nothingatall-32/icon.svg"),
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Code:    params.ErrNotFound,
-			Message: "cannot get icon: entity not found",
+			Message: `cannot get icon: entity not found`,
 		},
 	})
 }
@@ -287,9 +299,11 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 }
 
 func (s *APISuite) TestServeBundleIcon(c *gc.C) {
+	s.addBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/something-32", 32))
+
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
-		URL:          storeURL("bundle/something-32/icon.svg"),
+		URL:          storeURL("~charmers/bundle/something-32/icon.svg"),
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Code:    params.ErrNotFound,

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -59,7 +59,7 @@ func (h *Handler) serveSearch(_ http.Header, req *http.Request) (interface{}, er
 				return nil
 			}
 			response.Results[i] = params.SearchResult{
-				Id:   ref,
+				Id:   ref.PreferredURL(),
 				Meta: meta,
 			}
 			return nil

--- a/internal/v4/status_test.go
+++ b/internal/v4/status_test.go
@@ -6,7 +6,6 @@ package v4_test
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 	"time"
 
 	jc "github.com/juju/testing/checkers"
@@ -16,21 +15,22 @@ import (
 	"gopkg.in/juju/charm.v5-unstable"
 
 	"gopkg.in/juju/charmstore.v4/internal/mongodoc"
+	"gopkg.in/juju/charmstore.v4/internal/router"
 	"gopkg.in/juju/charmstore.v4/params"
 )
 
 var zeroTimeStr = time.Time{}.Format(time.RFC3339)
 
 func (s *APISuite) TestStatus(c *gc.C) {
-	for _, id := range []string{
-		"cs:precise/wordpress-2",
-		"cs:precise/wordpress-3",
-		"cs:~foo/precise/arble-9",
-		"cs:~bar/utopic/arble-10",
-		"cs:bundle/oflaughs-3",
-		"cs:~bar/bundle/oflaughs-4",
+	for _, id := range []*router.ResolvedURL{
+		newResolvedURL("cs:~charmers/precise/wordpress-2", 2),
+		newResolvedURL("cs:~charmers/precise/wordpress-3", 3),
+		newResolvedURL("cs:~foo/precise/arble-9", -1),
+		newResolvedURL("cs:~bar/utopic/arble-10", -1),
+		newResolvedURL("cs:~charmers/bundle/oflaughs-3", 3),
+		newResolvedURL("cs:~bar/bundle/oflaughs-4", -1),
 	} {
-		if strings.Contains(id, "bundle") {
+		if id.URL.Series == "bundle" {
 			s.addBundle(c, "wordpress-simple", id)
 		} else {
 			s.addCharm(c, "wordpress", id)


### PR DESCRIPTION
By doing this, we preserve whether the original URL specified by
the API client was promulgated or not, while still resolving
entity URLs to their canonical (with user) form.

Inevitably this is a somewhat invasive change.
