### PR TITLE
internal/charmstore: limit number of mongo sessions

### DIFF
--- a/cmd/charmd/config.yaml
+++ b/cmd/charmd/config.yaml
@@ -15,5 +15,6 @@ identity-api-url: http://localhost:8081
 #agent-key:
 #  private: 85ZQqTnqiNdEggFVy7TGjRDGMulJHHz8UKkfVl5tTu8=
 #  public: X3Yj/aThvG20FoBhRAIX+JbFk300r9Roc2D78r/37iw=
-# Statistics Cache maximum age, default 3600s (1 hour).
-#stats-cache-max-age: 3600
+# Statistics Cache maximum age, default 1 hour
+#stats-cache-max-age: 1h
+#request-timeout: 500ms

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
@@ -29,7 +30,9 @@ type Config struct {
 	IdentityAPIURL   string          `yaml:"identity-api-url"`
 	AgentUsername    string          `yaml:"agent-username"`
 	AgentKey         *bakery.KeyPair `yaml:"agent-key"`
-	StatsCacheMaxAge int             `yaml:"stats-cache-max-age"` // optional
+	MaxMgoSessions   int             `yaml:"max-mgo-sessions"`
+	RequestTimeout   DurationString  `yaml:"request-timeout"`
+	StatsCacheMaxAge DurationString  `yaml:"stats-cache-max-age"`
 }
 
 func (c *Config) validate() error {
@@ -76,4 +79,19 @@ func Read(path string) (*Config, error) {
 		return nil, errgo.Mask(err)
 	}
 	return &conf, nil
+}
+
+// DurationString holds a duration that marshals and
+// unmarshals as a friendly string.
+type DurationString struct {
+	time.Duration
+}
+
+func (dp *DurationString) UnmarshalText(data []byte) error {
+	d, err := time.ParseDuration(string(data))
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	dp.Duration = d
+	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"path"
 	"testing"
+	"time"
 
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -40,7 +41,9 @@ agent-username: agentuser
 agent-key:
   private: lsvcDkapKoFxIyjX9/eQgb3s41KVwPMISFwAJdVCZ70=
   public: +qNbDWly3kRTDVv2UN03hrv/CBt4W6nxY5dHdw+KJFA=
-stats-cache-max-age: 3600
+stats-cache-max-age: 1h
+request-timeout: 500ms
+max-mgo-sessions: 10
 `
 
 func (s *ConfigSuite) readConfig(c *gc.C, content string) (*config.Config, error) {
@@ -75,7 +78,9 @@ func (s *ConfigSuite) TestRead(c *gc.C) {
 				mustParseKey("lsvcDkapKoFxIyjX9/eQgb3s41KVwPMISFwAJdVCZ70="),
 			},
 		},
-		StatsCacheMaxAge: 3600,
+		StatsCacheMaxAge: config.DurationString{time.Hour},
+		RequestTimeout:   config.DurationString{500 * time.Millisecond},
+		MaxMgoSessions:   10,
 	})
 }
 

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -18,7 +18,7 @@ golang.org/x/net	git	7dbad50ab5b31073856416cdcfeb2796d682f844	2015-03-20T03:46:2
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z
 gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:38Z
 gopkg.in/juju/charm.v6-unstable	git	39582dcfed323ad6e835289b869389e2aca9654a	2015-05-18T15:11:19Z
-gopkg.in/juju/charmrepo.v0	git	2b07cd7bd33cf21b26a736cf845653365908a18a	2015-05-18T17:31:51Z
+gopkg.in/juju/charmrepo.v0	git	bff4baaca14937f262fd8c2a85123f615f8460b6	2015-06-10T12:41:56Z
 gopkg.in/juju/jujusvg.v1	git	3eedb1c722ece2b66d62508368ca3e8b7f916569	2015-05-20T11:48:32Z
 gopkg.in/macaroon-bakery.v1	git	f359c9a722e0151de4b02bce1f69cec3b2aba25c	2015-05-21T11:06:50Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -15,7 +15,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
-	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 )
 
 func TestPackage(t *testing.T) {
@@ -23,7 +22,7 @@ func TestPackage(t *testing.T) {
 }
 
 type BlobStoreSuite struct {
-	storetesting.IsolatedMgoSuite
+	jujutesting.IsolatedMgoSuite
 }
 
 var _ = gc.Suite(&BlobStoreSuite{})

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -20,6 +20,7 @@ import (
 
 type StoreSearchSuite struct {
 	storetesting.IsolatedMgoESSuite
+	pool  *Pool
 	store *Store
 	index SearchIndex
 }
@@ -43,6 +44,7 @@ func (s *StoreSearchSuite) SetUpTest(c *gc.C) {
 	s.ES.RefreshIndex(".versions")
 	pool, err := NewPool(s.Session.DB("foo"), &s.index, nil, ServerParams{})
 	c.Assert(err, gc.IsNil)
+	s.pool = pool
 	s.store = pool.Store()
 	s.addCharmsToStore(c)
 	c.Assert(err, gc.IsNil)
@@ -50,6 +52,7 @@ func (s *StoreSearchSuite) SetUpTest(c *gc.C) {
 
 func (s *StoreSearchSuite) TearDownTest(c *gc.C) {
 	s.store.Close()
+	s.pool.Close()
 	s.IsolatedMgoESSuite.TearDownTest(c)
 }
 

--- a/internal/charmstore/stats.go
+++ b/internal/charmstore/stats.go
@@ -265,13 +265,10 @@ type Counter struct {
 
 // Counters aggregates and returns counter values according to the provided request.
 func (s *Store) Counters(req *CounterRequest) ([]Counter, error) {
-	db := s.DB.Copy()
-	defer db.Close()
+	tokensColl := s.DB.StatTokens()
+	countersColl := s.DB.StatCounters()
 
-	tokensColl := db.StatTokens()
-	countersColl := db.StatCounters()
-
-	searchKey, err := s.stats.key(db, req.Key, false)
+	searchKey, err := s.stats.key(s.DB, req.Key, false)
 	if errgo.Cause(err) == params.ErrNotFound {
 		if !req.List {
 			return []Counter{{

--- a/internal/charmstore/stats_test.go
+++ b/internal/charmstore/stats_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -21,7 +22,7 @@ import (
 )
 
 type StatsSuite struct {
-	storetesting.IsolatedMgoSuite
+	jujutesting.IsolatedMgoSuite
 	store *charmstore.Store
 }
 
@@ -32,6 +33,7 @@ func (s *StatsSuite) SetUpTest(c *gc.C) {
 	pool, err := charmstore.NewPool(s.Session.DB("foo"), nil, nil, charmstore.ServerParams{})
 	c.Assert(err, gc.IsNil)
 	s.store = pool.Store()
+	pool.Close()
 }
 
 func (s *StatsSuite) TearDownTest(c *gc.C) {
@@ -273,6 +275,7 @@ func (s *StatsSuite) TestListCounters(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	st := pool.Store()
 	defer st.Close()
+	pool.Close()
 
 	for i := range tests {
 		req := &charmstore.CounterRequest{Key: tests[i].prefix, Prefix: true, List: true}

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"time"
 
+	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
@@ -37,8 +38,8 @@ var serverParams = charmstore.ServerParams{
 }
 
 type APISuite struct {
-	storetesting.IsolatedMgoSuite
-	srv   http.Handler
+	jujutesting.IsolatedMgoSuite
+	srv   *charmstore.Server
 	store *charmstore.Store
 }
 
@@ -51,10 +52,12 @@ func (s *APISuite) SetUpTest(c *gc.C) {
 
 func (s *APISuite) TearDownTest(c *gc.C) {
 	s.store.Close()
+	s.store.Pool().Close()
+	s.srv.Close()
 	s.IsolatedMgoSuite.TearDownTest(c)
 }
 
-func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (http.Handler, *charmstore.Store) {
+func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (*charmstore.Server, *charmstore.Store) {
 	db := session.DB("charmstore")
 	pool, err := charmstore.NewPool(db, nil, nil, config)
 	c.Assert(err, gc.IsNil)

--- a/internal/mempool/LICENSE
+++ b/internal/mempool/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/internal/mempool/pool.go
+++ b/internal/mempool/pool.go
@@ -1,0 +1,80 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package mempool implements a version of sync.Pool
+// as supported in Go versions later than 1.2.
+//
+// TODO use sync.Pool when we can use Go 1.3 or later.
+package mempool
+
+import "sync"
+
+// A Pool is a set of temporary objects that may be individually saved and
+// retrieved.
+//
+// Any item stored in the Pool may be removed automatically at any time without
+// notification. If the Pool holds the only reference when this happens, the
+// item might be deallocated.
+//
+// A Pool is safe for use by multiple goroutines simultaneously.
+//
+// Pool's purpose is to cache allocated but unused items for later reuse,
+// relieving pressure on the garbage collector. That is, it makes it easy to
+// build efficient, thread-safe free lists. However, it is not suitable for all
+// free lists.
+//
+// An appropriate use of a Pool is to manage a group of temporary items
+// silently shared among and potentially reused by concurrent independent
+// clients of a package. Pool provides a way to amortize allocation overhead
+// across many clients.
+//
+// An example of good use of a Pool is in the fmt package, which maintains a
+// dynamically-sized store of temporary output buffers. The store scales under
+// load (when many goroutines are actively printing) and shrinks when
+// quiescent.
+//
+// On the other hand, a free list maintained as part of a short-lived object is
+// not a suitable use for a Pool, since the overhead does not amortize well in
+// that scenario. It is more efficient to have such objects implement their own
+// free list.
+//
+type Pool struct {
+	mu     sync.Mutex
+	values []interface{}
+
+	// New optionally specifies a function to generate
+	// a value when Get would otherwise return nil.
+	// It may not be changed concurrently with calls to Get.
+	New func() interface{}
+}
+
+// Put adds x to the pool.
+func (p *Pool) Put(x interface{}) {
+	p.mu.Lock()
+	p.values = append(p.values, x)
+	p.mu.Unlock()
+}
+
+// Get selects an arbitrary item from the Pool, removes it from the
+// Pool, and returns it to the caller.
+// Get may choose to ignore the pool and treat it as empty.
+// Callers should not assume any relation between values passed to Put and
+// the values returned by Get.
+//
+// If Get would otherwise return nil and p.New is non-nil, Get returns
+// the result of calling p.New.
+func (p *Pool) Get() interface{} {
+	p.mu.Lock()
+	if n := len(p.values); n > 0 {
+		v := p.values[n-1]
+		p.values = p.values[0 : n-1]
+		p.mu.Unlock()
+		return v
+	}
+	p.mu.Unlock()
+	if p.New == nil {
+		return nil
+	}
+	return p.New()
+}

--- a/internal/mempool/pool_test.go
+++ b/internal/mempool/pool_test.go
@@ -1,0 +1,114 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Pool is no-op under race detector, so all these tests do not work.
+// +build !race
+
+package mempool_test
+
+import (
+	. "sync"
+	"testing"
+)
+
+// Note: the tests in this file are taken directly from
+// $GOROOT/src/sync/pool_test.go, with the
+// exception of all the GC-driven behaviour
+// which has been removed.
+
+func TestPool(t *testing.T) {
+	var p Pool
+	if p.Get() != nil {
+		t.Fatal("expected empty")
+	}
+	p.Put("a")
+	p.Put("b")
+	if g := p.Get(); g != "a" {
+		t.Fatalf("got %#v; want a", g)
+	}
+	if g := p.Get(); g != "b" {
+		t.Fatalf("got %#v; want b", g)
+	}
+	if g := p.Get(); g != nil {
+		t.Fatalf("got %#v; want nil", g)
+	}
+
+	p.Put("c")
+}
+
+func TestPoolNew(t *testing.T) {
+	i := 0
+	p := Pool{
+		New: func() interface{} {
+			i++
+			return i
+		},
+	}
+	if v := p.Get(); v != 1 {
+		t.Fatalf("got %v; want 1", v)
+	}
+	if v := p.Get(); v != 2 {
+		t.Fatalf("got %v; want 2", v)
+	}
+	p.Put(42)
+	if v := p.Get(); v != 42 {
+		t.Fatalf("got %v; want 42", v)
+	}
+	if v := p.Get(); v != 3 {
+		t.Fatalf("got %v; want 3", v)
+	}
+}
+
+func TestPoolStress(t *testing.T) {
+	const P = 10
+	N := int(1e6)
+	if testing.Short() {
+		N /= 100
+	}
+	var p Pool
+	done := make(chan bool)
+	for i := 0; i < P; i++ {
+		go func() {
+			var v interface{} = 0
+			for j := 0; j < N; j++ {
+				if v == nil {
+					v = 0
+				}
+				p.Put(v)
+				v = p.Get()
+				if v != nil && v.(int) != 0 {
+					t.Fatalf("expect 0, got %v", v)
+				}
+			}
+			done <- true
+		}()
+	}
+	for i := 0; i < P; i++ {
+		<-done
+	}
+}
+
+func BenchmarkPool(b *testing.B) {
+	var p Pool
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			p.Put(1)
+			p.Get()
+		}
+	})
+}
+
+func BenchmarkPoolOverflow(b *testing.B) {
+	var p Pool
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for b := 0; b < 100; b++ {
+				p.Put(1)
+			}
+			for b := 0; b < 100; b++ {
+				p.Get()
+			}
+		}
+	})
+}

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -55,6 +55,8 @@ func errorToResp1(err error) (int, interface{}) {
 		// response.
 		// Perhaps we should not ever return StatusMethodNotAllowed.
 		status = http.StatusMethodNotAllowed
+	case params.ErrServiceUnavailable:
+		status = http.StatusServiceUnavailable
 	}
 	return status, errorBody
 }

--- a/internal/storetesting/suite.go
+++ b/internal/storetesting/suite.go
@@ -8,57 +8,27 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-type IsolatedMgoSuite struct {
-	jujutesting.IsolationSuite
-	jujutesting.MgoSuite
-}
-
-func (s *IsolatedMgoSuite) SetUpSuite(c *gc.C) {
-	s.IsolationSuite.SetUpSuite(c)
-	s.MgoSuite.SetUpSuite(c)
-}
-
-func (s *IsolatedMgoSuite) TearDownSuite(c *gc.C) {
-	s.MgoSuite.TearDownSuite(c)
-	s.IsolationSuite.TearDownSuite(c)
-}
-
-func (s *IsolatedMgoSuite) SetUpTest(c *gc.C) {
-	s.IsolationSuite.SetUpTest(c)
-	s.MgoSuite.SetUpTest(c)
-}
-
-func (s *IsolatedMgoSuite) TearDownTest(c *gc.C) {
-	s.MgoSuite.TearDownTest(c)
-	s.IsolationSuite.TearDownTest(c)
-}
-
 type IsolatedMgoESSuite struct {
-	jujutesting.IsolationSuite
-	jujutesting.MgoSuite
+	jujutesting.IsolatedMgoSuite
 	ElasticSearchSuite
 }
 
 func (s *IsolatedMgoESSuite) SetUpSuite(c *gc.C) {
-	s.IsolationSuite.SetUpSuite(c)
+	s.IsolatedMgoSuite.SetUpSuite(c)
 	s.ElasticSearchSuite.SetUpSuite(c)
-	s.MgoSuite.SetUpSuite(c)
 }
 
 func (s *IsolatedMgoESSuite) TearDownSuite(c *gc.C) {
-	s.MgoSuite.TearDownSuite(c)
 	s.ElasticSearchSuite.TearDownSuite(c)
-	s.IsolationSuite.TearDownSuite(c)
+	s.IsolatedMgoSuite.TearDownSuite(c)
 }
 
 func (s *IsolatedMgoESSuite) SetUpTest(c *gc.C) {
-	s.IsolationSuite.SetUpTest(c)
+	s.IsolatedMgoSuite.SetUpTest(c)
 	s.ElasticSearchSuite.SetUpTest(c)
-	s.MgoSuite.SetUpTest(c)
 }
 
 func (s *IsolatedMgoESSuite) TearDownTest(c *gc.C) {
-	s.MgoSuite.TearDownTest(c)
 	s.ElasticSearchSuite.TearDownTest(c)
-	s.IsolationSuite.TearDownTest(c)
+	s.IsolatedMgoSuite.TearDownTest(c)
 }

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -4,7 +4,6 @@
 package v4 // import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 var (
-	BundleCharms                   = (*Handler).bundleCharms
 	ParseSearchParams              = parseSearchParams
 	DefaultIcon                    = defaultIcon
 	ArchiveCacheVersionedMaxAge    = &archiveCacheVersionedMaxAge
@@ -14,7 +13,9 @@ var (
 	ProcessIcon                    = processIcon
 	ErrProbablyNotXML              = errProbablyNotXML
 	UsernameAttr                   = usernameAttr
-	GetNewPromulgatedRevision      = (*Handler).getNewPromulgatedRevision
 	DelegatableMacaroonExpiry      = delegatableMacaroonExpiry
-	GroupsForUser                  = (*Handler).groupsForUser
+
+	BundleCharms              = (*ReqHandler).bundleCharms
+	GetNewPromulgatedRevision = (*ReqHandler).getNewPromulgatedRevision
+	GroupsForUser             = (*ReqHandler).groupsForUser
 )

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -20,7 +20,7 @@ const maxConcurrency = 20
 
 // GET search[?text=text][&autocomplete=1][&filter=value…][&limit=limit][&include=meta][&skip=count][&sort=field[+dir]]
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-search
-func (h *Handler) serveSearch(_ http.Header, req *http.Request) (interface{}, error) {
+func (h *ReqHandler) serveSearch(_ http.Header, req *http.Request) (interface{}, error) {
 	sp, err := parseSearchParams(req)
 	if err != nil {
 		return "", err
@@ -39,9 +39,7 @@ func (h *Handler) serveSearch(_ http.Header, req *http.Request) (interface{}, er
 		sp.Groups = append(sp.Groups, groups...)
 	}
 	// perform query
-	store := h.pool.Store()
-	defer store.Close()
-	results, err := store.Search(sp)
+	results, err := h.Store.Search(sp)
 	if err != nil {
 		return nil, errgo.Notef(err, "error performing search")
 	}
@@ -92,7 +90,7 @@ func (h *Handler) serveSearch(_ http.Header, req *http.Request) (interface{}, er
 
 // GET search/interesting[?limit=limit][&include=meta]
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-searchinteresting
-func (h *Handler) serveSearchInteresting(w http.ResponseWriter, req *http.Request) {
+func (h *ReqHandler) serveSearchInteresting(w http.ResponseWriter, req *http.Request) {
 	router.WriteError(w, errNotImplemented)
 }
 

--- a/internal/v4/stats.go
+++ b/internal/v4/stats.go
@@ -41,7 +41,7 @@ func parseDateRange(form url.Values) (start, stop time.Time, err error) {
 
 // GET stats/counter/key[:key]...?[by=unit]&start=date][&stop=date][&list=1]
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-statscounter
-func (h *Handler) serveStatsCounter(_ http.Header, r *http.Request) (interface{}, error) {
+func (h *ReqHandler) serveStatsCounter(_ http.Header, r *http.Request) (interface{}, error) {
 	base := strings.TrimPrefix(r.URL.Path, "/")
 	if strings.Index(base, "/") > 0 {
 		return nil, errgo.WithCausef(nil, params.ErrNotFound, "invalid key")
@@ -77,9 +77,7 @@ func (h *Handler) serveStatsCounter(_ http.Header, r *http.Request) (interface{}
 			return nil, errgo.WithCausef(nil, params.ErrForbidden, "unknown key")
 		}
 	}
-	store := h.pool.Store()
-	defer store.Close()
-	entries, err := store.Counters(&req)
+	entries, err := h.Store.Counters(&req)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot query counters")
 	}

--- a/internal/v4/status.go
+++ b/internal/v4/status.go
@@ -15,29 +15,26 @@ import (
 	"gopkg.in/juju/charmrepo.v0/csclient/params"
 	"gopkg.in/mgo.v2/bson"
 
-	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 )
 
 // GET /debug/status
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-debugstatus
-func (h *Handler) serveDebugStatus(_ http.Header, req *http.Request) (interface{}, error) {
-	store := h.pool.Store()
-	defer store.Close()
-	store.SetReconnectTimeout(500 * time.Millisecond)
+func (h *ReqHandler) serveDebugStatus(_ http.Header, req *http.Request) (interface{}, error) {
+	h.Store.SetReconnectTimeout(500 * time.Millisecond)
 	return debugstatus.Check(
 		debugstatus.ServerStartTime,
-		debugstatus.Connection(store.DB.Session),
-		debugstatus.MongoCollections(store.DB),
-		h.checkElasticSearch(store),
-		h.checkEntities(store),
-		h.checkBaseEntities(store),
-		h.checkLogs(store,
+		debugstatus.Connection(h.Store.DB.Session),
+		debugstatus.MongoCollections(h.Store.DB),
+		h.checkElasticSearch,
+		h.checkEntities,
+		h.checkBaseEntities,
+		h.checkLogs(
 			"ingestion", "Ingestion",
 			mongodoc.IngestionType,
 			params.IngestionStart, params.IngestionComplete,
 		),
-		h.checkLogs(store,
+		h.checkLogs(
 			"legacy_statistics", "Legacy Statistics Load",
 			mongodoc.LegacyStatisticsType,
 			params.LegacyStatisticsImportStart, params.LegacyStatisticsImportComplete,
@@ -45,84 +42,77 @@ func (h *Handler) serveDebugStatus(_ http.Header, req *http.Request) (interface{
 	), nil
 }
 
-func (h *Handler) checkElasticSearch(store *charmstore.Store) debugstatus.CheckerFunc {
-	return func() (key string, result debugstatus.CheckResult) {
-		key = "elasticsearch"
-		result.Name = "Elastic search is running"
-		if store.ES == nil || store.ES.Database == nil {
-			result.Value = "Elastic search is not configured"
-			result.Passed = true
-			return key, result
-		}
-		health, err := store.ES.Health()
-		if err != nil {
-			result.Value = "Connection issues to Elastic Search: " + err.Error()
-			return key, result
-		}
-		result.Value = health.String()
-		result.Passed = health.Status == "green"
+func (h *ReqHandler) checkElasticSearch() (key string, result debugstatus.CheckResult) {
+	key = "elasticsearch"
+	result.Name = "Elastic search is running"
+	if h.Store.ES == nil || h.Store.ES.Database == nil {
+		result.Value = "Elastic search is not configured"
+		result.Passed = true
 		return key, result
 	}
+	health, err := h.Store.ES.Health()
+	if err != nil {
+		result.Value = "Connection issues to Elastic Search: " + err.Error()
+		return key, result
+	}
+	result.Value = health.String()
+	result.Passed = health.Status == "green"
+	return key, result
 }
 
-func (h *Handler) checkEntities(store *charmstore.Store) debugstatus.CheckerFunc {
-	return func() (key string, result debugstatus.CheckResult) {
-		result.Name = "Entities in charm store"
-		charms, err := store.DB.Entities().Find(bson.D{{"series", bson.D{{"$ne", "bundle"}}}}).Count()
-		if err != nil {
-			result.Value = "Cannot count charms for consistency check: " + err.Error()
-			return "entities", result
-		}
-		bundles, err := store.DB.Entities().Find(bson.D{{"series", "bundle"}}).Count()
-		if err != nil {
-			result.Value = "Cannot count bundles for consistency check: " + err.Error()
-			return "entities", result
-		}
-		promulgated, err := store.DB.Entities().Find(bson.D{{"promulgated-url", bson.D{{"$exists", true}}}}).Count()
-		if err != nil {
-			result.Value = "Cannot count promulgated for consistency check: " + err.Error()
-			return "entities", result
-		}
-		result.Value = fmt.Sprintf("%d charms; %d bundles; %d promulgated", charms, bundles, promulgated)
-		result.Passed = true
+func (h *ReqHandler) checkEntities() (key string, result debugstatus.CheckResult) {
+	result.Name = "Entities in charm store"
+	charms, err := h.Store.DB.Entities().Find(bson.D{{"series", bson.D{{"$ne", "bundle"}}}}).Count()
+	if err != nil {
+		result.Value = "Cannot count charms for consistency check: " + err.Error()
 		return "entities", result
 	}
+	bundles, err := h.Store.DB.Entities().Find(bson.D{{"series", "bundle"}}).Count()
+	if err != nil {
+		result.Value = "Cannot count bundles for consistency check: " + err.Error()
+		return "entities", result
+	}
+	promulgated, err := h.Store.DB.Entities().Find(bson.D{{"promulgated-url", bson.D{{"$exists", true}}}}).Count()
+	if err != nil {
+		result.Value = "Cannot count promulgated for consistency check: " + err.Error()
+		return "entities", result
+	}
+	result.Value = fmt.Sprintf("%d charms; %d bundles; %d promulgated", charms, bundles, promulgated)
+	result.Passed = true
+	return "entities", result
 }
 
-func (h *Handler) checkBaseEntities(store *charmstore.Store) debugstatus.CheckerFunc {
-	return func() (key string, result debugstatus.CheckResult) {
-		resultKey := "base_entities"
-		result.Name = "Base entities in charm store"
+func (h *ReqHandler) checkBaseEntities() (key string, result debugstatus.CheckResult) {
+	resultKey := "base_entities"
+	result.Name = "Base entities in charm store"
 
-		// Retrieve the number of base entities.
-		baseNum, err := store.DB.BaseEntities().Count()
-		if err != nil {
-			result.Value = "Cannot count base entities: " + err.Error()
-			return resultKey, result
-		}
-
-		// Retrieve the number of entities.
-		num, err := store.DB.Entities().Count()
-		if err != nil {
-			result.Value = "Cannot count entities for consistency check: " + err.Error()
-			return resultKey, result
-		}
-
-		result.Value = fmt.Sprintf("count: %d", baseNum)
-		result.Passed = num >= baseNum
+	// Retrieve the number of base entities.
+	baseNum, err := h.Store.DB.BaseEntities().Count()
+	if err != nil {
+		result.Value = "Cannot count base entities: " + err.Error()
 		return resultKey, result
 	}
+
+	// Retrieve the number of entities.
+	num, err := h.Store.DB.Entities().Count()
+	if err != nil {
+		result.Value = "Cannot count entities for consistency check: " + err.Error()
+		return resultKey, result
+	}
+
+	result.Value = fmt.Sprintf("count: %d", baseNum)
+	result.Passed = num >= baseNum
+	return resultKey, result
 }
 
-func (h *Handler) checkLogs(
-	store *charmstore.Store,
+func (h *ReqHandler) checkLogs(
 	resultKey, resultName string,
 	logType mongodoc.LogType,
 	startPrefix, endPrefix string,
 ) debugstatus.CheckerFunc {
 	return func() (key string, result debugstatus.CheckResult) {
 		result.Name = resultName
-		start, end, err := h.findTimesInLogs(store, logType, startPrefix, endPrefix)
+		start, end, err := h.findTimesInLogs(logType, startPrefix, endPrefix)
 		if err != nil {
 			result.Value = err.Error()
 			return resultKey, result
@@ -135,9 +125,9 @@ func (h *Handler) checkLogs(
 
 // findTimesInLogs goes through logs in reverse order finding when the start and
 // end messages were last added.
-func (h *Handler) findTimesInLogs(store *charmstore.Store, logType mongodoc.LogType, startPrefix, endPrefix string) (start, end time.Time, err error) {
+func (h *ReqHandler) findTimesInLogs(logType mongodoc.LogType, startPrefix, endPrefix string) (start, end time.Time, err error) {
 	var log mongodoc.Log
-	iter := store.DB.Logs().
+	iter := h.Store.DB.Logs().
 		Find(bson.D{
 		{"level", mongodoc.InfoLevel},
 		{"type", logType},

--- a/server_test.go
+++ b/server_test.go
@@ -24,7 +24,7 @@ func TestPackage(t *testing.T) {
 }
 
 type ServerSuite struct {
-	storetesting.IsolatedMgoSuite
+	jujutesting.IsolatedMgoSuite
 	config charmstore.ServerParams
 }
 
@@ -64,6 +64,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 
 	h, err := charmstore.NewServer(db, nil, "", s.config, charmstore.V4)
 	c.Assert(err, gc.IsNil)
+	defer h.Close()
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      h,
@@ -118,6 +119,7 @@ func (s *ServerESSuite) SetUpSuite(c *gc.C) {
 func (s *ServerESSuite) TestNewServerWithElasticsearch(c *gc.C) {
 	db := s.Session.DB("foo")
 
-	_, err := charmstore.NewServer(db, s.ES, s.TestIndex, s.config, charmstore.V4)
+	srv, err := charmstore.NewServer(db, s.ES, s.TestIndex, s.config, charmstore.V4)
 	c.Assert(err, gc.IsNil)
+	srv.Close()
 }


### PR DESCRIPTION
This implements a limiter and cache of mongo connections
used by the API handlers, so the number of concurrent mongo
connections won't rise much above a set limit.
