### PR TITLE
internal/v4: fix crash when putting null to extra-info fields

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1117,7 +1117,8 @@ true
 #### PUT *id*/meta/extra-info
 
 This request updates the value of any metadata values. Any values that are not
-mentioned in the request are left untouched.
+mentioned in the request are left untouched. Any fields with null values are
+deleted.
 
 Example: `PUT precise/wordpress-32/meta/extra-info`
 
@@ -1131,6 +1132,7 @@ Request body:
 #### PUT *id*/meta/extra-info/*key*
 
 This request creates or updates the value for a specific key.
+If the value is null, the key is deleted.
 
 Example: `PUT precise/wordpress-32/meta/extra-info/vcs-digest`
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -755,6 +755,31 @@ func (s *APISuite) TestExtraInfo(c *gc.C) {
 		"bar":  "barval",
 		"frob": []int{1, 4, 6},
 	})
+
+	// Delete a single value.
+	s.assertPut(c, id+"/meta/extra-info/foo", nil)
+	s.assertGet(c, id+"/meta/extra-info", map[string]interface{}{
+		"baz":  "bazval",
+		"bar":  "barval",
+		"frob": []int{1, 4, 6},
+	})
+
+	// Delete a value and add some values at the same time.
+	s.assertPut(c, id+"/meta/any", params.MetaAnyResponse{
+		Meta: map[string]interface{}{
+			"extra-info": map[string]interface{}{
+				"baz":    nil,
+				"bar":    nil,
+				"dazzle": "x",
+				"fizzle": "y",
+			},
+		},
+	})
+	s.assertGet(c, id+"/meta/extra-info", map[string]interface{}{
+		"frob":   []int{1, 4, 6},
+		"dazzle": "x",
+		"fizzle": "y",
+	})
 }
 
 var extraInfoBadPutRequestsTests = []struct {
@@ -2558,8 +2583,8 @@ func (s *APISuite) TestPromulgate(c *gc.C) {
 			ref.Revision = 0
 
 			e := audit.Entry{
-				User: test.expectUser,
-				Op: audit.OpUnpromulgate,
+				User:   test.expectUser,
+				Op:     audit.OpUnpromulgate,
 				Entity: ref,
 			}
 			if test.expectPromulgate {

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -754,7 +754,6 @@ func (s *SearchSuite) TestLegacyStatsUpdatesSearch(c *gc.C) {
 	doc, err = s.store.ES.GetSearchDocument(charm.MustParseReference("~openstack-charmers/trusty/mysql-7"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(doc.TotalDownloads, gc.Equals, int64(57))
-
 }
 
 func (s *SearchSuite) assertPut(c *gc.C, url string, val interface{}) {


### PR DESCRIPTION
We now treat null when putting as a "delete this field" signal.
