### PR TITLE
Unexport DenormalizeEntity

### DIFF
--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -255,14 +255,14 @@ func (s *migrationsSuite) TestMigrateParallelMigration(c *gc.C) {
 		PromulgatedURL: charm.MustParseReference("trusty/django-3"),
 		Size:           12,
 	}
-	DenormalizeEntity(e1)
+	denormalizeEntity(e1)
 	s.insertEntity(c, e1, initialEntityFields)
 
 	e2 := &mongodoc.Entity{
 		URL:  charm.MustParseReference("~who/utopic/rails-47"),
 		Size: 13,
 	}
-	DenormalizeEntity(e2)
+	denormalizeEntity(e2)
 	s.insertEntity(c, e2, initialEntityFields)
 
 	// Run the migrations in parallel.
@@ -305,7 +305,7 @@ func (s *migrationsSuite) TestAddSupportedSeries(c *gc.C) {
 		Size: 13,
 	}}
 	for _, e := range entities {
-		DenormalizeEntity(e)
+		denormalizeEntity(e)
 		s.insertEntity(c, e, entityFields[migrationAddSupportedSeries])
 	}
 

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -542,7 +542,7 @@ func (s *Store) AddCharm(c charm.Charm, p AddParams) (err error) {
 		CharmRequiredInterfaces: interfacesForRelations(c.Meta().Requires),
 		Contents:                p.Contents,
 	}
-	DenormalizeEntity(entity)
+	denormalizeEntity(entity)
 
 	// Check that we're not going to create a charm that duplicates
 	// the name of a bundle. This is racy, but it's the best we can do.
@@ -561,7 +561,7 @@ func (s *Store) AddCharm(c charm.Charm, p AddParams) (err error) {
 	return nil
 }
 
-// DenormalizeEntity sets all denormalized fields in e
+// denormalizeEntity sets all denormalized fields in e
 // from their associated canonical fields.
 //
 // It is the responsibility of the caller to set e.SupportedSeries
