### PR TITLE
internal/legacy: check authorization in gated charms

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -110,7 +110,7 @@ func New(pool *charmstore.Pool, config charmstore.ServerParams) *Handler {
 			// endpoints not yet implemented:
 			// "color": router.SingleIncludeHandler(h.metaColor),
 		},
-	}, h.resolveURL, h.authorizeEntity, h.entityExists)
+	}, h.resolveURL, h.AuthorizeEntity, h.entityExists)
 	return h
 }
 
@@ -920,7 +920,7 @@ type resolvedIdHandler func(id *router.ResolvedURL, fullySpecified bool, w http.
 // invoking f.
 func (h *Handler) authId(f resolvedIdHandler) resolvedIdHandler {
 	return func(id *router.ResolvedURL, fullySpecified bool, w http.ResponseWriter, req *http.Request) error {
-		if err := h.authorizeEntity(id, req); err != nil {
+		if err := h.AuthorizeEntity(id, req); err != nil {
 			return errgo.Mask(err, errgo.Any)
 		}
 		if err := f(id, fullySpecified, w, req); err != nil {

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -118,7 +118,9 @@ func (h *Handler) checkRequest(req *http.Request, entityId *router.ResolvedURL) 
 	}, nil
 }
 
-func (h *Handler) authorizeEntity(id *router.ResolvedURL, req *http.Request) error {
+// AuthorizeEntity checks that the given HTTP request
+// can access the entity with the given id.
+func (h *Handler) AuthorizeEntity(id *router.ResolvedURL, req *http.Request) error {
 	store := h.pool.Store()
 	defer store.Close()
 	baseEntity, err := store.FindBaseEntity(&id.URL, "acls")


### PR DESCRIPTION
This closes a security loophole.
