### PR TITLE
id/archive: handle uploading development entities.

### DIFF
--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -678,7 +678,7 @@ func (s *Store) insertEntity(entity *mongodoc.Entity) (err error) {
 // If the given URL has no user then it is assumed to be a
 // promulgated entity.
 func (s *Store) FindEntity(url *router.ResolvedURL, fields ...string) (*mongodoc.Entity, error) {
-	entities, err := s.FindEntities(&url.URL, fields...)
+	entities, err := s.FindEntities(url.UserOwnedURL(), fields...)
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}
@@ -1439,7 +1439,7 @@ func (s *Store) SynchroniseElasticsearch() error {
 }
 
 // EntityResolvedURL returns the ResolvedURL for the entity.
-// It requires the PromulgatedURL field to have been
+// It requires PromulgatedURL and Development fields to have been
 // filled out in the entity.
 func EntityResolvedURL(e *mongodoc.Entity) *router.ResolvedURL {
 	rurl := &router.ResolvedURL{

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -176,21 +176,28 @@ func MustNewResolvedURL(urlStr string, promulgatedRev int) *ResolvedURL {
 	}
 }
 
+// UserOwnedURL returns the non-promulgated URL for the given id.
+// The returned *charm.URL may be modified freely.
+func (id *ResolvedURL) UserOwnedURL() *charm.URL {
+	u := id.URL
+	if id.Development {
+		u.Channel = charm.DevelopmentChannel
+	}
+	return &u
+}
+
 // PreferredURL returns the promulgated URL for
 // the given id if there is one, otherwise it
 // returns the non-promulgated URL. The returned *charm.URL
 // may be modified freely.
 func (id *ResolvedURL) PreferredURL() *charm.URL {
-	u := id.URL
-	if id.Development {
-		u.Channel = charm.DevelopmentChannel
-	}
+	u := id.UserOwnedURL()
 	if id.PromulgatedRevision == -1 {
-		return &u
+		return u
 	}
 	u.User = ""
 	u.Revision = id.PromulgatedRevision
-	return &u
+	return u
 }
 
 // PromulgatedURL returns the promulgated URL for id if there

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -2261,6 +2261,20 @@ func (s *RouterSuite) TestHandlers(c *gc.C) {
 	}
 }
 
+func (s *RouterSuite) TestResolvedURLUserOwnedURL(c *gc.C) {
+	r := MustNewResolvedURL("~charmers/precise/wordpress-23", 4)
+	u := r.UserOwnedURL()
+	c.Assert(u, gc.DeepEquals, charm.MustParseURL("~charmers/precise/wordpress-23"))
+	u.Series = "foo"
+	c.Assert(r.URL.Series, gc.Equals, "precise")
+
+	r = MustNewResolvedURL("~who/development/trusty/wordpress-42", -1)
+	u = r.UserOwnedURL()
+	c.Assert(u, gc.DeepEquals, charm.MustParseURL("~who/development/trusty/wordpress-42"))
+	u.Series = "foo"
+	c.Assert(r.URL.Series, gc.Equals, "trusty")
+}
+
 func (s *RouterSuite) TestResolvedURLPreferredURL(c *gc.C) {
 	r := MustNewResolvedURL("~charmers/precise/wordpress-23", 4)
 	// Ensure it's not aliased.


### PR DESCRIPTION
Do not allow development entities to be served via
published URLs.

Note: publishing of entities is not handled here and
will be done in the next branch.
