### PR TITLE
New revisions of promulgated entities can only be published by charners.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Charm store API
 
-The current live api lives at https://api.jujucharms.com/charmstore/v4
+The current live API lives at https://api.jujucharms.com/charmstore/v4
 
 ## Intro
 

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -110,6 +110,13 @@ func (b BaseEntityBuilder) WithPromulgated(promulgated bool) BaseEntityBuilder {
 	return b
 }
 
+// WithACLs sets the non-development ACLs field on the BaseEntity.
+func (b BaseEntityBuilder) WithACLs(acls mongodoc.ACL) BaseEntityBuilder {
+	b = b.copy()
+	b.baseEntity.ACLs = acls
+	return b
+}
+
 // Build creates a mongodoc.BaseEntity from the BaseEntityBuilder.
 func (b BaseEntityBuilder) Build() *mongodoc.BaseEntity {
 	return b.copy().baseEntity
@@ -127,5 +134,6 @@ func baseURL(url *charm.URL) *charm.URL {
 	baseURL := *url
 	baseURL.Series = ""
 	baseURL.Revision = -1
+	baseURL.Channel = ""
 	return &baseURL
 }

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -2624,7 +2624,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.ACL{
+			Write: []string{v4.PromulgatorsGroup},
+		}).WithPromulgated(true).Build(),
 	},
 	expectPromulgate: true,
 	expectUser:       "admin",
@@ -2732,7 +2734,7 @@ var promulgateTests = []struct {
 	id:   "~charmers/wordpress",
 	body: storetesting.JSONReader(params.PromulgateRequest{Promulgated: false}),
 	caveats: []checkers.Caveat{
-		checkers.DeclaredCaveat(v4.UsernameAttr, "promulgators"),
+		checkers.DeclaredCaveat(v4.UsernameAttr, v4.PromulgatorsGroup),
 	},
 	expectStatus: http.StatusOK,
 	expectEntities: []*mongodoc.Entity{
@@ -2741,7 +2743,7 @@ var promulgateTests = []struct {
 	expectBaseEntities: []*mongodoc.BaseEntity{
 		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
 	},
-	expectUser: "promulgators",
+	expectUser: v4.PromulgatorsGroup,
 }, {
 	about: "promulgate base entity with macaroon",
 	entities: []*mongodoc.Entity{
@@ -2753,17 +2755,19 @@ var promulgateTests = []struct {
 	id:   "~charmers/wordpress",
 	body: storetesting.JSONReader(params.PromulgateRequest{Promulgated: true}),
 	caveats: []checkers.Caveat{
-		checkers.DeclaredCaveat(v4.UsernameAttr, "promulgators"),
+		checkers.DeclaredCaveat(v4.UsernameAttr, v4.PromulgatorsGroup),
 	},
 	expectStatus: http.StatusOK,
 	expectEntities: []*mongodoc.Entity{
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.ACL{
+			Write: []string{v4.PromulgatorsGroup},
+		}).WithPromulgated(true).Build(),
 	},
 	expectPromulgate: true,
-	expectUser:       "promulgators",
+	expectUser:       v4.PromulgatorsGroup,
 }, {
 	about: "promulgate base entity with group macaroon",
 	entities: []*mongodoc.Entity{
@@ -2778,14 +2782,16 @@ var promulgateTests = []struct {
 		checkers.DeclaredCaveat(v4.UsernameAttr, "bob"),
 	},
 	groups: map[string][]string{
-		"bob": {"promulgators", "yellow"},
+		"bob": {v4.PromulgatorsGroup, "yellow"},
 	},
 	expectStatus: http.StatusOK,
 	expectEntities: []*mongodoc.Entity{
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.ACL{
+			Write: []string{v4.PromulgatorsGroup},
+		}).WithPromulgated(true).Build(),
 	},
 	expectPromulgate: true,
 	expectUser:       "bob",

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	basicRealm        = "CharmStore4"
-	promulgatorsGroup = "promulgators"
+	promulgatorsGroup = "charmers"
 )
 
 // authorize checks that the current user is authorized based on the provided

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -10,6 +10,7 @@ var (
 	ParamsLogLevels           = paramsLogLevels
 	ParamsLogTypes            = paramsLogTypes
 	ProcessIcon               = processIcon
+	PromulgatorsGroup         = promulgatorsGroup
 	ErrProbablyNotXML         = errProbablyNotXML
 	UsernameAttr              = usernameAttr
 	DelegatableMacaroonExpiry = delegatableMacaroonExpiry


### PR DESCRIPTION
Right after promulgation, change write ACLs for the published entity so that
the user is no longer able to publish subsequent development revisions.
Promulgators have the responsibility to review and publish new promulgated
entities under development.

Also, promulgators are now called "charmers", for historical reasons.
