### PR TITLE
internal/charmstore: copy bakery session appropriately

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -4,8 +4,9 @@
 package audit
 
 import (
-	"gopkg.in/juju/charm.v6-unstable"
 	"time"
+
+	"gopkg.in/juju/charm.v6-unstable"
 )
 
 // Operation represents the type of an entry.

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -20,10 +20,10 @@ gopkg.in/errgo.v1	git	81357a83344ddd9f7772884874e5622c2a3da21c	2014-10-13T17:33:
 gopkg.in/juju/charm.v6-unstable	git	39582dcfed323ad6e835289b869389e2aca9654a	2015-05-18T15:11:19Z
 gopkg.in/juju/charmrepo.v0	git	bff4baaca14937f262fd8c2a85123f615f8460b6	2015-06-10T12:41:56Z
 gopkg.in/juju/jujusvg.v1	git	3eedb1c722ece2b66d62508368ca3e8b7f916569	2015-05-20T11:48:32Z
-gopkg.in/macaroon-bakery.v1	git	f359c9a722e0151de4b02bce1f69cec3b2aba25c	2015-05-21T11:06:50Z
+gopkg.in/macaroon-bakery.v1	git	9b9ac0e3ff31c52ecbb264d1f4ec608f39870fa2	2015-06-22T08:19:08Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	c6a7dce14133ccac2dcac3793f1d6e2ef048503a	2015-01-24T11:37:54Z
-gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f5	2014-07-25T20:51:33Z
+gopkg.in/natefinch/lumberjack.v2	git	d28785c2f27cd682d872df46ccd8232843629f54	2014-07-25T20:51:33Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
 gopkg.in/yaml.v2	git	c1cd2254a6dd314c9d73c338c12688c9325d85c6	2015-05-19T10:42:33Z
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20140529072043-hzcrlnl3ygvg914q	18

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -14,9 +14,9 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
-	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // NewAPIHandlerFunc is a function that returns a new API handler that uses

--- a/internal/router/fieldinclude.go
+++ b/internal/router/fieldinclude.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"gopkg.in/errgo.v1"
+
 	"gopkg.in/juju/charmstore.v5-unstable/audit"
 )
 

--- a/server.go
+++ b/server.go
@@ -11,12 +11,12 @@ import (
 
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/mgo.v2"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/elasticsearch"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/legacy"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v4"
-	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // Versions of the API that can be served.


### PR DESCRIPTION
This means that the charmstore macaroon handling won't die
when mongo restarts or changes leader.
