### PR TITLE
internal/charmstore: copy mgo sessions

### DIFF
--- a/cmd/cshash256/main.go
+++ b/cmd/cshash256/main.go
@@ -69,10 +69,12 @@ func run(confPath string) error {
 	db := session.DB("juju")
 
 	logger.Infof("instantiating the store")
-	store, err := charmstore.NewStore(db, nil, nil)
+	pool, err := charmstore.NewPool(db, nil, nil)
 	if err != nil {
 		return errgo.Notef(err, "cannot create a new store")
 	}
+	store := pool.Store()
+	defer store.Close()
 
 	logger.Infof("updating entities")
 	if err := update(store); err != nil {

--- a/cmd/essync/main.go
+++ b/cmd/essync/main.go
@@ -70,11 +70,14 @@ func populate(confPath string) error {
 	}
 	defer session.Close()
 	db := session.DB("juju")
-	s, err := charmstore.NewStore(db, si, nil)
+
+	pool, err := charmstore.NewPool(db, si, nil)
 	if err != nil {
-		return errgo.Notef(err, "cannot create store")
+		return errgo.Notef(err, "cannot create a new store")
 	}
-	if err := s.SynchroniseElasticsearch(); err != nil {
+	store := pool.Store()
+	defer store.Close()
+	if err := store.SynchroniseElasticsearch(); err != nil {
 		return errgo.Notef(err, "cannot synchronise elasticsearch")
 	}
 	return nil

--- a/csclient/csclient_test.go
+++ b/csclient/csclient_test.go
@@ -73,12 +73,12 @@ func (s *suite) startServer(c *gc.C, session *mgo.Session) {
 	}
 
 	db := session.DB("charmstore")
-	store, err := internalCharmstore.NewStore(db, nil, nil)
+	pool, err := internalCharmstore.NewPool(db, nil, nil)
 	c.Assert(err, gc.IsNil)
 	handler, err := charmstore.NewServer(db, nil, "", serverParams, charmstore.V4)
 	c.Assert(err, gc.IsNil)
 	s.srv = httptest.NewServer(handler)
-	s.store = store
+	s.store = pool.Store()
 	s.serverParams = serverParams
 
 }
@@ -95,6 +95,7 @@ func (s *suite) SetUpTest(c *gc.C) {
 
 func (s *suite) TearDownTest(c *gc.C) {
 	s.srv.Close()
+	s.store.Close()
 	s.IsolatedMgoSuite.TearDownTest(c)
 }
 

--- a/internal/charmstore/hash.go
+++ b/internal/charmstore/hash.go
@@ -35,7 +35,9 @@ func (s *Store) UpdateEntitySHA256(id *router.ResolvedURL) (string, error) {
 	// Update the entry asynchronously because it doesn't matter if it succeeds
 	// or fails, or if several instances of the charm store do it concurrently,
 	// and it doesn't need to be on the critical path for API endpoints.
-	go UpdateEntitySHA256(s, id, sum256)
+	s.Go(func(s *Store) {
+		UpdateEntitySHA256(s, id, sum256)
+	})
 
 	return sum256, nil
 }

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -35,7 +35,7 @@ func (s *migrationsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *migrationsSuite) newServer(c *gc.C) error {
-	apiHandler := func(store *Store, config ServerParams) http.Handler {
+	apiHandler := func(p *Pool, config ServerParams) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})
 	}
 	_, err := NewServer(s.db.Database, nil, serverParams, map[string]NewAPIHandlerFunc{

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -69,11 +69,11 @@ type SearchDoc struct {
 // UpdateSearchAsync will update the search record for the entity
 // reference r in the backgroud.
 func (s *Store) UpdateSearchAsync(r *router.ResolvedURL) {
-	go func() {
+	s.Go(func(s *Store) {
 		if err := s.UpdateSearch(r); err != nil {
 			logger.Errorf("cannot update search record for %v: %s", r, err)
 		}
-	}()
+	})
 }
 
 // UpdateSearch updates the search record for the entity reference r.

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -38,8 +38,7 @@ type versionResponse struct {
 func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	db := s.Session.DB("foo")
 	serveVersion := func(vers string) NewAPIHandlerFunc {
-		return func(store *Store, config ServerParams) http.Handler {
-			c.Assert(store.DB.Database, gc.Equals, db)
+		return func(p *Pool, config ServerParams) http.Handler {
 			return router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 				return versionResponse{
 					Version: vers,
@@ -86,7 +85,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 }
 
 func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
-	serveConfig := func(store *Store, config ServerParams) http.Handler {
+	serveConfig := func(p *Pool, config ServerParams) http.Handler {
 		return router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 			return config, nil
 		})
@@ -103,7 +102,7 @@ func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
 }
 
 func (s *ServerSuite) TestNewServerWithElasticSearch(c *gc.C) {
-	serveConfig := func(store *Store, config ServerParams) http.Handler {
+	serveConfig := func(p *Pool, config ServerParams) http.Handler {
 		return router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 			return config, nil
 		})

--- a/internal/charmstore/stats_test.go
+++ b/internal/charmstore/stats_test.go
@@ -25,12 +25,13 @@ var _ = gc.Suite(&StatsSuite{})
 
 func (s *StatsSuite) SetUpTest(c *gc.C) {
 	s.IsolatedMgoSuite.SetUpTest(c)
-	store, err := charmstore.NewStore(s.Session.DB("foo"), nil, nil)
+	pool, err := charmstore.NewPool(s.Session.DB("foo"), nil, nil)
 	c.Assert(err, gc.IsNil)
-	s.store = store
+	s.store = pool.Store()
 }
 
 func (s *StatsSuite) TearDownTest(c *gc.C) {
+	s.store.Close()
 	s.IsolatedMgoSuite.TearDownTest(c)
 }
 
@@ -264,8 +265,10 @@ func (s *StatsSuite) TestListCounters(c *gc.C) {
 	}
 
 	// Use a different store to exercise cache filling.
-	st, err := charmstore.NewStore(s.store.DB.Database, nil, nil)
+	pool, err := charmstore.NewPool(s.store.DB.Database, nil, nil)
 	c.Assert(err, gc.IsNil)
+	st := pool.Store()
+	defer st.Close()
 
 	for i := range tests {
 		req := &charmstore.CounterRequest{Key: tests[i].prefix, Prefix: true, List: true}

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -49,13 +49,18 @@ func (s *APISuite) SetUpTest(c *gc.C) {
 	s.srv, s.store = newServer(c, s.Session, serverParams)
 }
 
+func (s *APISuite) TearDownTest(c *gc.C) {
+	s.store.Close()
+	s.IsolatedMgoSuite.TearDownTest(c)
+}
+
 func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (http.Handler, *charmstore.Store) {
 	db := session.DB("charmstore")
-	store, err := charmstore.NewStore(db, nil, nil)
+	pool, err := charmstore.NewPool(db, nil, nil)
 	c.Assert(err, gc.IsNil)
 	srv, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"": legacy.NewAPIHandler})
 	c.Assert(err, gc.IsNil)
-	return srv, store
+	return srv, pool.Store()
 }
 
 func (s *APISuite) TestCharmArchive(c *gc.C) {

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -50,6 +50,11 @@ func (s *ArchiveSuite) SetUpTest(c *gc.C) {
 	s.srv, s.store = newServer(c, s.Session, nil, serverParams)
 }
 
+func (s *ArchiveSuite) TearDownTest(c *gc.C) {
+	s.store.Close()
+	s.IsolatedMgoSuite.TearDownTest(c)
+}
+
 func (s *ArchiveSuite) TestGet(c *gc.C) {
 	patchArchiveCacheAges(s)
 	wordpress := s.assertUploadCharm(c, "POST", newResolvedURL("cs:~charmers/precise/wordpress-0", -1), "wordpress")
@@ -930,7 +935,7 @@ func (s *ArchiveSuite) TestBundleCharms(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Retrieve the bundleCharms method.
-	handler := v4.New(s.store, serverParams)
+	handler := v4.New(s.store.Pool(), serverParams)
 
 	tests := []struct {
 		about  string
@@ -1392,7 +1397,7 @@ func (s *ArchiveSuite) TestGetNewPromulgatedRevision(c *gc.C) {
 		})
 		c.Assert(err, gc.IsNil)
 	}
-	handler := v4.New(s.store, serverParams)
+	handler := v4.New(s.store.Pool(), serverParams)
 	for i, test := range getNewPromulgatedRevisionTests {
 		c.Logf("%d. %s", i, test.about)
 		rev, err := v4.GetNewPromulgatedRevision(handler, test.id)
@@ -1451,6 +1456,11 @@ func (s *ArchiveSearchSuite) SetUpTest(c *gc.C) {
 
 	si := charmstore.SearchIndex{s.ES, s.TestIndex}
 	s.srv, s.store = newServer(c, s.Session, &si, serverParams)
+}
+
+func (s *ArchiveSearchSuite) TearDownTest(c *gc.C) {
+	s.store.Close()
+	s.IsolatedMgoESSuite.TearDownTest(c)
 }
 
 func (s *ArchiveSearchSuite) TestGetSearchUpdate(c *gc.C) {

--- a/internal/v4/log_test.go
+++ b/internal/v4/log_test.go
@@ -34,6 +34,11 @@ func (s *logSuite) SetUpTest(c *gc.C) {
 	s.srv, s.store = newServer(c, s.Session, nil, serverParams)
 }
 
+func (s *logSuite) TearDownTest(c *gc.C) {
+	s.store.Close()
+	s.IsolatedMgoSuite.TearDownTest(c)
+}
+
 var logResponses = map[string]*params.LogResponse{
 	"info1": {
 		Data:  rawMessage("info data 1"),

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -53,9 +53,11 @@ func (h *Handler) metaCharmRelated(entity *mongodoc.Entity, id *router.ResolvedU
 		{"promulgated-revision", 1},
 	}
 
+	store := h.pool.Store()
+	defer store.Close()
 	// Retrieve the entities from the database.
 	var entities []mongodoc.Entity
-	if err := h.store.DB.Entities().Find(query).Select(fields).Sort("_id").All(&entities); err != nil {
+	if err := store.DB.Entities().Find(query).Select(fields).Sort("_id").All(&entities); err != nil {
 		return nil, errgo.Notef(err, "cannot retrieve the related charms")
 	}
 
@@ -179,9 +181,11 @@ func (h *Handler) metaBundlesContaining(entity *mongodoc.Entity, id *router.Reso
 		searchId.Series = ""
 	}
 
+	store := h.pool.Store()
+	defer store.Close()
 	// Retrieve the bundles containing the resulting charm id.
 	var entities []*mongodoc.Entity
-	if err := h.store.DB.Entities().
+	if err := store.DB.Entities().
 		Find(bson.D{{"bundlecharms", &searchId}}).
 		Select(bson.D{{"_id", 1}, {"bundlecharms", 1}, {"promulgated-url", 1}}).
 		All(&entities); err != nil {

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -45,6 +45,11 @@ func (s *RelationsSuite) SetUpTest(c *gc.C) {
 	s.srv, s.store = newServer(c, s.Session, nil, serverParams)
 }
 
+func (s *RelationsSuite) TearDownTest(c *gc.C) {
+	s.store.Close()
+	s.IsolatedMgoSuite.TearDownTest(c)
+}
+
 // metaCharmRelatedCharms defines a bunch of charms to be used in
 // the relation tests.
 var metaCharmRelatedCharms = map[string]charm.Charm{

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -35,7 +35,9 @@ func (h *Handler) serveSearch(_ http.Header, req *http.Request) (interface{}, er
 	}
 	sp.Groups = append(sp.Groups, auth.Groups...)
 	// perform query
-	results, err := h.store.Search(sp)
+	store := h.pool.Store()
+	defer store.Close()
+	results, err := store.Search(sp)
 	if err != nil {
 		return nil, errgo.Notef(err, "error performing search")
 	}

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -74,6 +74,7 @@ func (s *SearchSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *SearchSuite) TearDownTest(c *gc.C) {
+	s.store.Close()
 	s.IsolatedMgoESSuite.TearDownTest(c)
 }
 

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -77,7 +77,9 @@ func (h *Handler) serveStatsCounter(_ http.Header, r *http.Request) (interface{}
 			return nil, errgo.WithCausef(nil, params.ErrForbidden, "unknown key")
 		}
 	}
-	entries, err := h.store.Counters(&req)
+	store := h.pool.Store()
+	defer store.Close()
+	entries, err := store.Counters(&req)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot query counters")
 	}

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -32,6 +32,11 @@ func (s *StatsSuite) SetUpTest(c *gc.C) {
 	s.srv, s.store = newServer(c, s.Session, nil, serverParams)
 }
 
+func (s *StatsSuite) TearDownTest(c *gc.C) {
+	s.store.Close()
+	s.IsolatedMgoSuite.TearDownTest(c)
+}
+
 func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 	tests := []struct {
 		path    string


### PR DESCRIPTION
We introduce a new Pool type which cannot be used for
charmstore operations, forcing clients to call Store to
operate on it.
