### PR TITLE
internal/charmstore: add /debug/check endpoint

### DIFF
--- a/internal/charmstore/debug.go
+++ b/internal/charmstore/debug.go
@@ -4,7 +4,14 @@
 package charmstore
 
 import (
+	"fmt"
 	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/mgo.v2"
 
 	"gopkg.in/juju/charmstore.v4/internal/router"
 	appver "gopkg.in/juju/charmstore.v4/version"
@@ -15,8 +22,75 @@ func serveDebugInfo(http.Header, *http.Request) (interface{}, error) {
 	return appver.VersionInfo, nil
 }
 
-func newServiceDebugHandler() http.Handler {
+// GET /debug/check.
+func debugCheck(checks map[string]func() error) http.Handler {
+	return router.HandleJSON(func(http.Header, *http.Request) (interface{}, error) {
+		n := len(checks)
+		type result struct {
+			name string
+			err  error
+		}
+		c := make(chan result)
+		for name, check := range checks {
+			name, check := name, check
+			go func() {
+				c <- result{name: name, err: check()}
+			}()
+		}
+		results := make(map[string]string, n)
+		var failed bool
+		for ; n > 0; n-- {
+			res := <-c
+			if res.err == nil {
+				results[res.name] = "OK"
+			} else {
+				failed = true
+				results[res.name] = res.err.Error()
+			}
+		}
+		if failed {
+			keys := make([]string, 0, len(results))
+			for k := range results {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			msgs := make([]string, len(results))
+			for i, k := range keys {
+				msgs[i] = fmt.Sprintf("[%s: %s]", k, results[k])
+			}
+			return nil, errgo.Newf("check failure: %s", strings.Join(msgs, " "))
+		}
+		return results, nil
+	})
+}
+
+func checkDB(db *mgo.Database) func() error {
+	return func() error {
+		s := db.Session.Copy()
+		s.SetSyncTimeout(500 * time.Millisecond)
+		defer s.Close()
+		return s.Ping()
+	}
+}
+
+func checkES(si *SearchIndex) func() error {
+	if si == nil || si.Database == nil {
+		return func() error {
+			return nil
+		}
+	}
+	return func() error {
+		_, err := si.Health()
+		return err
+	}
+}
+
+func newServiceDebugHandler(db *mgo.Database, si *SearchIndex) http.Handler {
 	mux := router.NewServeMux()
 	mux.Handle("/info", router.HandleJSON(serveDebugInfo))
+	mux.Handle("/check", debugCheck(map[string]func() error{
+		"mongodb":       checkDB(db),
+		"elasticsearch": checkES(si),
+	}))
 	return mux
 }

--- a/internal/charmstore/debug_test.go
+++ b/internal/charmstore/debug_test.go
@@ -1,0 +1,100 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmstore
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/juju/testing/httptesting"
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/juju/charmstore.v4/internal/router"
+	"gopkg.in/juju/charmstore.v4/params"
+	appver "gopkg.in/juju/charmstore.v4/version"
+)
+
+type debugSuite struct{}
+
+var _ = gc.Suite(&debugSuite{})
+
+var debugCheckTests = []struct {
+	about        string
+	checks       map[string]func() error
+	expectStatus int
+	expectBody   interface{}
+}{{
+	about:        "no checks",
+	expectStatus: http.StatusOK,
+	expectBody:   map[string]string{},
+}, {
+	about: "passing check",
+	checks: map[string]func() error{
+		"pass": func() error { return nil },
+	},
+	expectStatus: http.StatusOK,
+	expectBody: map[string]string{
+		"pass": "OK",
+	},
+}, {
+	about: "failing check",
+	checks: map[string]func() error{
+		"fail": func() error { return errors.New("test fail") },
+	},
+	expectStatus: http.StatusInternalServerError,
+	expectBody: params.Error{
+		Message: "check failure: [fail: test fail]",
+	},
+}, {
+	about: "many pass",
+	checks: map[string]func() error{
+		"pass1": func() error { return nil },
+		"pass2": func() error { return nil },
+	},
+	expectStatus: http.StatusOK,
+	expectBody: map[string]string{
+		"pass1": "OK",
+		"pass2": "OK",
+	},
+}, {
+	about: "many fail",
+	checks: map[string]func() error{
+		"fail1": func() error { return errors.New("test fail1") },
+		"fail2": func() error { return errors.New("test fail2") },
+	},
+	expectStatus: http.StatusInternalServerError,
+	expectBody: params.Error{
+		Message: "check failure: [fail1: test fail1] [fail2: test fail2]",
+	},
+}, {
+	about: "pass and fail",
+	checks: map[string]func() error{
+		"pass": func() error { return nil },
+		"fail": func() error { return errors.New("test fail") },
+	},
+	expectStatus: http.StatusInternalServerError,
+	expectBody: params.Error{
+		Message: "check failure: [fail: test fail] [pass: OK]",
+	},
+}}
+
+func (s *debugSuite) TestDebugCheck(c *gc.C) {
+	for i, test := range debugCheckTests {
+		c.Logf("%d. %s", i, test.about)
+		hnd := debugCheck(test.checks)
+		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+			Handler:      hnd,
+			ExpectStatus: test.expectStatus,
+			ExpectBody:   test.expectBody,
+		})
+	}
+}
+
+func (s *debugSuite) TestDebugInfo(c *gc.C) {
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      router.HandleJSON(serveDebugInfo),
+		ExpectStatus: http.StatusOK,
+		ExpectBody:   appver.VersionInfo,
+	})
+}

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -71,7 +71,7 @@ func NewServer(db *mgo.Database, si *SearchIndex, config ServerParams, versions 
 	})
 	mux := router.NewServeMux()
 	// Version independent API.
-	handle(mux, "/debug", newServiceDebugHandler())
+	handle(mux, "/debug", newServiceDebugHandler(db, si))
 	for vers, newAPI := range versions {
 		handle(mux, "/"+vers, newAPI(pool, config))
 	}


### PR DESCRIPTION
Add a /debug/check endpoint to quickly assess health.
