### PR TITLE
csclient: return bakery errors from more endpoints

### DIFF
--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -1065,7 +1065,8 @@ func (s *suite) TestMacaroonAuthorization(c *gc.C) {
 	var result struct{ IdRevision struct{ Revision int } }
 	// TODO 2015-01-23: once supported, rewrite the test using POST requests.
 	_, err = client.Meta(rurl.PromulgatedURL(), &result)
-	c.Assert(err, gc.ErrorMatches, `cannot get "/utopic/wordpress-42/meta/any\?include=id-revision": cannot get discharge from ".*": cannot discharge: no discharge`)
+	c.Assert(err, gc.ErrorMatches, `cannot get "/utopic/wordpress-42/meta/any\?include=id-revision": cannot get discharge from ".*": third party refused discharge: cannot discharge: no discharge`)
+	c.Assert(httpbakery.IsDischargeError(errgo.Cause(err)), gc.Equals, true)
 
 	s.discharge = func(cond, arg string) ([]checkers.Caveat, error) {
 		return []checkers.Caveat{checkers.DeclaredCaveat("username", "bob")}, nil
@@ -1095,4 +1096,5 @@ func (s *suite) TestMacaroonAuthorization(c *gc.C) {
 	_, err = client.Meta(rurl.PromulgatedURL(), &result)
 	c.Assert(err, gc.ErrorMatches, `cannot get "/utopic/wordpress-42/meta/any\?include=id-revision": cannot get discharge from ".*": cannot start interactive session: stopping interaction`)
 	c.Assert(result.IdRevision.Revision, gc.Equals, rurl.URL.Revision)
+	c.Assert(httpbakery.IsInteractionError(errgo.Cause(err)), gc.Equals, true)
 }

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -18,7 +18,7 @@ golang.org/x/crypto	git	4ed45ec682102c643324fae5dff8dab085b6c300	2015-01-12T22:0
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
 gopkg.in/juju/charm.v5-unstable	git	94b03fbac2d2ecc2ee6967ef4c229d228e591a53	2015-04-03T16:53:10Z
-gopkg.in/macaroon-bakery.v0	git	03628d9b61db1eeef27468c926eefd15ad10be67	2015-02-20T14:21:09Z
+gopkg.in/macaroon-bakery.v0	git	071a85896ea9b4a2470a26eeeb67c3154bff69cf	2015-04-07T11:04:30Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	c6a7dce14133ccac2dcac3793f1d6e2ef048503a	2015-01-24T11:37:54Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -159,7 +159,7 @@ func testMacaroonAuth(c *gc.C, session *mgo.Session, p httptesting.JSONCallParam
 	dischargeError = fmt.Errorf("go away")
 	p.Password = ""
 	p.Username = ""
-	p.ExpectError = `cannot get discharge from "http://[^"]*": cannot discharge: go away`
+	p.ExpectError = `cannot get discharge from "http://[^"]*": third party refused discharge: cannot discharge: go away`
 	httptesting.AssertJSONCall(c, p)
 }
 


### PR DESCRIPTION
This will allow users of csclient to determine when authorization errors
are returned from httpbakery.
