### PR TITLE
always resolve the requested entity URL against the database

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -228,13 +228,6 @@ func (h *ReqHandler) Close() {
 // ResolveURL resolves the series and revision of the given URL if either is
 // unspecified by filling them out with information retrieved from the store.
 func ResolveURL(store *charmstore.Store, url *charm.Reference) (*router.ResolvedURL, error) {
-	if url.Series != "" && url.Revision != -1 && url.User != "" {
-		// URL is fully specified; no need for a database lookup.
-		return &router.ResolvedURL{
-			URL:                 *url,
-			PromulgatedRevision: -1,
-		}, nil
-	}
 	entity, err := store.FindBestEntity(url, "_id", "promulgated-revision")
 	if err != nil && errgo.Cause(err) != params.ErrNotFound {
 		return nil, errgo.Mask(err)

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -711,10 +711,11 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 }
 
 func (s *APISuite) TestMetaPermPutUnauthorized(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/utopic/wordpress-23", 23))
+	id := "precise/wordpress-23"
+	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.noMacaroonSrv,
-		URL:     storeURL("~charmers/precise/wordpress-23/meta/perm/read"),
+		URL:     storeURL("~charmers/" + id + "/meta/perm/read"),
 		Method:  "PUT",
 		Header: http.Header{
 			"Content-Type": {"application/json"},
@@ -1255,8 +1256,8 @@ var resolveURLTests = []struct {
 	url:    "~charmers/precise/wordpress",
 	expect: newResolvedURL("cs:~charmers/precise/wordpress-24", -1),
 }, {
-	url:    "~charmers/precise/wordpress-99",
-	expect: newResolvedURL("cs:~charmers/precise/wordpress-99", -1),
+	url:      "~charmers/precise/wordpress-99",
+	notFound: true,
 }, {
 	url:    "~charmers/wordpress",
 	expect: newResolvedURL("cs:~charmers/trusty/wordpress-25", -1),
@@ -1331,13 +1332,6 @@ var serveExpandIdTests = []struct {
 		{Id: "cs:~charmers/trusty/wordpress-47"},
 	},
 }, {
-	about: "fully qualified URL that does not exist",
-	url:   "~charmers/trusty/wordpress-99",
-	expect: []params.ExpandedId{
-		{Id: "cs:~charmers/utopic/wordpress-42"},
-		{Id: "cs:~charmers/trusty/wordpress-47"},
-	},
-}, {
 	about: "partial URL",
 	url:   "haproxy",
 	expect: []params.ExpandedId{
@@ -1359,7 +1353,7 @@ var serveExpandIdTests = []struct {
 }, {
 	about: "fully qualified URL with no entities found",
 	url:   "~charmers/precise/no-such-42",
-	err:   `entity "cs:~charmers/precise/no-such-42" not found`,
+	err:   `no matching charm or bundle for "cs:~charmers/precise/no-such-42"`,
 }, {
 	about: "partial URL with no entities found",
 	url:   "no-such",
@@ -2397,52 +2391,6 @@ var promulgateTests = []struct {
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
 		Message: `no matching charm or bundle for "cs:~charmers/mysql"`,
-	},
-	expectEntities: []*mongodoc.Entity{
-		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),
-	},
-	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
-	},
-}, {
-	about: "promulgate base entity not found, fully qualified URL",
-	entities: []*mongodoc.Entity{
-		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),
-	},
-	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
-	},
-	id:           "~charmers/precise/mysql-9",
-	body:         storetesting.JSONReader(params.PromulgateRequest{Promulgated: true}),
-	username:     testUsername,
-	password:     testPassword,
-	expectStatus: http.StatusNotFound,
-	expectBody: params.Error{
-		Code:    params.ErrNotFound,
-		Message: `base entity "cs:~charmers/mysql" not found`,
-	},
-	expectEntities: []*mongodoc.Entity{
-		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),
-	},
-	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
-	},
-}, {
-	about: "unpromulgate base entity not found, fully qualified URL",
-	entities: []*mongodoc.Entity{
-		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),
-	},
-	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
-	},
-	id:           "~charmers/precise/mysql-9",
-	body:         storetesting.JSONReader(params.PromulgateRequest{Promulgated: true}),
-	username:     testUsername,
-	password:     testPassword,
-	expectStatus: http.StatusNotFound,
-	expectBody: params.Error{
-		Code:    params.ErrNotFound,
-		Message: `base entity "cs:~charmers/mysql" not found`,
 	},
 	expectEntities: []*mongodoc.Entity{
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -913,7 +913,7 @@ var archiveFileErrorsTests = []struct {
 	about:         "entity not found",
 	path:          "~charmers/trusty/no-such-42/archive/icon.svg",
 	expectStatus:  http.StatusNotFound,
-	expectMessage: `entity "cs:~charmers/trusty/no-such-42" not found`,
+	expectMessage: `no matching charm or bundle for "cs:~charmers/trusty/no-such-42"`,
 	expectCode:    params.ErrNotFound,
 }, {
 	about:         "directory listing",
@@ -1178,7 +1178,7 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 		Password:     testPassword,
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
-			Message: `entity "cs:~charmers/utopic/no-such-0" not found`,
+			Message: `no matching charm or bundle for "cs:~charmers/utopic/no-such-0"`,
 			Code:    params.ErrNotFound,
 		},
 	})

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -36,7 +36,7 @@ var serveDiagramErrorsTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: `entity "cs:~charmers/bundle/foo-23" not found`,
+		Message: `no matching charm or bundle for "cs:~charmers/bundle/foo-23"`,
 	},
 }, {
 	about:        "diagram for a charm",
@@ -211,44 +211,6 @@ func (s *APISuite) TestServeReadMe(c *gc.C) {
 			assertCacheControl(c, rec.Header(), true)
 		}
 	}
