### PR TITLE
internal/charmstore: remove redundant migrations

### DIFF
--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -5,12 +5,13 @@ package charmstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/char
 
 import (
 	"gopkg.in/errgo.v1"
-	"gopkg.in/juju/charmrepo.v1/csclient/params"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 )
+
+// TODO add migration names for all the migrations.
 
 // migrations holds all the migration functions that are executed in the order
 // they are defined when the charm store server is started. Each migration is
@@ -19,23 +20,11 @@ import (
 // migration name and function to this list, and update the
 // TestMigrateMigrationList test in migration_test.go adding the new name(s).
 // Note that migration names must be unique across the list.
-var migrations = []migration{{
-	name:    "entity ids denormalization",
-	migrate: denormalizeEntityIds,
-}, {
-	name:    "base entities creation",
-	migrate: createBaseEntities,
-}, {
-	name:    "read acl creation",
-	migrate: populateReadACL,
-}, {
-	name:    "write acl creation",
-	migrate: populateWriteACL,
-}}
+var migrations = []migration{}
 
 // migration holds a migration function with its corresponding name.
 type migration struct {
-	name    string
+	name    mongodoc.MigrationName
 	migrate func(StoreDatabase) error
 }
 
@@ -65,9 +54,9 @@ func migrate(db StoreDatabase) error {
 	return nil
 }
 
-func getExecuted(db StoreDatabase) (map[string]bool, error) {
+func getExecuted(db StoreDatabase) (map[mongodoc.MigrationName]bool, error) {
 	// Retrieve the already executed migration names.
-	executed := make(map[string]bool)
+	executed := make(map[mongodoc.MigrationName]bool)
 	var doc mongodoc.Migration
 	if err := db.Migrations().Find(nil).Select(bson.D{{"executed", 1}}).One(&doc); err != nil {
 		if err == mgo.ErrNotFound {
@@ -76,11 +65,12 @@ func getExecuted(db StoreDatabase) (map[string]bool, error) {
 		return nil, errgo.Notef(err, "cannot retrieve executed migrations")
 	}
 
-	names := make(map[string]bool, len(migrations))
+	names := make(map[mongodoc.MigrationName]bool, len(migrations))
 	for _, m := range migrations {
 		names[m.name] = true
 	}
 	for _, name := range doc.Executed {
+		name := mongodoc.MigrationName(name)
 		// Check that the already executed migrations are known.
 		if !names[name] {
 			return nil, errgo.Newf("found unknown migration %q; running old charm store code on newer charm store database?", name)
@@ -91,134 +81,11 @@ func getExecuted(db StoreDatabase) (map[string]bool, error) {
 	return executed, nil
 }
 
-func setExecuted(db StoreDatabase, name string) error {
+func setExecuted(db StoreDatabase, name mongodoc.MigrationName) error {
 	if _, err := db.Migrations().Upsert(nil, bson.D{{
 		"$addToSet", bson.D{{"executed", name}},
 	}}); err != nil {
 		return errgo.Notef(err, "cannot add %s to executed migrations", name)
 	}
-	return nil
-}
-
-// denormalizeEntityIds adds the user, name, revision and series fields to
-// entities where those fields are missing.
-// This function is not supposed to be called directly.
-func denormalizeEntityIds(db StoreDatabase) error {
-	entities := db.Entities()
-	var entity mongodoc.Entity
-	iter := entities.Find(bson.D{{
-		// Use the name field to collect not migrated entities.
-		"name", bson.D{{"$exists", false}},
-	}}).Select(bson.D{{"_id", 1}}).Iter()
-	defer iter.Close()
-
-	for iter.Next(&entity) {
-		logger.Infof("updating %s", entity.URL)
-		if err := entities.UpdateId(entity.URL, bson.D{{
-			"$set", bson.D{
-				{"user", entity.URL.User},
-				{"name", entity.URL.Name},
-				{"revision", entity.URL.Revision},
-				{"series", entity.URL.Series},
-			},
-		}}); err != nil {
-			return errgo.Notef(err, "cannot denormalize entity id %s", entity.URL)
-		}
-	}
-	if err := iter.Close(); err != nil {
-		return errgo.Notef(err, "cannot iterate entities")
-	}
-	return nil
-}
-
-// createBaseEntities creates base entities for each entity in the database.
-func createBaseEntities(db StoreDatabase) error {
-	baseEntities := db.BaseEntities()
-	counter := 0
-
-	var entity mongodoc.Entity
-	iter := db.Entities().Find(nil).Select(bson.D{{"baseurl", 1}}).Iter()
-	defer iter.Close()
-
-	for iter.Next(&entity) {
-		baseEntity := &mongodoc.BaseEntity{
-			URL:    entity.BaseURL,
-			Name:   entity.BaseURL.Name,
-			User:   entity.BaseURL.User,
-			Public: true,
-		}
-		err := baseEntities.Insert(baseEntity)
-		if err == nil {
-			counter++
-		} else if !mgo.IsDup(err) {
-			return errgo.Notef(err, "cannot create base entity %s", entity.BaseURL)
-		}
-
-	}
-	if err := iter.Close(); err != nil {
-		return errgo.Notef(err, "cannot iterate base entities")
-	}
-	logger.Infof("%d base entities created", counter)
-	return nil
-}
-
-// populateReadACL adds the read ACL to base entities not having it.
-func populateReadACL(db StoreDatabase) error {
-	baseEntities := db.BaseEntities()
-	var entity mongodoc.BaseEntity
-	iter := baseEntities.Find(bson.D{{
-		"$or", []bson.D{
-			{{"acls", bson.D{{"$exists", false}}}},
-			{{"acls.read", bson.D{{"$size", 0}}}},
-		},
-	}}).Select(bson.D{{"_id", 1}}).Iter()
-
-	defer iter.Close()
-
-	counter := 0
-	for iter.Next(&entity) {
-		readPerm := everyonePerm
-		if entity.URL.User != "" {
-			readPerm = []string{params.Everyone, entity.URL.User}
-		}
-		if err := baseEntities.UpdateId(entity.URL, bson.D{{
-			"$set", bson.D{{"acls.read", readPerm}},
-		}}); err != nil {
-			return errgo.Notef(err, "cannot populate read ACL for base entity %s", entity.URL)
-		}
-		counter++
-	}
-	if err := iter.Close(); err != nil {
-		return errgo.Notef(err, "cannot iterate base entities")
-	}
-	logger.Infof("%d base entities updated", counter)
-	return nil
-}
-
-// populateWriteACL adds the write ACL to base entities not having the field.
-func populateWriteACL(db StoreDatabase) error {
-	baseEntities := db.BaseEntities()
-	var entity mongodoc.BaseEntity
-	iter := baseEntities.Find(bson.D{{
-		"acls.write", bson.D{{"$exists", false}},
-	}, {
-		"user", bson.D{{"$ne", ""}},
-	}}).Select(bson.D{{"_id", 1}}).Iter()
-
-	defer iter.Close()
-
-	counter := 0
-	for iter.Next(&entity) {
-		if err := baseEntities.UpdateId(entity.URL, bson.D{{
-			"$set", bson.D{{"acls.write", []string{entity.URL.User}}},
-		}}); err != nil {
-			return errgo.Notef(err, "cannot populate write ACL for base entity %s", entity.URL)
-		}
-		counter++
-	}
-	if err := iter.Close(); err != nil {
-		return errgo.Notef(err, "cannot iterate base entities")
-	}
-	logger.Infof("%d base entities updated", counter)
 	return nil
 }

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -5,7 +5,6 @@ package charmstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/char
 
 import (
 	"net/http"
-	"sort"
 	"sync"
 
 	jujutesting "github.com/juju/testing"
@@ -13,7 +12,6 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-	"gopkg.in/juju/charmrepo.v1/csclient/params"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
@@ -23,7 +21,7 @@ import (
 type migrationsSuite struct {
 	jujutesting.IsolatedMgoSuite
 	db       StoreDatabase
-	executed []string
+	executed []mongodoc.MigrationName
 }
 
 var _ = gc.Suite(&migrationsSuite{})
@@ -31,7 +29,60 @@ var _ = gc.Suite(&migrationsSuite{})
 func (s *migrationsSuite) SetUpTest(c *gc.C) {
 	s.IsolatedMgoSuite.SetUpTest(c)
 	s.db = StoreDatabase{s.Session.DB("migration-testing")}
-	s.executed = []string{}
+	s.executed = nil
+}
+
+var (
+	// migrationFields holds the fields added to mongodoc.Entity,
+	// keyed by the migration step that added them.
+	migrationEntityFields = map[mongodoc.MigrationName][]string{}
+
+	// initialFields holds all the mongodoc.Entity fields
+	// at the dawn of migration time.
+	initialEntityFields = []string{
+		"_id",
+		"baseurl",
+		"user",
+		"name",
+		"revision",
+		"series",
+		"blobhash",
+		"blobhash256",
+		"size",
+		"blobname",
+		"uploadtime",
+		"extrainfo",
+		"charmmeta",
+		"charmconfig",
+		"charmactions",
+		"charmprovidedinterfaces",
+		"charmrequiredinterfaces",
+		"bundledata",
+		"bundlereadme",
+		"bundlemachinecount",
+		"bundleunitcount",
+		"contents",
+		"promulgated-url",
+		"promulgated-revision",
+	}
+
+	// finalEntityFields holds all the entity fields after all the migrations
+	// have taken place.
+	finalEntityFields []string
+
+	// entityFields holds all the fields in mongodoc.Entity just
+	// before the named migration (the key) has been applied.
+	entityFields = make(map[mongodoc.MigrationName][]string)
+)
+
+func init() {
+	// Initialize entityFields using the information specified in migrationFields.
+	allFields := initialEntityFields
+	for _, m := range migrations {
+		entityFields[m.name] = allFields
+		allFields = append(allFields, migrationEntityFields[m.name]...)
+	}
+	finalEntityFields = allFields
 }
 
 func (s *migrationsSuite) newServer(c *gc.C) error {
@@ -47,7 +98,7 @@ func (s *migrationsSuite) newServer(c *gc.C) error {
 	return err
 }
 
-// patchMigrations patches the charm store migration list with the given ms.
+// patchMigrations patches the charm store migration list with the given migrations.
 func (s *migrationsSuite) patchMigrations(c *gc.C, ms []migration) {
 	original := migrations
 	s.AddCleanup(func(*gc.C) {
@@ -58,7 +109,7 @@ func (s *migrationsSuite) patchMigrations(c *gc.C, ms []migration) {
 
 // makeMigrations generates default migrations using the given names, and then
 // patches the charm store migration list with the generated ones.
-func (s *migrationsSuite) makeMigrations(c *gc.C, names ...string) {
+func (s *migrationsSuite) makeMigrations(c *gc.C, names ...mongodoc.MigrationName) {
 	ms := make([]migration, len(names))
 	for i, name := range names {
 		name := name
@@ -75,7 +126,7 @@ func (s *migrationsSuite) makeMigrations(c *gc.C, names ...string) {
 
 func (s *migrationsSuite) TestMigrate(c *gc.C) {
 	// Create migrations.
-	names := []string{"migr-1", "migr-2"}
+	names := []mongodoc.MigrationName{"migr-1", "migr-2"}
 	s.makeMigrations(c, names...)
 
 	// Start the server.
@@ -123,7 +174,7 @@ func (s *migrationsSuite) TestMigrateNewMigration(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Only one migration has been executed.
-	c.Assert(s.executed, jc.DeepEquals, []string{"migr-3"})
+	c.Assert(s.executed, jc.DeepEquals, []mongodoc.MigrationName{"migr-3"})
 
 	// The migration document in the db reports that the execution is done.
 	s.checkExecuted(c, "migr-1", "migr-2", "migr-3")
@@ -174,7 +225,7 @@ func (s *migrationsSuite) TestMigrateErrorExecutingMigration(c *gc.C) {
 }
 
 func (s *migrationsSuite) TestMigrateMigrationNames(c *gc.C) {
-	names := make(map[string]bool, len(migrations))
+	names := make(map[mongodoc.MigrationName]bool, len(migrations))
 	for _, m := range migrations {
 		c.Assert(names[m.name], jc.IsFalse, gc.Commentf("multiple migrations named %q", m.name))
 		names[m.name] = true
@@ -184,12 +235,7 @@ func (s *migrationsSuite) TestMigrateMigrationNames(c *gc.C) {
 func (s *migrationsSuite) TestMigrateMigrationList(c *gc.C) {
 	// When adding migration, update the list below, but never remove existing
 	// migrations.
-	existing := []string{
-		"entity ids denormalization",
-		"base entities creation",
-		"read acl creation",
-		"write acl creation",
-	}
+	existing := []string{}
 	for i, name := range existing {
 		m := migrations[i]
 		c.Assert(m.name, gc.Equals, name)
@@ -201,11 +247,18 @@ func (s *migrationsSuite) TestMigrateParallelMigration(c *gc.C) {
 	// well when done in parallel, for example when multiple charm store units
 	// are deployed together.
 
-	// Prepare a database for the denormalizeEntityIds migration.
-	id1 := charm.MustParseReference("trusty/django-42")
-	id2 := charm.MustParseReference("~who/utopic/rails-47")
-	s.insertEntity(c, id1, "", 12)
-	s.insertEntity(c, id2, "", 13)
+	// Prepare a database for the migration.
+	e1 := denormalizeEntity(&mongodoc.Entity{
+		URL:            charm.MustParseReference("~charmers/trusty/django-42"),
+		PromulgatedURL: charm.MustParseReference("trusty/django-3"),
+		Size:           12,
+	})
+	e2 := denormalizeEntity(&mongodoc.Entity{
+		URL:  charm.MustParseReference("~who/utopic/rails-47"),
+		Size: 13,
+	})
+	s.insertEntity(c, e1, initialEntityFields)
+	s.insertEntity(c, e2, initialEntityFields)
 
 	// Run the migrations in parallel.
 	var wg sync.WaitGroup
@@ -225,41 +278,24 @@ func (s *migrationsSuite) TestMigrateParallelMigration(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 	}
 
-	// Ensure entities have been updated correctly by denormalizeEntityIds.
+	// Ensure entities have been updated correctly by all the migrations.
+	// TODO when there are migrations, update e1 and e2 accordingly.
 	s.checkCount(c, s.db.Entities(), 2)
-	s.checkEntity(c, &mongodoc.Entity{
-		URL:      id1,
-		BaseURL:  baseURL(id1),
-		User:     "",
-		Name:     "django",
-		Revision: 42,
-		Series:   "trusty",
-		Size:     12,
-	})
-	s.checkEntity(c, &mongodoc.Entity{
-		URL:      id2,
-		BaseURL:  baseURL(id2),
-		User:     "who",
-		Name:     "rails",
-		Revision: 47,
-		Series:   "utopic",
-		Size:     13,
-	})
+	s.checkEntity(c, e1)
+	s.checkEntity(c, e2)
 }
 
-func (s *migrationsSuite) checkExecuted(c *gc.C, expected ...string) {
-	var obtained []string
+func (s *migrationsSuite) checkExecuted(c *gc.C, expected ...mongodoc.MigrationName) {
+	var obtained []mongodoc.MigrationName
 	var doc mongodoc.Migration
 	if err := s.db.Migrations().Find(nil).One(&doc); err != mgo.ErrNotFound {
 		c.Assert(err, gc.IsNil)
 		obtained = doc.Executed
-		sort.Strings(obtained)
 	}
-	sort.Strings(expected)
-	c.Assert(obtained, jc.DeepEquals, expected)
+	c.Assert(obtained, jc.SameContents, expected)
 }
 
-func getMigrations(names ...string) (ms []migration) {
+func getMigrations(names ...mongodoc.MigrationName) (ms []migration) {
 	for _, name := range names {
 		for _, m := range migrations {
 			if m.name == name {
@@ -270,539 +306,11 @@ func getMigrations(names ...string) (ms []migration) {
 	return ms
 }
 
-func (s *migrationsSuite) TestDenormalizeEntityIds(c *gc.C) {
-	s.patchMigrations(c, getMigrations("entity ids denormalization"))
-	// Store entities with missing name in the db.
-	id1 := charm.MustParseReference("trusty/django-42")
-	id2 := charm.MustParseReference("~who/utopic/rails-47")
-	s.insertEntity(c, id1, "", 12)
-	s.insertEntity(c, id2, "", 13)
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure entities have been updated correctly.
-	s.checkCount(c, s.db.Entities(), 2)
-	s.checkEntity(c, &mongodoc.Entity{
-		URL:      id1,
-		BaseURL:  baseURL(id1),
-		User:     "",
-		Name:     "django",
-		Revision: 42,
-		Series:   "trusty",
-		Size:     12,
-	})
-	s.checkEntity(c, &mongodoc.Entity{
-		URL:      id2,
-		BaseURL:  baseURL(id2),
-		User:     "who",
-		Name:     "rails",
-		Revision: 47,
-		Series:   "utopic",
-		Size:     13,
-	})
-}
-
-func (s *migrationsSuite) TestDenormalizeEntityIdsNoEntities(c *gc.C) {
-	s.patchMigrations(c, getMigrations("entity ids denormalization"))
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure no new entities are added in the process.
-	s.checkCount(c, s.db.Entities(), 0)
-}
-
-func (s *migrationsSuite) TestDenormalizeEntityIdsNoUpdates(c *gc.C) {
-	s.patchMigrations(c, getMigrations("entity ids denormalization"))
-	// Store entities with a name in the db.
-	id1 := charm.MustParseReference("trusty/django-42")
-	id2 := charm.MustParseReference("~who/utopic/rails-47")
-	s.insertEntity(c, id1, "django", 21)
-	s.insertEntity(c, id2, "rails2", 22)
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure entities have been updated correctly.
-	s.checkCount(c, s.db.Entities(), 2)
-	s.checkEntity(c, &mongodoc.Entity{
-		URL:     id1,
-		BaseURL: baseURL(id1),
-		User:    "",
-		Name:    "django",
-		// Since the name field already existed, the Revision and Series fields
-		// have not been populated.
-		Size: 21,
-	})
-	s.checkEntity(c, &mongodoc.Entity{
-		URL:     id2,
-		BaseURL: baseURL(id2),
-		// The name is left untouched (even if it's obviously wrong).
-		Name: "rails2",
-		// Since the name field already existed, the User, Revision and Series
-		// fields have not been populated.
-		Size: 22,
-	})
-}
-
-func (s *migrationsSuite) TestDenormalizeEntityIdsSomeUpdates(c *gc.C) {
-	s.patchMigrations(c, getMigrations("entity ids denormalization"))
-	// Store entities with and without names in the db
-	id1 := charm.MustParseReference("~dalek/utopic/django-42")
-	id2 := charm.MustParseReference("~dalek/utopic/django-47")
-	id3 := charm.MustParseReference("precise/postgres-0")
-	s.insertEntity(c, id1, "", 1)
-	s.insertEntity(c, id2, "django", 2)
-	s.insertEntity(c, id3, "", 3)
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure entities have been updated correctly.
-	s.checkCount(c, s.db.Entities(), 3)
-	s.checkEntity(c, &mongodoc.Entity{
-		URL:      id1,
-		BaseURL:  baseURL(id1),
-		User:     "dalek",
-		Name:     "django",
-		Revision: 42,
-		Series:   "utopic",
-		Size:     1,
-	})
-	s.checkEntity(c, &mongodoc.Entity{
-		URL:     id2,
-		BaseURL: baseURL(id2),
-		Name:    "django",
-		Size:    2,
-	})
-	s.checkEntity(c, &mongodoc.Entity{
-		URL:      id3,
-		BaseURL:  baseURL(id3),
-		User:     "",
-		Name:     "postgres",
-		Revision: 0,
-		Series:   "precise",
-		Size:     3,
-	})
-}
-
-func (s *migrationsSuite) TestCreateBaseEntities(c *gc.C) {
-	s.patchMigrations(c, getMigrations("base entities creation"))
-	// Store entities with missing base in the db.
-	id1 := charm.MustParseReference("trusty/django-42")
-	id2 := charm.MustParseReference("trusty/django-47")
-	id3 := charm.MustParseReference("~who/utopic/rails-47")
-	s.insertEntity(c, id1, "django", 12)
-	s.insertEntity(c, id2, "django", 12)
-	s.insertEntity(c, id3, "rails", 13)
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure base entities have been created correctly.
-	s.checkCount(c, s.db.BaseEntities(), 2)
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id1),
-		Name:   "django",
-		Public: true,
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id3),
-		User:   "who",
-		Name:   "rails",
-		Public: true,
-	})
-}
-
-func (s *migrationsSuite) TestCreateBaseEntitiesNoEntities(c *gc.C) {
-	s.patchMigrations(c, getMigrations("base entities creation"))
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure no new base entities are added in the process.
-	s.checkCount(c, s.db.BaseEntities(), 0)
-}
-
-func (s *migrationsSuite) TestCreateBaseEntitiesNoUpdates(c *gc.C) {
-	s.patchMigrations(c, getMigrations("base entities creation"))
-	// Store entities with their corresponding base in the db.
-	id1 := charm.MustParseReference("trusty/django-42")
-	id2 := charm.MustParseReference("~who/utopic/rails-47")
-	s.insertEntity(c, id1, "django", 21)
-	s.insertEntity(c, id2, "rails2", 22)
-	s.insertBaseEntity(c, baseURL(id1), nil)
-	s.insertBaseEntity(c, baseURL(id2), nil)
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure no new base entities are added in the process.
-	s.checkCount(c, s.db.BaseEntities(), 2)
-}
-
-func (s *migrationsSuite) TestCreateBaseEntitiesSomeUpdates(c *gc.C) {
-	s.patchMigrations(c, getMigrations("base entities creation"))
-	// Store entities with and without bases in the db
-	id1 := charm.MustParseReference("~dalek/utopic/django-42")
-	id2 := charm.MustParseReference("~dalek/utopic/django-47")
-	id3 := charm.MustParseReference("precise/postgres-0")
-	s.insertEntity(c, id1, "django", 1)
-	s.insertEntity(c, id2, "django", 2)
-	s.insertEntity(c, id3, "postgres", 3)
-	s.insertBaseEntity(c, baseURL(id2), nil)
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure missing base entities have been created correctly.
-	s.checkCount(c, s.db.BaseEntities(), 2)
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id1),
-		User:   "dalek",
-		Name:   "django",
-		Public: true,
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id3),
-		Name:   "postgres",
-		Public: true,
-	})
-}
-
-func (s *migrationsSuite) TestPopulateReadACL(c *gc.C) {
-	s.patchMigrations(c, getMigrations("read acl creation"))
-	// Store entities with their base in the db.
-	// The base entities will not include any read permission.
-	id1 := charm.MustParseReference("trusty/django-42")
-	id2 := charm.MustParseReference("trusty/django-47")
-	id3 := charm.MustParseReference("~who/utopic/rails-47")
-	s.insertEntity(c, id1, "django", 12)
-	s.insertEntity(c, id2, "django", 12)
-	s.insertEntity(c, id3, "rails", 13)
-	baseId1 := baseURL(id1)
-	baseId3 := baseURL(id3)
-	s.insertBaseEntity(c, baseId1, nil)
-	s.insertBaseEntity(c, baseId3, nil)
-
-	// Ensure read permission is empty.
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId1,
-		Name:   "django",
-		Public: true,
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId3,
-		User:   "who",
-		Name:   "rails",
-		Public: true,
-	})
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure read permission has been correctly set.
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId1,
-		Name:   "django",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{params.Everyone},
-		},
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId3,
-		User:   "who",
-		Name:   "rails",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{params.Everyone, "who"},
-		},
-	})
-}
-
-func (s *migrationsSuite) TestCreateBaseEntitiesAndPopulateReadACL(c *gc.C) {
-	s.patchMigrations(c, getMigrations("base entities creation", "read acl creation"))
-	// Store entities with missing base in the db.
-	id1 := charm.MustParseReference("trusty/django-42")
-	id2 := charm.MustParseReference("trusty/django-47")
-	id3 := charm.MustParseReference("~who/utopic/rails-47")
-	s.insertEntity(c, id1, "django", 12)
-	s.insertEntity(c, id2, "django", 12)
-	s.insertEntity(c, id3, "rails", 13)
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure base entities have been created correctly.
-	s.checkCount(c, s.db.BaseEntities(), 2)
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id1),
-		Name:   "django",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{params.Everyone},
-		},
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id3),
-		User:   "who",
-		Name:   "rails",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{params.Everyone, "who"},
-		},
-	})
-}
-
-func (s *migrationsSuite) TestPopulateReadACLNoEntities(c *gc.C) {
-	s.patchMigrations(c, getMigrations("read acl creation"))
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure no new base entities are added in the process.
-	s.checkCount(c, s.db.BaseEntities(), 0)
-}
-
-func (s *migrationsSuite) TestPopulateReadACLNoUpdates(c *gc.C) {
-	s.patchMigrations(c, getMigrations("read acl creation"))
-	// Store entities with their corresponding base in the db.
-	id1 := charm.MustParseReference("trusty/django-42")
-	id2 := charm.MustParseReference("~who/utopic/rails-47")
-	s.insertEntity(c, id1, "django", 21)
-	s.insertEntity(c, id2, "rails2", 22)
-	s.insertBaseEntity(c, baseURL(id1), &mongodoc.ACL{
-		Read: []string{"jean-luc"},
-	})
-	s.insertBaseEntity(c, baseURL(id2), &mongodoc.ACL{
-		Read: []string{"who"},
-	})
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure no new base entities are added in the process, and read
-	// permissions were not changed.
-	s.checkCount(c, s.db.BaseEntities(), 2)
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id1),
-		Name:   "django",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{"jean-luc"},
-		},
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id2),
-		User:   "who",
-		Name:   "rails",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{"who"},
-		},
-	})
-}
-
-func (s *migrationsSuite) TestPopulateReadACLSomeUpdates(c *gc.C) {
-	s.patchMigrations(c, getMigrations("read acl creation"))
-	// Store entities with and without bases in the db
-	id1 := charm.MustParseReference("~dalek/utopic/django-42")
-	id2 := charm.MustParseReference("~dalek/utopic/django-47")
-	id3 := charm.MustParseReference("precise/postgres-0")
-	s.insertEntity(c, id1, "django", 1)
-	s.insertEntity(c, id2, "django", 2)
-	s.insertEntity(c, id3, "postgres", 3)
-	baseId1 := baseURL(id1)
-	baseId3 := baseURL(id3)
-	s.insertBaseEntity(c, baseId1, nil)
-	s.insertBaseEntity(c, baseId3, &mongodoc.ACL{
-		Read: []string{"benjamin"},
-	})
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure missing read permissions have been populated correctly.
-	s.checkCount(c, s.db.BaseEntities(), 2)
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId1,
-		User:   "dalek",
-		Name:   "django",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{params.Everyone, "dalek"},
-		},
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId3,
-		Name:   "postgres",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{"benjamin"},
-		},
-	})
-}
-
-func (s *migrationsSuite) TestPopulateWriteACL(c *gc.C) {
-	s.patchMigrations(c, getMigrations("write acl creation"))
-	// Store entities with their base in the db.
-	// The base entities will not include any write permission.
-	id1 := charm.MustParseReference("~who/trusty/django-42")
-	id2 := charm.MustParseReference("~who/django-47")
-	id3 := charm.MustParseReference("~dalek/utopic/rails-47")
-	s.insertEntity(c, id1, "django", 12)
-	s.insertEntity(c, id2, "django", 12)
-	s.insertEntity(c, id3, "rails", 13)
-	baseId1 := baseURL(id1)
-	baseId3 := baseURL(id3)
-	s.insertBaseEntity(c, baseId1, nil)
-	s.insertBaseEntity(c, baseId3, nil)
-
-	// Ensure write permission is empty.
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId1,
-		User:   "who",
-		Name:   "django",
-		Public: true,
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId3,
-		User:   "dalek",
-		Name:   "rails",
-		Public: true,
-	})
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure write permission has been correctly set.
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId1,
-		User:   "who",
-		Name:   "django",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Write: []string{"who"},
-		},
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId3,
-		User:   "dalek",
-		Name:   "rails",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Write: []string{"dalek"},
-		},
-	})
-}
-
-func (s *migrationsSuite) TestPopulateWriteACLNoEntities(c *gc.C) {
-	s.patchMigrations(c, getMigrations("write acl creation"))
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure no new base entities are added in the process.
-	s.checkCount(c, s.db.BaseEntities(), 0)
-}
-
-func (s *migrationsSuite) TestPopulateWriteACLNoUpdates(c *gc.C) {
-	s.patchMigrations(c, getMigrations("write acl creation"))
-	// Store entities with their corresponding base in the db.
-	id1 := charm.MustParseReference("trusty/django-42")
-	id2 := charm.MustParseReference("~who/utopic/rails-47")
-	s.insertEntity(c, id1, "django", 21)
-	s.insertEntity(c, id2, "rails2", 22)
-	s.insertBaseEntity(c, baseURL(id1), nil)
-	s.insertBaseEntity(c, baseURL(id2), &mongodoc.ACL{
-		Write: []string{"dalek"},
-	})
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure no new base entities are added in the process, and write
-	// permissions were not changed.
-	s.checkCount(c, s.db.BaseEntities(), 2)
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id1),
-		Name:   "django",
-		Public: true,
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseURL(id2),
-		User:   "who",
-		Name:   "rails",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Write: []string{"dalek"},
-		},
-	})
-}
-
-func (s *migrationsSuite) TestPopulateWriteACLSomeUpdates(c *gc.C) {
-	s.patchMigrations(c, getMigrations("write acl creation"))
-	// Store entities with and without bases in the db
-	id1 := charm.MustParseReference("~dalek/utopic/django-42")
-	id2 := charm.MustParseReference("~dalek/utopic/django-47")
-	id3 := charm.MustParseReference("~jean-luc/precise/postgres-0")
-	s.insertEntity(c, id1, "django", 1)
-	s.insertEntity(c, id2, "django", 2)
-	s.insertEntity(c, id3, "postgres", 3)
-	baseId1 := baseURL(id1)
-	baseId3 := baseURL(id3)
-	s.insertBaseEntity(c, baseId1, nil)
-	s.insertBaseEntity(c, baseId3, &mongodoc.ACL{
-		Write: []string{"benjamin"},
-	})
-
-	// Start the server.
-	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
-
-	// Ensure missing write permissions have been populated correctly.
-	s.checkCount(c, s.db.BaseEntities(), 2)
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId1,
-		User:   "dalek",
-		Name:   "django",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Write: []string{"dalek"},
-		},
-	})
-	s.checkBaseEntity(c, &mongodoc.BaseEntity{
-		URL:    baseId3,
-		User:   "jean-luc",
-		Name:   "postgres",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Write: []string{"benjamin"},
-		},
-	})
-}
-
 func (s *migrationsSuite) checkEntity(c *gc.C, expectEntity *mongodoc.Entity) {
 	var entity mongodoc.Entity
 	err := s.db.Entities().FindId(expectEntity.URL).One(&entity)
 	c.Assert(err, gc.IsNil)
 
-	// Ensure that the denormalized fields are now present, and the previously
-	// existing fields are still there.
 	c.Assert(&entity, jc.DeepEquals, expectEntity)
 }
 
