### PR TITLE
Set project to be v5-unstable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifndef GOPATH
 $(warning You need to set up a GOPATH.)
 endif
 
-PROJECT := gopkg.in/juju/charmstore.v4
+PROJECT := gopkg.in/juju/charmstore.v5-unstable
 PROJECT_DIR := $(shell go list -e -f '{{.Dir}}' $(PROJECT))
 
 ifeq ($(shell uname -p | sed -r 's/.*(x86|armel|armhf).*/golang/'), golang)


### PR DESCRIPTION
The Makefile requires that the PROJECT symbol match the actual path. This project is named v5-unstable so that's what must be specified in the Makefile.
