### PR TITLE
use router.ResolvedURL in more places

### DIFF
--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -377,22 +377,17 @@ func (s *APISuite) TestServerStatus(c *gc.C) {
 }
 
 func (s *APISuite) addCharm(c *gc.C, charmName, curl string) (*router.ResolvedURL, *charm.CharmArchive) {
-	url := charm.MustParseReference(curl)
-	var purl *charm.Reference
-	if url.User == "" {
-		purl = new(charm.Reference)
-		*purl = *url
-		url.User = "charmers"
+	rurl := &router.ResolvedURL{
+		URL:                 *charm.MustParseReference(curl),
+		PromulgatedRevision: -1,
+	}
+	if rurl.URL.User == "" {
+		rurl.URL.User = "charmers"
+		rurl.PromulgatedRevision = rurl.URL.Revision
 	}
 	archive := storetesting.Charms.CharmArchive(c.MkDir(), charmName)
-	err := s.store.AddCharmWithArchive(url, purl, archive)
+	err := s.store.AddCharmWithArchive(rurl, archive)
 	c.Assert(err, gc.IsNil)
-	var rurl *router.ResolvedURL
-	if purl != nil {
-		rurl = router.MustNewResolvedURL(url.String(), purl.Revision)
-	} else {
-		rurl = router.MustNewResolvedURL(url.String(), -1)
-	}
 	return rurl, archive
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -176,6 +176,22 @@ func (id *ResolvedURL) PreferredURL() *charm.Reference {
 	return &u
 }
 
+// PromulgatedURL returns the promulgated URL for id if there
+// is one, or nil otherwise.
+func (id *ResolvedURL) PromulgatedURL() *charm.Reference {
+	if id.PromulgatedRevision == -1 {
+		return nil
+	}
+	return id.PreferredURL()
+}
+
+func (id *ResolvedURL) GoString() string {
+	if id.PromulgatedRevision != -1 {
+		return fmt.Sprintf("%d %s", id.PromulgatedRevision, &id.URL)
+	}
+	return id.URL.String()
+}
+
 // String returns the preferred string representation of u.
 // It prefers to use the promulgated URL when there is one.
 func (u *ResolvedURL) String() string {

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -329,9 +329,9 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 
 		// Add a charm to the store, used for testing.
 		err := store.AddCharmWithArchive(
-			charm.MustParseReference("~charmers/utopic/wordpress-42"),
-			nil,
-			storetesting.Charms.CharmDir("wordpress"))
+			newResolvedURL("~charmers/utopic/wordpress-42", -1),
+			storetesting.Charms.CharmDir("wordpress"),
+		)
 		c.Assert(err, gc.IsNil)
 		baseUrl := charm.MustParseReference("~charmers/wordpress")
 
@@ -465,8 +465,7 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 
 		// Add a charm to the store, used for testing.
 		err := store.AddCharmWithArchive(
-			charm.MustParseReference("~charmers/utopic/wordpress-42"),
-			nil,
+			newResolvedURL("~charmers/utopic/wordpress-42", -1),
 			storetesting.Charms.CharmDir("wordpress"))
 		c.Assert(err, gc.IsNil)
 		baseUrl := charm.MustParseReference("~charmers/wordpress")

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -15,5 +15,5 @@ var (
 	ErrProbablyNotXML              = errProbablyNotXML
 	UsernameAttr                   = usernameAttr
 	GroupsAttr                     = groupsAttr
-	GetPromulgatedURL              = (*Handler).getPromulgatedURL
+	GetNewPromulgatedRevision      = (*Handler).getNewPromulgatedRevision
 )

--- a/params/params.go
+++ b/params/params.go
@@ -41,6 +41,7 @@ type MetaAnyResponse struct {
 // See https://github.com/juju/charmstore/blob/v4/docs/API.md#post-idarchive
 type ArchiveUploadResponse struct {
 	Id *charm.Reference
+	PromulgatedId *charm.Reference		`json:",omitempty"`
 }
 
 // ExpandedId holds a charm or bundle fully qualified id.


### PR DESCRIPTION
In particular, we make AddCharm and AddBundle and friends take a ResolvedURL.
Almost all of the changes are in the tests.
