### PR TITLE
Add ability to resolve development URLs.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -18,7 +18,7 @@ golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:0
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/juju/charm.v6-unstable	git	7a350e31b7caa6588ba0448627fd760bf805c927	2015-11-12T17:59:38Z
+gopkg.in/juju/charm.v6-unstable	git	016300b086ad5f4019423815da0ac341c4a6403b	2015-11-13T13:21:32Z
 gopkg.in/juju/charmrepo.v2-unstable	git	26fc50fe661a8bcbfdfdff7c39976773c18a233c	2015-11-13T11:15:40Z
 gopkg.in/juju/jujusvg.v1	git	af9eeac59c8724a359206dfd987b42242999fbd6	2015-11-12T18:48:11Z
 gopkg.in/macaroon-bakery.v1	git	e569eb58bf9977eb8a1f20d405535d45c66035be	2015-10-22T13:30:53Z

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -235,16 +235,15 @@ func ResolveURL(store *charmstore.Store, url *charm.URL) (*router.ResolvedURL, e
 	if errgo.Cause(err) == params.ErrNotFound {
 		return nil, noMatchingURLError(url)
 	}
-	if url.User == "" {
-		return &router.ResolvedURL{
-			URL:                 *entity.URL,
-			PromulgatedRevision: entity.PromulgatedRevision,
-		}, nil
-	}
-	return &router.ResolvedURL{
+	rurl := &router.ResolvedURL{
 		URL:                 *entity.URL,
 		PromulgatedRevision: -1,
-	}, nil
+		Development:         url.Channel == charm.DevelopmentChannel,
+	}
+	if url.User == "" {
+		rurl.PromulgatedRevision = entity.PromulgatedRevision
+	}
+	return rurl, nil
 }
 
 func noMatchingURLError(url *charm.URL) error {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -1247,46 +1247,154 @@ var resolveURLTests = []struct {
 	url:    "wordpress",
 	expect: newResolvedURL("cs:~charmers/trusty/wordpress-25", 25),
 }, {
+	url:    "development/wordpress",
+	expect: newResolvedURL("cs:~charmers/development/trusty/wordpress-25", 25),
+}, {
 	url:    "precise/wordpress",
 	expect: newResolvedURL("cs:~charmers/precise/wordpress-24", 24),
+}, {
+	url:    "development/precise/wordpress",
+	expect: newResolvedURL("cs:~charmers/development/precise/wordpress-24", 24),
 }, {
 	url:    "utopic/bigdata",
 	expect: newResolvedURL("cs:~charmers/utopic/bigdata-10", 10),
 }, {
+	url:    "development/utopic/bigdata",
+	expect: newResolvedURL("cs:~charmers/development/utopic/bigdata-10", 10),
+}, {
 	url:    "~charmers/precise/wordpress",
 	expect: newResolvedURL("cs:~charmers/precise/wordpress-24", -1),
 }, {
+	url:    "~charmers/development/precise/wordpress",
+	expect: newResolvedURL("cs:~charmers/development/precise/wordpress-24", -1),
+}, {
 	url:      "~charmers/precise/wordpress-99",
+	notFound: true,
+}, {
+	url:      "~charmers/development/precise/wordpress-99",
 	notFound: true,
 }, {
 	url:    "~charmers/wordpress",
 	expect: newResolvedURL("cs:~charmers/trusty/wordpress-25", -1),
 }, {
+	url:    "~charmers/development/wordpress",
+	expect: newResolvedURL("cs:~charmers/development/trusty/wordpress-25", -1),
+}, {
 	url:      "~charmers/wordpress-24",
+	notFound: true,
+}, {
+	url:      "~charmers/development/wordpress-24",
 	notFound: true,
 }, {
 	url:    "~bob/wordpress",
 	expect: newResolvedURL("cs:~bob/trusty/wordpress-1", -1),
 }, {
+	url:    "~bob/development/wordpress",
+	expect: newResolvedURL("cs:~bob/development/trusty/wordpress-1", -1),
+}, {
 	url:    "~bob/precise/wordpress",
 	expect: newResolvedURL("cs:~bob/precise/wordpress-2", -1),
+}, {
+	url:    "~bob/development/precise/wordpress",
+	expect: newResolvedURL("cs:~bob/development/precise/wordpress-2", -1),
 }, {
 	url:    "bigdata",
 	expect: newResolvedURL("cs:~charmers/utopic/bigdata-10", 10),
 }, {
+	url:    "development/bigdata",
+	expect: newResolvedURL("cs:~charmers/development/utopic/bigdata-10", 10),
+}, {
 	url:      "wordpress-24",
+	notFound: true,
+}, {
+	url:      "development/wordpress-24",
 	notFound: true,
 }, {
 	url:    "bundlelovin",
 	expect: newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10),
 }, {
+	url:    "development/bundlelovin",
+	expect: newResolvedURL("cs:~charmers/development/bundle/bundlelovin-10", 10),
+}, {
 	url:      "wordpress-26",
+	notFound: true,
+}, {
+	url:      "development/wordpress-26",
 	notFound: true,
 }, {
 	url:      "foo",
 	notFound: true,
 }, {
+	url:      "development/foo",
+	notFound: true,
+}, {
 	url:      "trusty/bigdata",
+	notFound: true,
+}, {
+	url:      "development/trusty/bigdata",
+	notFound: true,
+}, {
+	url:      "~bob/wily/django-47",
+	notFound: true,
+}, {
+	url:      "~bob/django",
+	notFound: true,
+}, {
+	url:      "wily/django",
+	notFound: true,
+}, {
+	url:      "django",
+	notFound: true,
+}, {
+	url:    "~bob/development/wily/django-47",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", -1),
+}, {
+	url:    "~bob/development/wily/django",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", -1),
+}, {
+	url:    "~bob/development/django",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", -1),
+}, {
+	url:    "development/wily/django-27",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", 27),
+}, {
+	url:    "development/wily/django",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", 27),
+}, {
+	url:    "development/django",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", 27),
+}, {
+	url:      "~bob/trusty/haproxy-0",
+	notFound: true,
+}, {
+	url:      "~bob/haproxy",
+	notFound: true,
+}, {
+	url:      "trusty/haproxy",
+	notFound: true,
+}, {
+	url:      "haproxy",
+	notFound: true,
+}, {
+	url:    "~bob/development/trusty/haproxy-0",
+	expect: newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1),
+}, {
+	url:    "~bob/development/trusty/haproxy",
+	expect: newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1),
+}, {
+	url:    "~bob/development/haproxy",
+	expect: newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1),
+}, {
+	url:      "~bob/development/trusty/haproxy-1",
+	notFound: true,
+}, {
+	url:      "development/trusty/haproxy-27",
+	notFound: true,
+}, {
+	url:      "development/trusty/haproxy",
+	notFound: true,
+}, {
+	url:      "development/haproxy",
 	notFound: true,
 }}
 
@@ -1303,6 +1411,8 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/other-2", -1))
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10))
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10))
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/wily/django-47", 27))
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1))
 
 	for i, test := range resolveURLTests {
 		c.Logf("test %d: %s", i, test.url)


### PR DESCRIPTION
The charm store now should correctly resolve and return entities with the development channel.
