### PR TITLE
all: add import path comments

### DIFF
--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013, 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package main
+package main	// import "gopkg.in/juju/charmstore.v5-unstable/cmd/charmd"
 
 import (
 	"flag"

--- a/cmd/cshash256/main.go
+++ b/cmd/cshash256/main.go
@@ -6,7 +6,7 @@
 // The first time this command is executed, all the entities are updated.
 // Subsequent runs have no effect.
 
-package main
+package main	// import "gopkg.in/juju/charmstore.v5-unstable/cmd/cshash256"
 
 import (
 	"crypto/sha256"

--- a/cmd/essync/main.go
+++ b/cmd/essync/main.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package main
+package main	// import "gopkg.in/juju/charmstore.v5-unstable/cmd/essync"
 
 import (
 	"flag"

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,7 @@
 
 // The config package defines configuration parameters for
 // the charm store.
-package config
+package config	// import "gopkg.in/juju/charmstore.v5-unstable/config"
 
 import (
 	"fmt"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,7 @@
 // Copyright 2012, 2013, 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package config_test
+package config_test	// import "gopkg.in/juju/charmstore.v5-unstable/config"
 
 import (
 	"io/ioutil"

--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package blobstore
+package blobstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
 
 import (
 	"crypto/sha512"

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package blobstore_test
+package blobstore_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
 
 import (
 	"fmt"

--- a/internal/charmstore/archive.go
+++ b/internal/charmstore/archive.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"bytes"

--- a/internal/charmstore/debug.go
+++ b/internal/charmstore/debug.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"bytes"

--- a/internal/charmstore/debug_test.go
+++ b/internal/charmstore/debug_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"errors"

--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import "encoding/json"
 

--- a/internal/charmstore/export_test.go
+++ b/internal/charmstore/export_test.go
@@ -1,6 +1,6 @@
 // Copyright 2013, 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 var TimeToStamp = timeToStamp

--- a/internal/charmstore/hash.go
+++ b/internal/charmstore/hash.go
@@ -5,7 +5,7 @@
 // with their SHA256 hash value. Entities are updated by running the cshash256
 // command.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"crypto/sha256"

--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"gopkg.in/errgo.v1"

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"net/http"

--- a/internal/charmstore/package_test.go
+++ b/internal/charmstore/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore_test
+package charmstore_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"testing"

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"crypto/sha1"

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"encoding/json"

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -4,7 +4,7 @@
 // This is the internal version of the charmstore package.
 // It exposes details to the various API packages
 // that we do not wish to expose to the world at large.
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"net/http"

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"net/http"

--- a/internal/charmstore/stats.go
+++ b/internal/charmstore/stats.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"encoding/json"

--- a/internal/charmstore/stats_test.go
+++ b/internal/charmstore/stats_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore_test
+package charmstore_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"fmt"

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"archive/zip"

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"archive/zip"

--- a/internal/charmstore/zip.go
+++ b/internal/charmstore/zip.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"archive/zip"

--- a/internal/charmstore/zip_test.go
+++ b/internal/charmstore/zip_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore_test
+package charmstore_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
 	"archive/zip"

--- a/internal/debug/handler.go
+++ b/internal/debug/handler.go
@@ -4,7 +4,7 @@
 // The debug package holds various functions that may
 // be used for debugging but should not be included
 // in production code.
-package debug
+package debug	// import "gopkg.in/juju/charmstore.v5-unstable/internal/debug"
 
 import (
 	"log"

--- a/internal/elasticsearch/elasticsearch.go
+++ b/internal/elasticsearch/elasticsearch.go
@@ -8,7 +8,7 @@
 // There is no reason to use different vocabulary from that of elasticsearch.
 // Use the elasticsearch terminology and avoid mapping names of things.
 
-package elasticsearch
+package elasticsearch	// import "gopkg.in/juju/charmstore.v5-unstable/internal/elasticsearch"
 
 import (
 	"bytes"

--- a/internal/elasticsearch/elasticsearch_test.go
+++ b/internal/elasticsearch/elasticsearch_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package elasticsearch_test
+package elasticsearch_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/elasticsearch"
 
 import (
 	"encoding/json"

--- a/internal/elasticsearch/query.go
+++ b/internal/elasticsearch/query.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package elasticsearch
+package elasticsearch	// import "gopkg.in/juju/charmstore.v5-unstable/internal/elasticsearch"
 
 import (
 	"encoding/json"

--- a/internal/elasticsearch/query_test.go
+++ b/internal/elasticsearch/query_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package elasticsearch_test
+package elasticsearch_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/elasticsearch"
 
 import (
 	jc "github.com/juju/testing/checkers"

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -63,7 +63,7 @@
 //
 //     charm-bundle:trusty:juju-gui  2014-06-17  5
 //     charm-bundle:trusty:mysql     2014-06-17  1
-package legacy
+package legacy	// import "gopkg.in/juju/charmstore.v5-unstable/internal/legacy"
 
 import (
 	"encoding/json"

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package legacy_test
+package legacy_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/legacy"
 
 import (
 	"crypto/sha256"

--- a/internal/legacy/package_test.go
+++ b/internal/legacy/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package legacy_test
+package legacy_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/legacy"
 
 import (
 	"testing"

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package mongodoc
+package mongodoc	// import "gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 
 import (
 	"time"

--- a/internal/mongodoc/doc_test.go
+++ b/internal/mongodoc/doc_test.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package mongodoc_test
+package mongodoc_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 
 import (
 	"testing"

--- a/internal/router/fieldinclude.go
+++ b/internal/router/fieldinclude.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package router
+package router	// import "gopkg.in/juju/charmstore.v5-unstable/internal/router"
 
 import (
 	"encoding/json"

--- a/internal/router/package_test.go
+++ b/internal/router/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package router_test
+package router_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/router"
 
 import (
 	"testing"

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -3,7 +3,7 @@
 
 // The router package implements an HTTP request router for charm store
 // HTTP requests.
-package router
+package router	// import "gopkg.in/juju/charmstore.v5-unstable/internal/router"
 
 import (
 	"encoding/json"

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package router
+package router	// import "gopkg.in/juju/charmstore.v5-unstable/internal/router"
 
 import (
 	"bytes"

--- a/internal/router/singleinclude.go
+++ b/internal/router/singleinclude.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package router
+package router	// import "gopkg.in/juju/charmstore.v5-unstable/internal/router"
 
 import (
 	"encoding/json"

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package router
+package router	// import "gopkg.in/juju/charmstore.v5-unstable/internal/router"
 
 import (
 	"fmt"

--- a/internal/router/util_test.go
+++ b/internal/router/util_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package router_test
+package router_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/router"
 
 import (
 	"net/url"

--- a/internal/storetesting/charm.go
+++ b/internal/storetesting/charm.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package storetesting
+package storetesting	// import "gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 
 import (
 	"gopkg.in/juju/charmrepo.v0/testing"

--- a/internal/storetesting/elasticsearch.go
+++ b/internal/storetesting/elasticsearch.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package storetesting
+package storetesting	// import "gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 
 import (
 	"os"

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package storetesting
+package storetesting	// import "gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 
 import (
 	jc "github.com/juju/testing/checkers"

--- a/internal/storetesting/flag.go
+++ b/internal/storetesting/flag.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package storetesting
+package storetesting	// import "gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 
 import (
 	"flag"

--- a/internal/storetesting/hashtesting/hash.go
+++ b/internal/storetesting/hashtesting/hash.go
@@ -5,7 +5,7 @@
 // db with their SHA256 hash value. Entities are updated by running the
 // cshash256 command.
 
-package hashtesting
+package hashtesting	// import "gopkg.in/juju/charmstore.v5-unstable/internal/storetesting/hashtesting"
 
 import (
 	"time"

--- a/internal/storetesting/json.go
+++ b/internal/storetesting/json.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package storetesting
+package storetesting	// import "gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 
 import (
 	"bytes"

--- a/internal/storetesting/stats/stats.go
+++ b/internal/storetesting/stats/stats.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package stats
+package stats	// import "gopkg.in/juju/charmstore.v5-unstable/internal/storetesting/stats"
 
 import (
 	"time"

--- a/internal/storetesting/suite.go
+++ b/internal/storetesting/suite.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package storetesting
+package storetesting	// import "gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 
 import (
 	jujutesting "github.com/juju/testing"

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"archive/zip"

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"archive/zip"

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"archive/zip"

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"archive/zip"

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"encoding/base64"

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"encoding/json"

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -1,4 +1,4 @@
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"encoding/json"

--- a/internal/v4/content.go
+++ b/internal/v4/content.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"archive/zip"

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"bytes"

--- a/internal/v4/defaulticon.go
+++ b/internal/v4/defaulticon.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 var defaultIcon = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->

--- a/internal/v4/defaulticon_test.go
+++ b/internal/v4/defaulticon_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"strings"

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 var (
 	BundleCharms                   = (*Handler).bundleCharms

--- a/internal/v4/httpfs.go
+++ b/internal/v4/httpfs.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"fmt"

--- a/internal/v4/log.go
+++ b/internal/v4/log.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"encoding/json"

--- a/internal/v4/log_test.go
+++ b/internal/v4/log_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"bytes"

--- a/internal/v4/package_test.go
+++ b/internal/v4/package_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"testing"

--- a/internal/v4/pprof.go
+++ b/internal/v4/pprof.go
@@ -1,4 +1,4 @@
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"net/http"

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"net/http"

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"encoding/json"

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"net/http"

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"bytes"

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -1,7 +1,7 @@
 // Copyright 2012 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"net/http"

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -1,7 +1,7 @@
 // Copyright 2012 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"encoding/json"

--- a/internal/v4/status.go
+++ b/internal/v4/status.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4
+package v4	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"encoding/json"

--- a/internal/v4/status_test.go
+++ b/internal/v4/status_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package v4_test
+package v4_test	// import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
 	"encoding/json"

--- a/server.go
+++ b/server.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore
+package charmstore // import "gopkg.in/juju/charmstore.v5-unstable"
 
 import (
 	"fmt"

--- a/server_test.go
+++ b/server_test.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package charmstore_test
+package charmstore_test // import "gopkg.in/juju/charmstore.v5-unstable"
 
 import (
 	"fmt"

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package version
+package version	// import "gopkg.in/juju/charmstore.v5-unstable/version"
 
 type Version struct {
 	GitCommit string


### PR DESCRIPTION
Mechanical change.
This allows the Go compiler to know when it's being imported with the
wrong import path.
