### PR TITLE
internal/charmstore: make a blobstore and bakery service for each Store instance

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,5 @@
 github.com/ajstarks/svgo	git	89e3ac64b5b3e403a5e7c35ea4f98d45db7b4518	2014-10-04T21:11:59Z
-github.com/juju/blobstore	git	337aa7d5d712728d181dbda2547a6556d4189626	2015-05-08T07:43:36Z
+github.com/juju/blobstore	git	3e9b30af648f96e85d8f41f946ae4a1ce0ce588b	2015-06-11T10:42:44Z
 github.com/juju/errors	git	036046bfdccf6f576e2e5dec7f7878597bcaebe7	2015-02-11T20:59:49Z
 github.com/juju/gojsonpointer	git	0154bf5a168b672d8c97d8dd83a54cb60cd088e8	2014-07-18T03:59:30Z
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -34,8 +34,7 @@ const (
 // error is returned holding the macaroon.
 func (h *ReqHandler) authorize(req *http.Request, acl []string, alwaysAuth bool, entityId *router.ResolvedURL) (authorization, error) {
 	logger.Infof(
-		"authorize, bakery %p, auth location %q, acl %q, path: %q, method: %q",
-		h.handler.pool.Bakery,
+		"authorize, auth location %q, acl %q, path: %q, method: %q",
 		h.handler.config.IdentityLocation,
 		acl,
 		req.URL.Path,
@@ -86,7 +85,7 @@ func (h *ReqHandler) checkRequest(req *http.Request, entityId *router.ResolvedUR
 		}
 		return authorization{Admin: true}, nil
 	}
-	bk := h.handler.pool.Bakery
+	bk := h.Store.Bakery
 	if errgo.Cause(err) != errNoCreds || bk == nil || h.handler.config.IdentityLocation == "" {
 		return authorization{}, errgo.WithCausef(err, params.ErrUnauthorized, "authentication failed")
 	}
@@ -191,7 +190,7 @@ func (h *ReqHandler) newMacaroon() (*macaroon.Macaroon, error) {
 	// TODO generate different caveats depending on the requested operation
 	// and whether there's a charm id or not.
 	// Mint an appropriate macaroon and send it back to the client.
-	return h.handler.pool.Bakery.NewMacaroon("", nil, []checkers.Caveat{checkers.NeedDeclaredCaveat(checkers.Caveat{
+	return h.Store.Bakery.NewMacaroon("", nil, []checkers.Caveat{checkers.NeedDeclaredCaveat(checkers.Caveat{
 		Location:  h.handler.config.IdentityLocation,
 		Condition: "is-authenticated-user",
 	}, usernameAttr)})


### PR DESCRIPTION
Also change the default semantics of Store.Copy so that it uses
a mgo.Session.Clone instead of Copy so that we can guarantee
consistency when deriving one store from another.