@@ -571,7 +571,7 @@ func (s *Store) AddCharm(c charm.Charm, p AddParams) (err error) {
 //
 // This is exported for the purposes of tests that
 // need to create directly into the database.
-func DenormalizeEntity(e *mongodoc.Entity) {
+func denormalizeEntity(e *mongodoc.Entity) {
 	e.BaseURL = baseURL(e.URL)
 	e.Name = e.URL.Name
 	e.User = e.URL.User
@@ -1018,7 +1018,7 @@ func (s *Store) AddBundle(b charm.Bundle, p AddParams) error {
 		Contents:           p.Contents,
 		PromulgatedURL:     p.URL.PromulgatedURL(),
 	}
-	DenormalizeEntity(entity)
+	denormalizeEntity(entity)
 
 	// Check that we're not going to create a bundle that duplicates
 	// the name of a charm. This is racy, but it's the best we can do.

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -2455,11 +2455,11 @@ func (s *StoreSuite) TestAddAuditWithNoLumberjack(c *gc.C) {
 	})
 }
 
-func (s *StoreSuite) TestDenormalizeEntity(c *gc.C) {
+func (s *StoreSuite) TestdenormalizeEntity(c *gc.C) {
 	e := &mongodoc.Entity{
 		URL: charm.MustParseReference("~someone/utopic/acharm-45"),
 	}
-	DenormalizeEntity(e)
+	denormalizeEntity(e)
 	c.Assert(e, jc.DeepEquals, &mongodoc.Entity{
 		URL:                 charm.MustParseReference("~someone/utopic/acharm-45"),
 		BaseURL:             charm.MustParseReference("~someone/acharm"),
@@ -2477,7 +2477,7 @@ func (s *StoreSuite) TestDenormalizePromulgatedEntity(c *gc.C) {
 		URL:            charm.MustParseReference("~someone/utopic/acharm-45"),
 		PromulgatedURL: charm.MustParseReference("utopic/acharm-5"),
 	}
-	DenormalizeEntity(e)
+	denormalizeEntity(e)
 	c.Assert(e, jc.DeepEquals, &mongodoc.Entity{
 		URL:                 charm.MustParseReference("~someone/utopic/acharm-45"),
 		BaseURL:             charm.MustParseReference("~someone/acharm"),
@@ -2495,7 +2495,7 @@ func (s *StoreSuite) TestDenormalizeBundleEntity(c *gc.C) {
 	e := &mongodoc.Entity{
 		URL: charm.MustParseReference("~someone/bundle/acharm-45"),
 	}
-	DenormalizeEntity(e)
+	denormalizeEntity(e)
 	c.Assert(e, jc.DeepEquals, &mongodoc.Entity{
 		URL:                 charm.MustParseReference("~someone/bundle/acharm-45"),
 		BaseURL:             charm.MustParseReference("~someone/acharm"),
@@ -2517,7 +2517,7 @@ func entity(url, purl string) *mongodoc.Entity {
 		URL:            id,
 		PromulgatedURL: pid,
 	}
-	DenormalizeEntity(e)
+	denormalizeEntity(e)
 	return e
 }
 
@@ -2535,6 +2535,6 @@ func baseEntity(url string, promulgated bool) *mongodoc.BaseEntity {
 // a copy of e with its denormalized fields filled out.
 func denormalizedEntity(e *mongodoc.Entity) *mongodoc.Entity {
 	e1 := *e
-	DenormalizeEntity(&e1)
+	denormalizeEntity(&e1)
 	return &e1
 }

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1383,91 +1383,27 @@ var getNewPromulgatedRevisionTests = []struct {
 }}
 
 func (s *ArchiveSuite) TestGetNewPromulgatedRevision(c *gc.C) {
-	baseEntities := []*mongodoc.BaseEntity{{
-		URL:    charm.MustParseReference("cs:~dduck/mysql"),
-		User:   "dduck",
-		Name:   "mysql",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{"everyone", "dduck"},
-		},
-		Promulgated: false,
-	}, {
-		URL:    charm.MustParseReference("cs:~goofy/mysql"),
-		User:   "goofy",
-		Name:   "mysql",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{"everyone", "goofy"},
-		},
-		Promulgated: true,
-	}, {
-		URL:    charm.MustParseReference("cs:~pluto/mariadb"),
-		User:   "pluto",
-		Name:   "mariadb",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{"everyone", "pluto"},
-		},
-		Promulgated: true,
-	}, {
-		URL:    charm.MustParseReference("cs:~tom/sed"),
-		User:   "tom",
-		Name:   "sed",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{"everyone", "tom"},
-		},
-		Promulgated: true,
-	}, {
-		URL:    charm.MustParseReference("cs:~jerry/sed"),
-		User:   "jerry",
-		Name:   "sed",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{"everyone", "jerry"},
-		},
-		Promulgated: false,
-	}, {
-		URL:    charm.MustParseReference("cs:~tom/awk"),
-		User:   "tom",
-		Name:   "awk",
-		Public: true,
-		ACLs: mongodoc.ACL{
-			Read: []string{"everyone", "tom"},
-		},
-		Promulgated: true,
-	}}
-	for _, e := range baseEntities {
-		err := s.store.DB.BaseEntities().Insert(e)
-		c.Assert(err, gc.IsNil)
+	charms := []string{
+		"cs:~dduck/trusty/mysql-14",
+		"14 cs:~goofy/precise/mysql-14",
+		"3 cs:~pluto/trusty/mariadb-5",
+		"0 cs:~tom/trusty/sed-0",
+		"cs:~jerry/trusty/sed-2",
+		"4 cs:~jerry/trusty/sed-3",
+		"0 cs:~tom/trusty/awk-0",
+		"1 cs:~tom/trusty/awk-1",
+		"2 cs:~tom/trusty/awk-2",
+		"3 cs:~tom/trusty/awk-3",
+		"4 cs:~tom/trusty/awk-4",
 	}
-	entities := []*mongodoc.Entity{{
-		URL:            charm.MustParseReference("cs:~pluto/trusty/mariadb-5"),
-		PromulgatedURL: charm.MustParseReference("cs:trusty/mariadb-3"),
-	}, {
-		URL:            charm.MustParseReference("cs:~tom/trusty/sed-0"),
-		PromulgatedURL: charm.MustParseReference("cs:trusty/sed-0"),
-	}, {
-		URL:            charm.MustParseReference("cs:~jerry/trusty/sed-3"),
-		PromulgatedURL: charm.MustParseReference("cs:trusty/sed-4"),
-	}}
-	for _, e := range entities {
-		charmstore.DenormalizeEntity(e)
-		err := s.store.DB.Entities().Insert(e)
-		c.Assert(err, gc.IsNil)
-	}
-	id := charm.MustParseReference("cs:~tom/trusty/awk")
-	pid := charm.MustParseReference("cs:trusty/awk")
-	for i := 0; i < 5; i++ {
-		id.Revision = i
-		pid.Revision = i
-		entity := &mongodoc.Entity{
-			URL:            id,
-			PromulgatedURL: pid,
-		}
-		charmstore.DenormalizeEntity(entity)
-		err := s.store.DB.Entities().Insert(entity)
+	for _, ch := range charms {
+		url := mustParseResolvedURL(ch)
+		err := s.store.AddCharm(&relationTestingCharm{}, charmstore.AddParams{
+			URL:      url,
+			BlobName: "blobName",
+			BlobHash: fakeBlobHash,
+			BlobSize: fakeBlobSize,
+		})
 		c.Assert(err, gc.IsNil)
 	}
 	handler := s.handler(c)


### PR DESCRIPTION
Stop using DenormalizeEntity in the one test outside of charmstore so that
the function can be unexported.
