### PR TITLE
internal/charmstore: implement multi-series find-id logic

### DIFF
--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -255,14 +255,14 @@ func (s *migrationsSuite) TestMigrateParallelMigration(c *gc.C) {
 		PromulgatedURL: charm.MustParseReference("trusty/django-3"),
 		Size:           12,
 	}
-	denormalizeEntity(e1)
+	DenormalizeEntity(e1)
 	s.insertEntity(c, e1, initialEntityFields)
 
 	e2 := &mongodoc.Entity{
 		URL:  charm.MustParseReference("~who/utopic/rails-47"),
 		Size: 13,
 	}
-	denormalizeEntity(e2)
+	DenormalizeEntity(e2)
 	s.insertEntity(c, e2, initialEntityFields)
 
 	// Run the migrations in parallel.
@@ -305,7 +305,7 @@ func (s *migrationsSuite) TestAddSupportedSeries(c *gc.C) {
 		Size: 13,
 	}}
 	for _, e := range entities {
-		denormalizeEntity(e)
+		DenormalizeEntity(e)
 		s.insertEntity(c, e, entityFields[migrationAddSupportedSeries])
 	}
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -1261,8 +1261,8 @@ var resolveURLTests = []struct {
 	url:    "~charmers/wordpress",
 	expect: newResolvedURL("cs:~charmers/trusty/wordpress-25", -1),
 }, {
-	url:    "~charmers/wordpress-24",
-	expect: newResolvedURL("cs:~charmers/trusty/wordpress-24", -1),
+	url:      "~charmers/wordpress-24",
+	notFound: true,
 }, {
 	url:    "~bob/wordpress",
 	expect: newResolvedURL("cs:~bob/trusty/wordpress-1", -1),
@@ -1273,8 +1273,8 @@ var resolveURLTests = []struct {
 	url:    "bigdata",
 	expect: newResolvedURL("cs:~charmers/utopic/bigdata-10", 10),
 }, {
-	url:    "wordpress-24",
-	expect: newResolvedURL("cs:~charmers/trusty/wordpress-24", 24),
+	url:      "wordpress-24",
+	notFound: true,
 }, {
 	url:    "bundlelovin",
 	expect: newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10),
@@ -1345,8 +1345,14 @@ var serveExpandIdTests = []struct {
 		{Id: "cs:precise/haproxy-1"},
 	},
 }, {
-	about: "single result",
+	about: "revision with series matches bundles (and multi-series charms) only",
 	url:   "mongo-0",
+	expect: []params.ExpandedId{
+		{Id: "cs:bundle/mongo-0"},
+	},
+}, {
+	about: "single result",
+	url:   "bundle/mongo-0",
 	expect: []params.ExpandedId{
 		{Id: "cs:bundle/mongo-0"},
 	},


### PR DESCRIPTION
This implements the behaviour described in https://docs.google.com/document/d/1hiQ1aka40Jx9QdnXHXgtGzAZopIuAkDIO-pV-cZhASc .

The EntitiesQuery logic could be made more efficient but I've left it as is because I think it more clear this way, and the actual performance hit from the redundant condition checks is likely to be negligible.

Note that this also introduces a behaviour change into the API. A charm id with a revision but no specified series will not match old charms. If anyone was using that functionality previously, they were almost certainly doing it wrong. 
