### PR TITLE
internal/v4: add delegatable-macaroon endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1768,6 +1768,26 @@ Request body:
 ["joe", "frank"]
 ```
 
+### Authorization
+
+#### GET /macaroon
+
+This endpoint returns a macaroon in JSON format that, when its third
+party caveats are discharged, will allow access to the charm store. No
+prior authorization is required.
+
+#### GET /delegatable-macaroon
+
+This endpoint returns a macaroon in JSON format that can be passed to
+third parties to allow them to access the charm store on the user's
+behalf.  A first party "is-entity" caveat may be added to restrict those
+parties so that they can only access a given charmstore entity with a
+specified id.
+
+A delegatable macaroon will only be returned to an authorized user (not
+including admin). It will carry the same privileges as the macaroon used
+to authorize the request.
+
 ### Logs
 
 #### GET /log

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -16,4 +16,5 @@ var (
 	UsernameAttr                   = usernameAttr
 	GroupsAttr                     = groupsAttr
 	GetNewPromulgatedRevision      = (*Handler).getNewPromulgatedRevision
+	DelegatableMacaroonExpiry      = delegatableMacaroonExpiry
 )

--- a/internal/v4/log.go
+++ b/internal/v4/log.go
@@ -23,7 +23,7 @@ import (
 // POST /log
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#post-log
 func (h *Handler) serveLog(w http.ResponseWriter, req *http.Request) error {
-	if err := h.authorize(req, nil, nil); err != nil {
+	if _, err := h.authorize(req, nil, true, nil); err != nil {
 		return err
 	}
 	switch req.Method {

--- a/internal/v4/pprof.go
+++ b/internal/v4/pprof.go
@@ -17,7 +17,7 @@ type pprofHandler struct {
 }
 
 type authorizer interface {
-	authorize(req *http.Request, acl []string, entityId *router.ResolvedURL) error
+	authorize(req *http.Request, acl []string, alwaysAuth bool, entityId *router.ResolvedURL) (authorization, error)
 }
 
 func newPprofHandler(auth authorizer) http.Handler {
@@ -33,7 +33,7 @@ func newPprofHandler(auth authorizer) http.Handler {
 }
 
 func (h *pprofHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if err := h.auth.authorize(req, nil, nil); err != nil {
+	if _, err := h.auth.authorize(req, nil, true, nil); err != nil {
 		router.WriteError(w, err)
 		return
 	}


### PR DESCRIPTION
This will allow a client to obtain a short-lived macaroon that an environment
can use to obtain a charm on behalf of a user.
