### PR TITLE
CS: allow n-grams for search in series

### DIFF
--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -108,6 +108,7 @@ const esMappingJSON = `
             "analyzer" : "n3_20grams",
             "include_in_all" : false
           }
+        }
       },
       "TotalDownloads": {
         "type": "long"

--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -10,7 +10,7 @@ var (
 	esMapping = mustParseJSON(esMappingJSON)
 )
 
-const esSettingsVersion = 6
+const esSettingsVersion = 7
 
 func mustParseJSON(s string) interface{} {
 	var j json.RawMessage
@@ -95,10 +95,19 @@ const esMappingJSON = `
         "index" : "not_analyzed"
       },
       "Series" : {
-        "type" : "string",
-        "index" : "not_analyzed",
-        "omit_norms" : true,
-        "index_options" : "docs"
+        "type" : "multi_field",
+        "fields" : {
+          "Series" : {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "omit_norms" : true,
+            "index_options" : "docs"
+          },
+          "ngrams" : {
+            "type" : "string",
+            "analyzer" : "n3_20grams",
+            "include_in_all" : false
+          }
       },
       "TotalDownloads": {
         "type": "long"

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -508,13 +508,10 @@ type SearchResult struct {
 // elasticsearch query.
 func queryFields(sp SearchParams) map[string]float64 {
 	fields := map[string]float64{
-		"URL.ngrams":           8,
-		"CharmMeta.Categories": 5,
-		"CharmMeta.Tags":       5,
-		"BundleData.Tags":      5,
-		// TODO(uros): Series should be n-grams so that one
-		// can search for all "win*" charms/bundles even in
-		// without the series filter.
+		"URL.ngrams":              8,
+		"CharmMeta.Categories":    5,
+		"CharmMeta.Tags":          5,
+		"BundleData.Tags":         5,
 		"Series.ngrams":           5,
 		"CharmProvidedInterfaces": 3,
 		"CharmRequiredInterfaces": 3,

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -515,7 +515,7 @@ func queryFields(sp SearchParams) map[string]float64 {
 		// TODO(uros): Series should be n-grams so that one
 		// can search for all "win*" charms/bundles even in
 		// without the series filter.
-		"Series":                  5,
+		"Series.ngrams":           5,
 		"CharmProvidedInterfaces": 3,
 		"CharmRequiredInterfaces": 3,
 		"CharmMeta.Description":   1,


### PR DESCRIPTION
- allow to search for "win", "centos", even "windows" in series, no longer requiring full names (filter still requires full name)
- first step towards supporting multiple OSes in charms
