### PR TITLE
charmd: use identity URL

### DIFF
--- a/cmd/charmd/config.yaml
+++ b/cmd/charmd/config.yaml
@@ -6,6 +6,9 @@ auth-password: example-passwd
 # For locally running services.
 identity-public-key: CIdWcEUN+0OZnKW9KwruRQnQDY/qqzVdD30CijwiWCk=
 identity-location: http://localhost:8081/v1/discharger
+identity-api-url: http://localhost:8081
+identity-api-username: admin
+identity-api-password: password
 # For production identity manager.
 #identity-public-key: hmHaPgCC1UfuhYHUSX5+aihSAZesqpVdjRv0mgfIwjo=
 #identity-location: https://api.jujucharms.com/identity/v1/discharger

--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -72,9 +72,12 @@ func serve(confPath string) error {
 
 	logger.Infof("setting up the API server")
 	cfg := charmstore.ServerParams{
-		AuthUsername:     conf.AuthUsername,
-		AuthPassword:     conf.AuthPassword,
-		IdentityLocation: conf.IdentityLocation,
+		AuthUsername:        conf.AuthUsername,
+		AuthPassword:        conf.AuthPassword,
+		IdentityLocation:    conf.IdentityLocation,
+		IdentityAPIURL:      conf.IdentityAPIURL,
+		IdentityAPIUsername: conf.IdentityAPIUsername,
+		IdentityAPIPassword: conf.IdentityAPIPassword,
 	}
 	var identityPublicKey bakery.PublicKey
 	err = identityPublicKey.UnmarshalText([]byte(conf.IdentityPublicKey))

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,10 @@ type Config struct {
 	ESAddr            string `yaml:"elasticsearch-addr"` // elasticsearch is optional
 	IdentityPublicKey string `yaml:"identity-public-key"`
 	IdentityLocation  string `yaml:"identity-location"`
+	// The identity API is optional
+	IdentityAPIURL      string `yaml:"identity-api-url"`
+	IdentityAPIUsername string `yaml:"identity-api-username"`
+	IdentityAPIPassword string `yaml:"identity-api-password"`
 }
 
 func (c *Config) validate() error {


### PR DESCRIPTION
Add the configuration to the charmd command so that charmstore can retrieve group information from IdM.
