### PR TITLE
Implement the publish API.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -263,6 +263,56 @@ Request body:
 }
 ```
 
+### Charm and bundle publishing
+
+#### PUT *id*/publish
+
+A PUT to ~*user*/*anyseries*/*name*-*anyrevision* sets whether the
+corresponding charm or bundle is published and can be accessed through a URL
+with no channel. If the revision number is not specified, the id is resolved to
+the charm or bundle with the latest development revision number. The id must
+not include the development channel.
+
+```go
+type PublishRequest struct {
+    Published bool
+}
+```
+
+If Published is true, the charm or bundle is made available at the
+non-development URL with the same revision number. If Published is false, the
+id is unpublished.
+
+The response include the id and promulgated id of the entity after the action
+is performed:
+
+```go
+type PublishResponse struct {
+    Id            *charm.URL
+    PromulgatedId *charm.URL `json:",omitempty"`
+}
+```
+
+If the charm or bundle have been unpublished, the identifiers in the response
+will represent a development charm or bundle.
+
+Example: `PUT ~charmers/trusty/django-42/publish`
+
+Request body:
+```json
+{
+    "Publish" : true,
+}
+```
+
+Response body:
+```json
+{
+    "Id" : "cs:~charmers/trusty/django-42",
+    "PromulgatedId": "cs:trusty/django-10",
+}
+```
+
 ### Stats
 
 #### GET stats/counter/...
@@ -1555,7 +1605,7 @@ Example: `GET ~bob/trusty/wordpress-42/meta/id-series`
 
 The meta/common-info path reports any common metadata recorded for the base
 entity. This contains only information stored by clients - the API server
-itself does not populate any fields. The resulting object holds an entry for 
+itself does not populate any fields. The resulting object holds an entry for
 each piece of metadata recorded with a PUT to `meta/common-info`.
 
 ```go

--- a/docs/API.md
+++ b/docs/API.md
@@ -270,8 +270,9 @@ Request body:
 A PUT to ~*user*/*anyseries*/*name*-*anyrevision* sets whether the
 corresponding charm or bundle is published and can be accessed through a URL
 with no channel. If the revision number is not specified, the id is resolved to
-the charm or bundle with the latest development revision number. The id must
-not include the development channel.
+the charm or bundle with the latest development revision number when
+publishing, and to the charm or bundle with the latest non-development revision
+number when unpublishing. The id must not include the development channel.
 
 ```go
 type PublishRequest struct {
@@ -283,7 +284,7 @@ If Published is true, the charm or bundle is made available at the
 non-development URL with the same revision number. If Published is false, the
 id is unpublished.
 
-The response include the id and promulgated id of the entity after the action
+The response includes the id and promulgated id of the entity after the action
 is performed:
 
 ```go