@@ -825,49 +333,55 @@ func (s *migrationsSuite) checkBaseEntitiesCount(c *gc.C, expectCount int) {
 	c.Assert(count, gc.Equals, expectCount)
 }
 
-func (s *migrationsSuite) insertEntity(c *gc.C, id *charm.Reference, name string, size int64) {
-	entity := &mongodoc.Entity{
-		URL:     id,
-		BaseURL: baseURL(id),
-		Name:    name,
-		Size:    size,
+// denormalizeEntity returns a copy of e0 with all denormalized fields
+// filled out if they are zero.
+func denormalizeEntity(e0 *mongodoc.Entity) *mongodoc.Entity {
+	e := *e0
+	if e.BaseURL == nil {
+		e.BaseURL = baseURL(e.URL)
 	}
-	err := s.db.Entities().Insert(entity)
-	c.Assert(err, gc.IsNil)
-
-	// Remove the denormalized fields if required.
-	if name != "" {
-		return
+	if e.Name == "" {
+		e.Name = e.URL.Name
 	}
-	err = s.db.Entities().UpdateId(id, bson.D{{
-		"$unset", bson.D{
-			{"user", true},
-			{"name", true},
-			{"revision", true},
-			{"series", true},
-		},
-	}})
-	c.Assert(err, gc.IsNil)
+	if e.User == "" {
+		e.User = e.URL.User
+	}
+	if e.Revision == 0 {
+		e.Revision = e.URL.Revision
+	}
+	if e.Series == "" {
+		e.Series = e.URL.Series
+	}
+	if e.PromulgatedRevision == 0 {
+		if e.PromulgatedURL == nil {
+			e.PromulgatedRevision = -1
+		} else {
+			e.PromulgatedRevision = e.PromulgatedURL.Revision
+		}
+	}
+	return &e
 }
 
-func (s *migrationsSuite) insertBaseEntity(c *gc.C, id *charm.Reference, acls *mongodoc.ACL) {
-	entity := &mongodoc.BaseEntity{
-		URL:    id,
-		Name:   id.Name,
-		User:   id.User,
-		Public: true,
-	}
-	if acls != nil {
-		entity.ACLs = *acls
-	}
-	err := s.db.BaseEntities().Insert(entity)
+// insertEntity inserts the given entity. If any include fields are specified,
+// only those given entity fields will be inserted.
+func (s *migrationsSuite) insertEntity(c *gc.C, e *mongodoc.Entity, includeFields []string) {
+	data, err := bson.Marshal(e)
+	c.Assert(err, gc.IsNil)
+	var rawEntity map[string]interface{}
+	err = bson.Unmarshal(data, &rawEntity)
 	c.Assert(err, gc.IsNil)
 
-	// Unset the ACL fields if required to simulate a migration.
-	if acls == nil {
-		err = s.db.BaseEntities().UpdateId(id, bson.D{{"$unset",
-			bson.D{{"acls", true}},
-		}})
-		c.Assert(err, gc.IsNil)
+	if len(includeFields) > 0 {
+	loop:
+		for k := range rawEntity {
+			for _, inc := range includeFields {
+				if inc == k {
+					continue loop
+				}
+			}
+			delete(rawEntity, k)
+		}
 	}
+	err = s.db.Entities().Insert(rawEntity)
+	c.Assert(err, gc.IsNil)
 }

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -237,10 +237,12 @@ const (
 	LegacyStatisticsType
 )
 
+type MigrationName string
+
 // Migration holds information about the database migration.
 type Migration struct {
 	// Executed holds the migration names for migrations already executed.
-	Executed []string
+	Executed []MigrationName
 }
 
 // IntBool is a bool that will be represented internally in the database as 1 for


### PR DESCRIPTION
We also refactor the insertEntity code so that it's more future-proof,
and record the expected entity fields at each version.
