### PR TITLE
Use appropriate ACL definition based on the channel.

### DIFF
--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -1004,6 +1004,7 @@ func baseURL(url *charm.URL) *charm.URL {
 	newURL := *url
 	newURL.Revision = -1
 	newURL.Series = ""
+	newURL.Channel = ""
 	return &newURL
 }
 
@@ -1179,8 +1180,12 @@ func (s *Store) findZipFile(blob io.ReadSeeker, size int64, isFile func(f *zip.F
 // the given id for "which" operations ("read" or "write")
 // to the given ACL. This is mostly provided for testing.
 func (s *Store) SetPerms(id *charm.URL, which string, acl ...string) error {
+	field := "acls"
+	if id.Channel == charm.DevelopmentChannel {
+		field = "developmentacls"
+	}
 	return s.DB.BaseEntities().UpdateId(baseURL(id), bson.D{{"$set",
-		bson.D{{"acls." + which, acl}},
+		bson.D{{field + "." + which, acl}},
 	}})
 }
 

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -121,11 +121,7 @@ func (h *ReqHandler) checkRequest(req *http.Request, entityId *router.ResolvedUR
 // AuthorizeEntity checks that the given HTTP request
 // can access the entity with the given id.
 func (h *ReqHandler) AuthorizeEntity(id *router.ResolvedURL, req *http.Request) error {
-	field := "acls"
-	if id.Development {
-		field = "developmentacls"
-	}
-	baseEntity, err := h.Store.FindBaseEntity(&id.URL, field)
+	baseEntity, err := h.Store.FindBaseEntity(&id.URL, "acls", "developmentacls")
 	if err != nil {
 		if errgo.Cause(err) == params.ErrNotFound {
 			return errgo.WithCausef(nil, params.ErrNotFound, "entity %q not found", id)

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -121,14 +121,22 @@ func (h *ReqHandler) checkRequest(req *http.Request, entityId *router.ResolvedUR
 // AuthorizeEntity checks that the given HTTP request
 // can access the entity with the given id.
 func (h *ReqHandler) AuthorizeEntity(id *router.ResolvedURL, req *http.Request) error {
-	baseEntity, err := h.Store.FindBaseEntity(&id.URL, "acls")
+	field := "acls"
+	if id.Development {
+		field = "developmentacls"
+	}
+	baseEntity, err := h.Store.FindBaseEntity(&id.URL, field)
 	if err != nil {
 		if errgo.Cause(err) == params.ErrNotFound {
 			return errgo.WithCausef(nil, params.ErrNotFound, "entity %q not found", id)
 		}
 		return errgo.Notef(err, "cannot retrieve entity %q for authorization", id)
 	}
-	return h.authorizeWithPerms(req, baseEntity.ACLs.Read, baseEntity.ACLs.Write, id)
+	acls := baseEntity.ACLs
+	if id.Development {
+		acls = baseEntity.DevelopmentACLs
+	}
+	return h.authorizeWithPerms(req, acls.Read, acls.Write, id)
 }
 
 func (h *ReqHandler) authorizeWithPerms(req *http.Request, read, write []string, entityId *router.ResolvedURL) error {


### PR DESCRIPTION
Use development ACLs if the development entity is requested.
