### PR TITLE
combine downloads with legacy statistics

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -203,7 +203,7 @@ func (s *Store) searchDocFromEntity(e *mongodoc.Entity, be *mongodoc.BaseEntity)
 		doc.Entity.PromulgatedURL = nil
 		doc.Entity.PromulgatedRevision = -1
 	}
-	_, allRevisions, err := s.ArchiveDownloadCounts(EntityResolvedURL(e))
+	_, allRevisions, err := s.ArchiveDownloadCounts(EntityResolvedURL(e).PreferredURL())
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -548,7 +548,7 @@ func (h *Handler) metaStats(entity *mongodoc.Entity, id *router.ResolvedURL, pat
 	store := h.pool.Store()
 	defer store.Close()
 	// Retrieve the aggregated downloads count for the specific revision.
-	counts, countsAllRevisions, err := store.ArchiveDownloadCounts(id)
+	counts, countsAllRevisions, err := store.ArchiveDownloadCounts(id.PreferredURL())
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -1641,6 +1641,13 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 					err := s.store.IncCounterAtTime(key, date)
 					c.Assert(err, gc.IsNil)
 				}
+				if url.PromulgatedRevision > -1 {
+					key := []string{params.StatsArchiveDownload, url.URL.Series, url.URL.Name, "", strconv.Itoa(url.PromulgatedRevision)}
+					for i := 0; i < downloads; i++ {
+						err := s.store.IncCounterAtTime(key, date)
+						c.Assert(err, gc.IsNil)
+					}
+				}
 			}
 		}
 
@@ -2346,7 +2353,7 @@ var promulgateTests = []struct {
 		checkers.DeclaredCaveat(v4.UsernameAttr, "bob"),
 	},
 	groups: map[string][]string{
-		"bob": []string{"promulgators", "yellow"},
+		"bob": {"promulgators", "yellow"},
 	},
 	expectStatus: http.StatusOK,
 	expectEntities: []*mongodoc.Entity{
@@ -2388,7 +2395,7 @@ var promulgateTests = []struct {
 		checkers.DeclaredCaveat(v4.UsernameAttr, "bob"),
 	},
 	groups: map[string][]string{
-		"bob": []string{"yellow"},
+		"bob": {"yellow"},
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -131,6 +131,9 @@ func (s *ArchiveSuite) TestGetCounters(c *gc.C) {
 		// Check that the downloads count for the entity has been updated.
 		key := []string{params.StatsArchiveDownload, "utopic", "mysql", id.URL.User, "42"}
 		stats.CheckCounterSum(c, s.store, key, false, 1)
+		// Check that the promulgated download count for the entity has also been updated
+		key = []string{params.StatsArchiveDownload, "utopic", "mysql", "", "42"}
+		stats.CheckCounterSum(c, s.store, key, false, 1)
 	}
 }
 


### PR DESCRIPTION
First part of combining download statistics with legacy download counts. This version always prefers a promulgated charm name if the entity has one.