@@ -294,14 +295,14 @@ type PublishResponse struct {
 ```
 
 If the charm or bundle have been unpublished, the identifiers in the response
-will represent a development charm or bundle.
+will represent the corresponding development charm or bundle.
 
 Example: `PUT ~charmers/trusty/django-42/publish`
 
 Request body:
 ```json
 {
-    "Publish" : true,
+    "Published" : true,
 }
 ```
 

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -1177,8 +1177,8 @@ func (h *ReqHandler) servePublish(id *charm.URL, w http.ResponseWriter, req *htt
 	if req.Method != "PUT" {
 		return errgo.WithCausef(nil, params.ErrMethodNotAllowed, "%s not allowed", req.Method)
 	}
-	if id.Channel == charm.DevelopmentChannel {
-		return errgo.WithCausef(nil, params.ErrForbidden, "cannot publish or unpublish development charm or bundle %q", id)
+	if id.Channel != "" {
+		return errgo.WithCausef(nil, params.ErrForbidden, "can only set publish on published URL, %q provided", id)
 	}
 	jsonContentType := "application/json"
 	if ct := req.Header.Get("Content-Type"); ct != jsonContentType {

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -1180,15 +1180,12 @@ func (h *ReqHandler) servePublish(id *charm.URL, w http.ResponseWriter, req *htt
 	if id.Channel != "" {
 		return errgo.WithCausef(nil, params.ErrForbidden, "can only set publish on published URL, %q provided", id)
 	}
-	jsonContentType := "application/json"
-	if ct := req.Header.Get("Content-Type"); ct != jsonContentType {
-		return errgo.WithCausef(nil, params.ErrBadRequest, "unexpected Content-Type %q; expected %q", ct, jsonContentType)
-	}
 
 	// Retrieve the requested action from the request body.
-	var publish params.PublishRequest
-	decoder := json.NewDecoder(req.Body)
-	if err := decoder.Decode(&publish); err != nil {
+	var publish struct {
+		params.PublishRequest `httprequest:",body"`
+	}
+	if err := httprequest.Unmarshal(httprequest.Params{Request: req}, &publish); err != nil {
 		return errgo.WithCausef(err, params.ErrBadRequest, "cannot unmarshal publish request body")
 	}
 

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -3295,7 +3295,7 @@ var publishErrorsTests = []struct {
 	expectStatus: http.StatusForbidden,
 	expectBody: params.Error{
 		Code:    params.ErrForbidden,
-		Message: `cannot publish or unpublish development charm or bundle "cs:~who/development/wily/django-42"`,
+		Message: `can only set publish on published URL, "cs:~who/development/wily/django-42" provided`,
 	},
 }, {
 	about:        "unexpected content type",

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -3305,7 +3305,7 @@ var publishErrorsTests = []struct {
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: `unexpected Content-Type "text/invalid"; expected "application/json"`,
+		Message: `cannot unmarshal publish request body: cannot unmarshal into field: unexpected content type text/invalid; want application/json; content: "{\"Published\":true}"`,
 	},
 }, {
 	about:        "invalid body",
@@ -3315,7 +3315,7 @@ var publishErrorsTests = []struct {
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: "cannot unmarshal publish request body: invalid character 'b' looking for beginning of value",
+		Message: "cannot unmarshal publish request body: cannot unmarshal into field: cannot unmarshal request body: invalid character 'b' looking for beginning of value",
 	},
 }, {
 	about:        "entity to be published not found",

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -101,7 +101,10 @@ func (h *ReqHandler) authorizeUpload(id *charm.URL, req *http.Request) error {
 	}
 	// The base entity does not currently exist, so we default to
 	// assuming write permissions for the entity user.
-	return errgo.Mask(h.authorizeWithPerms(req, nil, []string{id.User}, nil), errgo.Any)
+	if err := h.authorizeWithPerms(req, nil, []string{id.User}, nil); err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+	return nil
 }
 
 func (h *ReqHandler) serveGetArchive(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error {

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -70,32 +70,38 @@ func (h *ReqHandler) serveArchive(id *charm.URL, w http.ResponseWriter, req *htt
 		}
 		return h.servePutArchive(id, w, req)
 	}
-	// TODO(rog) params.ErrMethodNotAllowed
-	return errgo.Newf("method not allowed")
+	return errgo.WithCausef(nil, params.ErrMethodNotAllowed, "%s not allowed", req.Method)
 }
 
 func (h *ReqHandler) authorizeUpload(id *charm.URL, req *http.Request) error {
 	if id.User == "" {
 		return badRequestf(nil, "user not specified in entity upload URL %q", id)
 	}
+	baseEntity, err := h.Store.FindBaseEntity(id, "acls", "developmentacls")
 	// Note that we pass a nil entity URL to authorizeWithPerms, because
 	// we haven't got a resolved URL at this point. At some
 	// point in the future, we may want to be able to allow
 	// is-entity first-party caveats to be allowed when uploading
 	// at which point we will need to rethink this a little.
-	baseURL := *id
-	baseURL.Revision = -1
-	baseURL.Series = ""
-	baseEntity, err := h.Store.FindBaseEntity(id, "acls")
 	if err == nil {
-		return h.authorizeWithPerms(req, baseEntity.ACLs.Read, baseEntity.ACLs.Write, nil)
+		if err := h.authorizeWithPerms(req, baseEntity.DevelopmentACLs.Read, baseEntity.DevelopmentACLs.Write, nil); err != nil {
+			return errgo.Mask(err, errgo.Any)
+		}
+		// If uploading a published entity, also check that the user has
+		// publishing permissions.
+		if id.Channel != charm.DevelopmentChannel {
+			if err := h.authorizeWithPerms(req, baseEntity.ACLs.Read, baseEntity.ACLs.Write, nil); err != nil {
+				return errgo.Mask(err, errgo.Any)
+			}
+		}
+		return nil
 	}
 	if errgo.Cause(err) != params.ErrNotFound {
 		return errgo.Notef(err, "cannot retrieve entity %q for authorization", id)
 	}
 	// The base entity does not currently exist, so we default to
 	// assuming write permissions for the entity user.
-	return h.authorizeWithPerms(req, nil, []string{id.User}, nil)
+	return errgo.Mask(h.authorizeWithPerms(req, nil, []string{id.User}, nil), errgo.Any)
 }
 
 func (h *ReqHandler) serveGetArchive(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error {
@@ -170,7 +176,17 @@ func (h *ReqHandler) servePostArchive(id *charm.URL, w http.ResponseWriter, req 
 	}
 	if oldHash == hash {
 		// The hash matches the hash of the latest revision, so
-		// no need to upload anything.
+		// no need to upload anything. When uploading a published URL and
+		// the latest revision is a development entity, then we need to
+		// actually publish the existing entity. Note that at this point the
+		// user is already known to have required permissions.
+		underDevelopment := id.Channel == charm.DevelopmentChannel
+		if oldUrl.Development && !underDevelopment {
+			if err := h.Store.SetDevelopment(oldUrl, false); err != nil {
+				return errgo.NoteMask(err, "cannot publish charm or bundle", errgo.Is(params.ErrNotFound))
+			}
+		}
+		oldUrl.Development = underDevelopment
 		return httprequest.WriteJSON(w, http.StatusOK, &params.ArchiveUploadResponse{
 			Id:            oldUrl.UserOwnedURL(),
 			PromulgatedId: oldUrl.PromulgatedURL(),
@@ -418,7 +434,7 @@ func checkIdAllowed(id *router.ResolvedURL, ch charm.Charm) error {
 }
 
 func (h *ReqHandler) latestRevisionInfo(id *charm.URL) (*router.ResolvedURL, string, error) {
-	entities, err := h.Store.FindEntities(id, "_id", "blobhash", "promulgated-url", "development")
+	entities, err := h.Store.FindEntities(id.WithChannel(charm.DevelopmentChannel), "_id", "blobhash", "promulgated-url", "development")
 	if err != nil {
 		return nil, "", errgo.Mask(err)
 	}


### PR DESCRIPTION
Use the proper permission checks when uploading charms or bundle.
Allow uploading and publishing at the same time.

This branch should complete the publishing work.
Later we will add promulgation policy as requested by eco.
In essence, on promulgating we can set the published write ACLs for
the entity to promulgators only, so that we don't allow
user publishing of promugated charms by default.
