### PR TITLE
Use ParseBool for handling the meta/any query flags.

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -326,18 +326,6 @@ func fieldsFromSelector(selector map[string]int) []string {
 	return fields
 }
 
-// parseBool returns the boolean value represented by the string.
-// It accepts "1" or "0". Any other value returns an error.
-func parseBool(value string) (bool, error) {
-	switch value {
-	case "0", "":
-		return false, nil
-	case "1":
-		return true, nil
-	}
-	return false, errgo.Newf(`unexpected bool value %q (must be "0" or "1")`, value)
-}
-
 var errNotImplemented = errgo.Newf("method not implemented")
 
 // GET /debug

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -160,15 +160,15 @@ func (h *Handler) metaBundlesContaining(entity *mongodoc.Entity, id *router.Reso
 	}
 
 	// Validate the URL query values.
-	anySeries, err := parseBool(flags.Get("any-series"))
+	anySeries, err := router.ParseBool(flags.Get("any-series"))
 	if err != nil {
 		return nil, badRequestf(err, "invalid value for any-series")
 	}
-	anyRevision, err := parseBool(flags.Get("any-revision"))
+	anyRevision, err := router.ParseBool(flags.Get("any-revision"))
 	if err != nil {
 		return nil, badRequestf(err, "invalid value for any-revision")
 	}
-	allResults, err := parseBool(flags.Get("all-results"))
+	allResults, err := router.ParseBool(flags.Get("all-results"))
 	if err != nil {
 		return nil, badRequestf(err, "invalid value for all-results")
 	}

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -105,7 +105,7 @@ func parseSearchParams(req *http.Request) (charmstore.SearchParams, error) {
 		case "text":
 			sp.Text = v[0]
 		case "autocomplete":
-			sp.AutoComplete, err = parseBool(v[0])
+			sp.AutoComplete, err = router.ParseBool(v[0])
 			if err != nil {
 				return charmstore.SearchParams{}, badRequestf(err, "invalid autocomplete parameter")
 			}
@@ -129,7 +129,7 @@ func parseSearchParams(req *http.Request) (charmstore.SearchParams, error) {
 			}
 			sp.Filters[k] = v
 		case "promulgated":
-			promulgated, err := parseBool(v[0])
+			promulgated, err := router.ParseBool(v[0])
 			if err != nil {
 				return charmstore.SearchParams{}, badRequestf(err, "invalid promulgated filter parameter")
 			}


### PR DESCRIPTION
Also include HTTP basic auth errors in meta/any authorization
error checks: not used in the real world, but can make tests
easier to write, and it's more consistent.
