### PR TITLE
match wily correctly in FindBestEntity and also in search

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -38,6 +38,8 @@ var seriesBoost = map[string]float64{
 	"trusty":      1.125,
 	"precise":     1.1125,
 	"utopic":      1.1,
+	"vivid":       1.101,
+	"wily":        1.102,
 	"win2012hvr2": 1.1,
 	"win2012hv":   1.1,
 	"win2012r2":   1.1,

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -693,6 +693,8 @@ var seriesScore = map[string]int{
 	"raring":  2,
 	"saucy":   3,
 	"utopic":  4,
+	"vivid":   5,
+	"wily":    6,
 }
 
 // EntitiesQuery creates a mgo.Query object that can be used to find

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -1720,6 +1720,9 @@ var findBestEntityTests = []struct {
 }, {
 	url:       "wordpress-simple",
 	expectURL: "~donald/bundle/wordpress-simple-1",
+}, {
+	url:       "~pluto/juju-gui",
+	expectURL: "~pluto/wily/juju-gui-1",
 }}
 
 func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
@@ -1831,6 +1834,28 @@ func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
 		Revision:            1,
 		PromulgatedURL:      charm.MustParseReference("bundle/wordpress-simple-0"),
 		PromulgatedRevision: 0,
+	})
+	c.Assert(err, gc.IsNil)
+	err = store.DB.Entities().Insert(&mongodoc.Entity{
+		URL:                 charm.MustParseReference("~pluto/utopic/juju-gui-2"),
+		BaseURL:             charm.MustParseReference("~pluto/juju-gui"),
+		User:                "pluto",
+		Series:              "utopic",
+		Name:                "juju-gui",
+		Revision:            2,
+		PromulgatedURL:      nil,
+		PromulgatedRevision: -1,
+	})
+	c.Assert(err, gc.IsNil)
+	err = store.DB.Entities().Insert(&mongodoc.Entity{
+		URL:                 charm.MustParseReference("~pluto/wily/juju-gui-1"),
+		BaseURL:             charm.MustParseReference("~pluto/juju-gui"),
+		User:                "pluto",
+		Series:              "wily",
+		Name:                "juju-gui",
+		Revision:            1,
+		PromulgatedURL:      nil,
+		PromulgatedRevision: -1,
 	})
 	c.Assert(err, gc.IsNil)
 	for i, test := range findBestEntityTests {


### PR DESCRIPTION
Add wily and vivid to the filtering and search mappings.
