### PR TITLE
use charm tags in search as well as categories

### DIFF
--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -10,7 +10,7 @@ var (
 	esMapping = mustParseJSON(esMappingJSON)
 )
 
-const esSettingsVersion = 5
+const esSettingsVersion = 6
 
 func mustParseJSON(s string) interface{} {
 	var j json.RawMessage
@@ -226,6 +226,12 @@ const esMappingJSON = `
             }
           },
           "Categories" : {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "omit_norms" : true,
+            "index_options" : "docs"
+          },
+          "Tags" : {
             "type" : "string",
             "index" : "not_analyzed",
             "omit_norms" : true,

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -446,6 +446,7 @@ func queryFields(sp SearchParams) map[string]float64 {
 	fields := map[string]float64{
 		"URL.ngrams":              8,
 		"CharmMeta.Categories":    5,
+		"CharmMeta.Tags":          5,
 		"BundleData.Tags":         5,
 		"CharmProvidedInterfaces": 3,
 		"CharmRequiredInterfaces": 3,

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -661,6 +661,10 @@ func tagsFilter(value string) elasticsearch.Filter {
 				Value: t,
 			},
 			elasticsearch.TermFilter{
+				Field: "CharmMeta.Tags",
+				Value: t,
+			},
+			elasticsearch.TermFilter{
 				Field: "BundleData.Tags",
 				Value: t,
 			},

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -141,7 +141,13 @@ func (s *StoreSearchSuite) TestExportSearchDocument(c *gc.C) {
 func (s *StoreSearchSuite) addCharmsToStore(c *gc.C, store *Store) {
 	for name, url := range exportTestCharms {
 		charmArchive := storetesting.Charms.CharmDir(name)
-		charmArchive.Meta().Categories = strings.Split(name, "-")
+		cats := strings.Split(name, "-")
+		charmArchive.Meta().Categories = cats
+		tags := make([]string, len(cats))
+		for i, s := range cats {
+			tags[i] = s + "TAG"
+		}
+		charmArchive.Meta().Tags = tags
 		err := store.AddCharmWithArchive(url, charmArchive)
 		c.Assert(err, gc.IsNil)
 		for i := 0; i < charmDownloadCounts[name]; i++ {
@@ -393,6 +399,17 @@ var searchTests = []struct {
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
 			exportTestBundles["wordpress-simple"],
+		},
+	}, {
+		about: "charm tags filter search",
+		sp: SearchParams{
+			Text: "",
+			Filters: map[string][]string{
+				"tags": {"wordpressTAG"},
+			},
+		},
+		results: []*router.ResolvedURL{
+			exportTestCharms["wordpress"],
 		},
 	},
 }


### PR DESCRIPTION
Use CharmMeta.Tags and CharmMeta.Categories in search queries.