-}
-
-func (s *APISuite) TestServeReadMeEntityNotFound(c *gc.C) {
-	// Add another charm so that the base entity exists so we
-	// actually get through to the code we're wanting to test.
-	// (if the base entity does not exist, the authorization code
-	// will fail).
-	url := newResolvedURL("~charmers/precise/nothingatall-1", -1)
-	s.addPublicCharm(c, "wordpress", url)
-
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler:      s.srv,
-		URL:          storeURL("~charmers/precise/nothingatall-32/readme"),
-		ExpectStatus: http.StatusNotFound,
-		ExpectBody: params.Error{
-			Code:    params.ErrNotFound,
-			Message: `cannot get README: entity not found`,
-		},
-	})
-}
-
-func (s *APISuite) TestServeIconEntityNotFound(c *gc.C) {
-	// Add another charm so that the base entity exists so we
-	// actually get through to the code we're wanting to test.
-	// (if the base entity does not exist, the authorization code
-	// will fail).
-	id := newResolvedURL("~charmers/precise/nothingatall-1", -1)
-	s.addPublicCharm(c, "wordpress", id)
-
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler:      s.srv,
-		URL:          storeURL("~charmers/precise/nothingatall-32/icon.svg"),
-		ExpectStatus: http.StatusNotFound,
-		ExpectBody: params.Error{
-			Code:    params.ErrNotFound,
-			Message: `cannot get icon: entity not found`,
-		},
-	})
 }
 
 func charmWithExtraFile(c *gc.C, name, file, content string) *charm.CharmDir {

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -222,7 +222,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 				CharmReference: charm.MustParseReference("~charmers/precise/unknown-23"),
 			}},
 		},
-		expectMessage: "cannot find entity cs:~charmers/precise/unknown-23: entity not found",
+		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for "cs:~charmers/precise/unknown-23"`,
 	}, {
 		path:   "stats/update",
 		status: http.StatusInternalServerError,
@@ -235,7 +235,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 				CharmReference: charm.MustParseReference("~charmers/precise/wordpress-23"),
 			}},
 		},
-		expectMessage: "cannot find entity cs:~charmers/precise/unknown-23: entity not found",
+		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for "cs:~charmers/precise/unknown-23"`,
 		partialUpdate: true,
 	}}
 


### PR DESCRIPTION
The tests that are removed are ones specifically to test the functionality of a fully resolved (unchecked) entity that is not present. This can no longer happen.
