### PR TITLE
fix some mongodb queries that cause errors with mongodb 2.6

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -348,7 +348,14 @@ func entityUpdateOp(fields map[string]interface{}) bson.D {
 			unsetFields = append(unsetFields, bson.DocElem{name, val})
 		}
 	}
-	return bson.D{{"$set", setFields}, {"$unset", unsetFields}}
+	op := make(bson.D, 0, 2)
+	if len(setFields) > 0 {
+		op = append(op, bson.DocElem{"$set", setFields})
+	}
+	if len(unsetFields) > 0 {
+		op = append(op, bson.DocElem{"$unset", unsetFields})
+	}
+	return op
 }
 
 func (h *ReqHandler) updateSearch(id *router.ResolvedURL, fields map[string]interface{}) error {


### PR DESCRIPTION
When running the tests locally I was getting errors from mongodb along the lines of: 

```
{'$set' is empty. You must specify a field like so: {$mod: {<field>: ...}}}
```

I think mongodb 2.6 is being stricter.

This changes the query that is generated for updates to only contain $set and $unset operations when necessary.
