### PR TITLE
channels: handle meta/perm and search.

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -86,7 +86,7 @@ func (s *Store) UpdateSearch(r *router.ResolvedURL) error {
 	if s.ES == nil || s.ES.Database == nil {
 		return nil
 	}
-	if deprecatedSeries[r.URL.Series] {
+	if deprecatedSeries[r.URL.Series] || r.Development {
 		return nil
 	}
 

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -120,6 +120,19 @@ func (s *StoreSearchSuite) TestNoExportDeprecated(c *gc.C) {
 	c.Assert(present, gc.Equals, false)
 }
 
+func (s *StoreSearchSuite) TestNoExportDevelopment(c *gc.C) {
+	rurl := newResolvedURL("cs:~charmers/development/trusty/mysql-42", -1)
+	err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("mysql"))
+	c.Assert(err, gc.IsNil)
+
+	var entity *mongodoc.Entity
+	err = s.store.DB.Entities().FindId(rurl.URL.String()).One(&entity)
+	c.Assert(err, gc.IsNil)
+	present, err := s.store.ES.HasDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL))
+	c.Assert(err, gc.IsNil)
+	c.Assert(present, gc.Equals, false)
+}
+
 func (s *StoreSearchSuite) TestExportOnlyLatest(c *gc.C) {
 	charmArchive := storetesting.Charms.CharmDir("wordpress")
 	url := newResolvedURL("cs:~charmers/precise/wordpress-24", -1)

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -177,8 +177,8 @@ func newReqHandler() *ReqHandler {
 			"id-revision":      h.entityHandler(h.metaIdRevision, "_id"),
 			"id-series":        h.entityHandler(h.metaIdSeries, "_id"),
 			"manifest":         h.entityHandler(h.metaManifest, "blobname"),
-			"perm":             h.puttableBaseEntityHandler(h.metaPerm, h.putMetaPerm, "acls"),
-			"perm/":            h.puttableBaseEntityHandler(h.metaPermWithKey, h.putMetaPermWithKey, "acls"),
+			"perm":             h.puttableBaseEntityHandler(h.metaPerm, h.putMetaPerm, "acls", "developmentacls"),
+			"perm/":            h.puttableBaseEntityHandler(h.metaPermWithKey, h.putMetaPermWithKey, "acls", "developmentacls"),
 			"promulgated":      h.baseEntityHandler(h.metaPromulgated, "promulgated"),
 			"revision-info":    router.SingleIncludeHandler(h.metaRevisionInfo),
 			"stats":            h.entityHandler(h.metaStats),
@@ -824,9 +824,13 @@ func checkExtraInfoKey(key string) error {
 // GET id/meta/perm
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaperm
 func (h *ReqHandler) metaPerm(entity *mongodoc.BaseEntity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
+	acls := entity.ACLs
+	if id.Development {
+		acls = entity.DevelopmentACLs
+	}
 	return params.PermResponse{
-		Read:  entity.ACLs.Read,
-		Write: entity.ACLs.Write,
+		Read:  acls.Read,
+		Write: acls.Write,
 	}, nil
 }
 
@@ -837,30 +841,33 @@ func (h *ReqHandler) putMetaPerm(id *router.ResolvedURL, path string, val *json.
 	if err := json.Unmarshal(*val, &perms); err != nil {
 		return errgo.Mask(err)
 	}
-	isPublic := false
-	for _, p := range perms.Read {
-		if p == params.Everyone {
-			isPublic = true
-			break
+	field := "acls"
+	if id.Development {
+		field = "developmentacls"
+	} else {
+		isPublic := false
+		for _, p := range perms.Read {
+			if p == params.Everyone {
+				isPublic = true
+				break
+			}
 		}
+		updater.UpdateField("public", isPublic, nil)
 	}
-
-	updater.UpdateField("acls.read", perms.Read, &audit.Entry{
+	updater.UpdateField(field+".read", perms.Read, &audit.Entry{
 		Op:     audit.OpSetPerm,
 		Entity: &id.URL,
 		ACL: &audit.ACL{
 			Read: perms.Read,
 		},
 	})
-	updater.UpdateField("public", isPublic, nil)
-	updater.UpdateField("acls.write", perms.Write, &audit.Entry{
+	updater.UpdateField(field+".write", perms.Write, &audit.Entry{
 		Op:     audit.OpSetPerm,
 		Entity: &id.URL,
 		ACL: &audit.ACL{
 			Write: perms.Write,
 		},
 	})
-
 	updater.UpdateSearch()
 	return nil
 }
@@ -876,11 +883,15 @@ func (h *ReqHandler) metaPromulgated(entity *mongodoc.BaseEntity, id *router.Res
 // GET id/meta/perm/key
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetapermkey
 func (h *ReqHandler) metaPermWithKey(entity *mongodoc.BaseEntity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
+	acls := entity.ACLs
+	if id.Development {
+		acls = entity.DevelopmentACLs
+	}
 	switch path {
 	case "/read":
-		return entity.ACLs.Read, nil
+		return acls.Read, nil
 	case "/write":
-		return entity.ACLs.Write, nil
+		return acls.Write, nil
 	}
 	return nil, errgo.WithCausef(nil, params.ErrNotFound, "unknown permission")
 }
@@ -892,27 +903,33 @@ func (h *ReqHandler) putMetaPermWithKey(id *router.ResolvedURL, path string, val
 	if err := json.Unmarshal(*val, &perms); err != nil {
 		return errgo.Mask(err)
 	}
-	isPublic := false
-	for _, p := range perms {
-		if p == params.Everyone {
-			isPublic = true
-			break
-		}
+	field := "acls"
+	if id.Development {
+		field = "developmentacls"
 	}
 	switch path {
 	case "/read":
-		updater.UpdateField("acls.read", perms, &audit.Entry{
+		updater.UpdateField(field+".read", perms, &audit.Entry{
 			Op:     audit.OpSetPerm,
 			Entity: &id.URL,
 			ACL: &audit.ACL{
 				Read: perms,
 			},
 		})
-		updater.UpdateField("public", isPublic, nil)
+		if !id.Development {
+			isPublic := false
+			for _, p := range perms {
+				if p == params.Everyone {
+					isPublic = true
+					break
+				}
+			}
+			updater.UpdateField("public", isPublic, nil)
+		}
 		updater.UpdateSearch()
 		return nil
 	case "/write":
-		updater.UpdateField("acls.write", perms, &audit.Entry{
+		updater.UpdateField(field+".write", perms, &audit.Entry{
 			Op:     audit.OpSetPerm,
 			Entity: &id.URL,
 			ACL: &audit.ACL{


### PR DESCRIPTION
In meta/perm, use the corresponding base entity ACLs.
Do not include development charms in elastic search.
