### PR TITLE
internal/v4: get groups from identity manager; reorganise test suite

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -11,8 +11,9 @@ github.com/juju/names	git	ce4ecb2967822062fc606e733919c677c584ab7e	2015-02-20T07
 github.com/juju/schema	git	27a52be50766490a6fd3531865095fda6c0eeb6d	2014-07-23T04:23:18Z
 github.com/juju/testing	git	c7042d828963caa252862b759ef56ada297e8323	2015-04-21T10:32:42Z
 github.com/juju/txn	git	e02f26c56cfb81c7c1236df499deebb0369bd97c	2014-09-25T11:49:22Z
-github.com/juju/utils	git	d8a12b2e10ef0baceaefbd5762853db024307f3a	2015-04-20T16:53:26Z
+github.com/juju/utils	git	a90aa2e02b9e7fe354ab816e05b1e0a77f27242d	2015-02-23T16:02:32Z
 github.com/juju/xml	git	91535ba18a6afd756e38a40c91fea0ed8e5dbaa6	2014-12-04T14:59:31Z
+github.com/julienschmidt/httprouter	git	b59a38004596b696aca7aa2adccfa68760864d86	2015-04-08T17:04:29Z
 golang.org/x/crypto	git	4ed45ec682102c643324fae5dff8dab085b6c300	2015-01-12T22:01:33Z
 golang.org/x/net	git	7dbad50ab5b31073856416cdcfeb2796d682f844	2015-03-20T03:46:21Z
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -880,7 +880,6 @@ func (h *Handler) serveDelegatableMacaroon(_ http.Header, req *http.Request) (in
 	// TODO propagate expiry time from macaroons in request.
 	m, err := store.Bakery.NewMacaroon("", nil, []checkers.Caveat{
 		checkers.DeclaredCaveat(usernameAttr, auth.Username),
-		checkers.DeclaredCaveat(groupsAttr, strings.Join(auth.Groups, " ")),
 		checkers.TimeBeforeCaveat(time.Now().Add(delegatableMacaroonExpiry)),
 	})
 	if err != nil {

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -1,0 +1,221 @@
+package v4_test
+
+import (
+	"encoding/json"
+	gc "gopkg.in/check.v1"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/julienschmidt/httprouter"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon-bakery.v0/bakery"
+	"gopkg.in/macaroon-bakery.v0/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v0/bakerytest"
+	"gopkg.in/macaroon-bakery.v0/httpbakery"
+
+	"gopkg.in/juju/charmstore.v4/internal/charmstore"
+	"gopkg.in/juju/charmstore.v4/internal/storetesting"
+	"gopkg.in/juju/charmstore.v4/internal/v4"
+)
+
+type commonSuite struct {
+	storetesting.IsolatedMgoSuite
+
+	// srv holds the store HTTP handler.
+	srv http.Handler
+
+	// srvParams holds the parameters that the
+	// srv handler was started with
+	srvParams charmstore.ServerParams
+
+	// noMacaroonSrv holds the store HTTP handler
+	// for an instance of the store without identity
+	// enabled. If enableIdentity is false, this is
+	// the same as srv.
+	noMacaroonSrv http.Handler
+
+	// noMacaroonSrvParams holds the parameters that the
+	// noMacaroonSrv handler was started with
+	noMacaroonSrvParams charmstore.ServerParams
+
+	// store holds an instance of *charm.Store
+	// that can be used to access the charmstore database
+	// directly.
+	store *charmstore.Store
+
+	// esSuite is set only when enableES is set to true.
+	esSuite *storetesting.ElasticSearchSuite
+
+	// discharge holds the function that will be used
+	// to check third party caveats by the mock
+	// discharger. This will be ignored if enableIdentity was
+	// not true before commonSuite.SetUpTest is invoked.
+	//
+	// It may be set by tests to influence the behavior of the
+	// discharger.
+	discharge func(cav, arg string) ([]checkers.Caveat, error)
+
+	discharger *bakerytest.Discharger
+	idM        *idM
+	idMServer  *httptest.Server
+
+	// The following fields may be set before
+	// SetUpSuite is invoked on commonSuite
+	// and influences how the suite sets itself up.
+
+	// enableIdentity holds whether the charmstore server
+	// will be started with a configured identity service.
+	enableIdentity bool
+
+	// enableES holds whether the charmstore server will be
+	// started with Elastic Search enabled.
+	enableES bool
+}
+
+func (s *commonSuite) SetUpSuite(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpSuite(c)
+	if s.enableES {
+		s.esSuite = new(storetesting.ElasticSearchSuite)
+		s.esSuite.SetUpSuite(c)
+	}
+}
+
+func (s *commonSuite) TearDownSuite(c *gc.C) {
+	if s.esSuite != nil {
+		s.esSuite.TearDownSuite(c)
+	}
+}
+
+func (s *commonSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	if s.esSuite != nil {
+		s.esSuite.SetUpTest(c)
+	}
+	if s.enableIdentity {
+		s.idM = newIdM()
+		s.idMServer = httptest.NewServer(s.idM)
+	}
+	s.startServer(c)
+}
+
+func (s *commonSuite) TearDownTest(c *gc.C) {
+	s.store.Close()
+	if s.esSuite != nil {
+		s.esSuite.TearDownTest(c)
+	}
+	if s.discharger != nil {
+		s.discharger.Close()
+		s.idMServer.Close()
+	}
+	s.IsolatedMgoSuite.TearDownTest(c)
+}
+
+// startServer creates a new charmstore server.
+func (s *commonSuite) startServer(c *gc.C) {
+	config := charmstore.ServerParams{
+		AuthUsername: testUsername,
+		AuthPassword: testPassword,
+	}
+	if s.enableIdentity {
+		s.discharge = func(_, _ string) ([]checkers.Caveat, error) {
+			return nil, errgo.New("no discharge")
+		}
+		discharger := bakerytest.NewDischarger(nil, func(_ *http.Request, cond string, arg string) ([]checkers.Caveat, error) {
+			return s.discharge(cond, arg)
+		})
+		config.IdentityLocation = discharger.Location()
+		config.PublicKeyLocator = discharger
+		config.IdentityAPIURL = s.idMServer.URL
+	}
+	var si *charmstore.SearchIndex
+	if s.enableES {
+		si = &charmstore.SearchIndex{
+			Database: s.esSuite.ES,
+			Index:    s.esSuite.TestIndex,
+		}
+	}
+	db := s.Session.DB("charmstore")
+	var err error
+	s.srv, err = charmstore.NewServer(db, si, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
+	c.Assert(err, gc.IsNil)
+	s.srvParams = config
+
+	if s.enableIdentity {
+		config.IdentityLocation = ""
+		config.PublicKeyLocator = nil
+		config.IdentityAPIURL = ""
+		s.noMacaroonSrv, err = charmstore.NewServer(db, si, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
+		c.Assert(err, gc.IsNil)
+	} else {
+		s.noMacaroonSrv = s.srv
+	}
+	s.noMacaroonSrvParams = config
+
+	pool, err := charmstore.NewPool(db, si, &bakery.NewServiceParams{})
+	c.Assert(err, gc.IsNil)
+	s.store = pool.Store()
+}
+
+func storeURL(path string) string {
+	return "/v4/" + path
+}
+
+func bakeryDo(client *http.Client) func(*http.Request) (*http.Response, error) {
+	if client == nil {
+		client = httpbakery.NewHTTPClient()
+	}
+	return func(req *http.Request) (*http.Response, error) {
+		if req.Body != nil {
+			return httpbakery.DoWithBody(client, req, httpbakery.SeekerBody(req.Body.(io.ReadSeeker)), noInteraction)
+		}
+		return httpbakery.Do(client, req, noInteraction)
+	}
+}
+
+type idM struct {
+	// groups may be set to determine the mapping
+	// from user to groups for that user.
+	groups map[string][]string
+
+	// body may be set to cause serveGroups to return
+	// an arbitrary HTTP response body.
+	body string
+
+	// status may be set to indicate the HTTP status code
+	// when body is not nil.
+	status int
+
+	router *httprouter.Router
+}
+
+func newIdM() *idM {
+	idM := &idM{
+		groups: make(map[string][]string),
+		router: httprouter.New(),
+	}
+	idM.router.GET("/v1/u/:user/idpgroups", idM.serveGroups)
+	return idM
+}
+
+func (idM *idM) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	idM.router.ServeHTTP(w, req)
+}
+
+func (idM *idM) serveGroups(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	if idM.body != "" {
+		if idM.status != 0 {
+			w.WriteHeader(idM.status)
+		}
+		w.Write([]byte(idM.body))
+		return
+	}
+	u := p.ByName("user")
+	if u == "" {
+		panic("no user")
+	}
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(idM.groups[u]); err != nil {
+		panic(err)
+	}
+}

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -14,7 +14,7 @@ var (
 	ProcessIcon                    = processIcon
 	ErrProbablyNotXML              = errProbablyNotXML
 	UsernameAttr                   = usernameAttr
-	GroupsAttr                     = groupsAttr
 	GetNewPromulgatedRevision      = (*Handler).getNewPromulgatedRevision
 	DelegatableMacaroonExpiry      = delegatableMacaroonExpiry
+	GroupsForUser                  = (*Handler).groupsForUser
 )

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -20,7 +20,6 @@ import (
 	"gopkg.in/juju/charmstore.v4/internal/blobstore"
 	"gopkg.in/juju/charmstore.v4/internal/charmstore"
 	"gopkg.in/juju/charmstore.v4/internal/router"
-	"gopkg.in/juju/charmstore.v4/internal/storetesting"
 	"gopkg.in/juju/charmstore.v4/params"
 )
 
@@ -33,22 +32,10 @@ var fakeBlobSize, fakeBlobHash = func() (int64, string) {
 }()
 
 type RelationsSuite struct {
-	storetesting.IsolatedMgoSuite
-	srv   http.Handler
-	store *charmstore.Store
+	commonSuite
 }
 
 var _ = gc.Suite(&RelationsSuite{})
-
-func (s *RelationsSuite) SetUpTest(c *gc.C) {
-	s.IsolatedMgoSuite.SetUpTest(c)
-	s.srv, s.store = newServer(c, s.Session, nil, serverParams)
-}
-
-func (s *RelationsSuite) TearDownTest(c *gc.C) {
-	s.store.Close()
-	s.IsolatedMgoSuite.TearDownTest(c)
-}
 
 // metaCharmRelatedCharms defines a bunch of charms to be used in
 // the relation tests.

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -32,8 +32,12 @@ func (h *Handler) serveSearch(_ http.Header, req *http.Request) (interface{}, er
 	sp.Admin = auth.Admin
 	if auth.Username != "" {
 		sp.Groups = append(sp.Groups, auth.Username)
+		groups, err := h.groupsForUser(auth.Username)
+		if err != nil {
+			logger.Infof("cannot get groups for user %q, assuming no groups: %v", auth.Username, err)
+		}
+		sp.Groups = append(sp.Groups, groups...)
 	}
-	sp.Groups = append(sp.Groups, auth.Groups...)
 	// perform query
 	store := h.pool.Store()
 	defer store.Close()

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -20,22 +20,10 @@ import (
 )
 
 type StatsSuite struct {
-	storetesting.IsolatedMgoSuite
-	srv   http.Handler
-	store *charmstore.Store
+	commonSuite
 }
 
 var _ = gc.Suite(&StatsSuite{})
-
-func (s *StatsSuite) SetUpTest(c *gc.C) {
-	s.IsolatedMgoSuite.SetUpTest(c)
-	s.srv, s.store = newServer(c, s.Session, nil, serverParams)
-}
-
-func (s *StatsSuite) TearDownTest(c *gc.C) {
-	s.store.Close()
-	s.IsolatedMgoSuite.TearDownTest(c)
-}
 
 func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 	tests := []struct {

--- a/internal/v4/status_test.go
+++ b/internal/v4/status_test.go
@@ -110,18 +110,6 @@ func (s *APISuite) TestStatus(c *gc.C) {
 	})
 }
 
-func (s *APISuite) TestStatusWithElasticSearch(c *gc.C) {
-	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv_es,
-		URL:     storeURL("debug/status"),
-	})
-	var results map[string]params.DebugStatus
-	err := json.Unmarshal(rec.Body.Bytes(), &results)
-	c.Assert(err, gc.IsNil)
-	c.Assert(results["elasticsearch"].Name, gc.Equals, "Elastic search is running")
-	c.Assert(results["elasticsearch"].Value, jc.Contains, "cluster_name:")
-}
-
 func (s *APISuite) TestStatusWithoutCorrectCollections(c *gc.C) {
 	s.store.DB.Entities().DropCollection()
 	s.AssertDebugStatus(c, false, map[string]params.DebugStatus{
@@ -267,4 +255,27 @@ func (s *APISuite) AssertDebugStatus(c *gc.C, complete bool, status map[string]p
 		gotStatus[key] = r
 	}
 	c.Assert(gotStatus, jc.DeepEquals, status)
+}
+
+type statusWithElasticSearchSuite struct {
+	commonSuite
+}
+
+var _ = gc.Suite(&statusWithElasticSearchSuite{})
+
+func (s *statusWithElasticSearchSuite) SetUpSuite(c *gc.C) {
+	s.enableES = true
+	s.commonSuite.SetUpSuite(c)
+}
+
+func (s *statusWithElasticSearchSuite) TestStatusWithElasticSearch(c *gc.C) {
+	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL("debug/status"),
+	})
+	var results map[string]params.DebugStatus
+	err := json.Unmarshal(rec.Body.Bytes(), &results)
+	c.Assert(err, gc.IsNil)
+	c.Assert(results["elasticsearch"].Name, gc.Equals, "Elastic search is running")
+	c.Assert(results["elasticsearch"].Value, jc.Contains, "cluster_name:")
 }

--- a/server.go
+++ b/server.go
@@ -46,12 +46,23 @@ type ServerParams struct {
 	AuthPassword string
 
 	// IdentityLocation holds the location of the third party authorization
-	// service to use when creating third party caveats.
+	// service to use when creating third party caveats,
+	// for example: http://api.jujucharms.com/identity/v1/discharger
+	// If it is empty, IdentityURL+"/v1/discharger" will be used.
 	IdentityLocation string
 
 	// PublicKeyLocator holds a public key store.
 	// It may be nil.
 	PublicKeyLocator bakery.PublicKeyLocator
+
+	// IdentityAPIURL holds the URL of the identity manager,
+	// for example http://api.jujucharms.com/identity
+	IdentityAPIURL string
+
+	// IdentityAPIUsername and IdentityAPIPassword hold the credentials
+	// to be used when querying the identity manager API.
+	IdentityAPIUsername string
+	IdentityAPIPassword string
 }
 
 // NewServer returns a new handler that handles charm store requests and stores


### PR DESCRIPTION
The test suite reorganisation creates a new commonSuite which
contains the logic for discharging and serving the mock identity
manager.

We haven't yet added the new attributes to the configuration file
format, so it's not possible to directly QA this yet (next PR).

Also, we currently do no caching of user groups (although we only
ask for groups when we need them). That's also a matter for
a subsequent PR.
