### PR TITLE
internal/charmstore: limit asynchronous goroutine count

### DIFF
--- a/internal/mempool/pool_test.go
+++ b/internal/mempool/pool_test.go
@@ -5,10 +5,9 @@
 // Pool is no-op under race detector, so all these tests do not work.
 // +build !race
 
-package mempool_test
+package mempool
 
 import (
-	. "sync"
 	"testing"
 )
 
@@ -24,10 +23,10 @@ func TestPool(t *testing.T) {
 	}
 	p.Put("a")
 	p.Put("b")
-	if g := p.Get(); g != "a" {
+	if g := p.Get(); g != "b" {
 		t.Fatalf("got %#v; want a", g)
 	}
-	if g := p.Get(); g != "b" {
+	if g := p.Get(); g != "a" {
 		t.Fatalf("got %#v; want b", g)
 	}
 	if g := p.Get(); g != nil {
@@ -87,28 +86,4 @@ func TestPoolStress(t *testing.T) {
 	for i := 0; i < P; i++ {
 		<-done
 	}
-}
-
-func BenchmarkPool(b *testing.B) {
-	var p Pool
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			p.Put(1)
-			p.Get()
-		}
-	})
-}
-
-func BenchmarkPoolOverflow(b *testing.B) {
-	var p Pool
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			for b := 0; b < 100; b++ {
-				p.Put(1)
-			}
-			for b := 0; b < 100; b++ {
-				p.Get()
-			}
-		}
-	})
 }

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -52,7 +52,7 @@ type Handler struct {
 	// searchCache is a cache of search results keyed on the query
 	// parameters of the search. It should only be used for searches
 	// from unauthenticated users.
-	searchCache    *cache.Cache
+	searchCache *cache.Cache
 }
 
 // ReqHandler holds the context for a single HTTP request.


### PR DESCRIPTION
We make sure that the number of goroutines can't exceed
a reasonable set limit and make sure they've all completed
when the store is closed.
