### PR TITLE
internal/v4: record authorization in ReqHandler

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -52,7 +52,7 @@ type Handler struct {
 	// searchCache is a cache of search results keyed on the query
 	// parameters of the search. It should only be used for searches
 	// from unauthenticated users.
-	searchCache    *cache.Cache
+	searchCache *cache.Cache
 }
 
 // ReqHandler holds the context for a single HTTP request.
@@ -65,6 +65,10 @@ type ReqHandler struct {
 	// Store holds the charmstore Store instance
 	// for the request.
 	Store *charmstore.Store
+
+	// auth holds the results of any authorization that
+	// has been done on this request.
+	auth authorization
 }
 
 const (
@@ -210,6 +214,7 @@ func (h *ReqHandler) Close() {
 	h.Store.Close()
 	h.Store = nil
 	h.handler = nil
+	h.auth = authorization{}
 	reqHandlerPool.Put(h)
 }
 

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -32,6 +32,8 @@ const (
 // A params.ErrUnauthorized error is returned if superuser credentials fail;
 // otherwise a macaroon is minted and a httpbakery discharge-required
 // error is returned holding the macaroon.
+//
+// This method also sets h.auth to the returned authorization info.
 func (h *ReqHandler) authorize(req *http.Request, acl []string, alwaysAuth bool, entityId *router.ResolvedURL) (authorization, error) {
 	logger.Infof(
 		"authorize, auth location %q, acl %q, path: %q, method: %q",
@@ -54,6 +56,7 @@ func (h *ReqHandler) authorize(req *http.Request, acl []string, alwaysAuth bool,
 		if err := h.checkACLMembership(auth, acl); err != nil {
 			return authorization{}, errgo.WithCausef(err, params.ErrUnauthorized, "")
 		}
+		h.auth = auth
 		return auth, nil
 	}
 	if _, ok := errgo.Cause(verr).(*bakery.VerificationError); !ok {


### PR DESCRIPTION
This will enable audit logging to log the current user even though
it hasn't performed the authorization itself.
