### PR TITLE
Backwards compatible delegatable macaroon

### DIFF
--- a/cmd/charmd/config.yaml
+++ b/cmd/charmd/config.yaml
@@ -1,3 +1,4 @@
+#terms-location: localhost:8081
 audit-log-file: audit.log
 mongo-url: localhost:27017
 api-addr: localhost:8080

--- a/cmd/charmd/config.yaml
+++ b/cmd/charmd/config.yaml
@@ -1,4 +1,3 @@
-#terms-location: localhost:8081
 audit-log-file: audit.log
 mongo-url: localhost:27017
 api-addr: localhost:8080
@@ -21,3 +20,5 @@ identity-api-url: http://localhost:8081
 #stats-cache-max-age: 1h
 #request-timeout: 500ms
 #search-cache-max-age: 0s
+# Uncomment to test with a terms service running locally
+#terms-location: localhost:8081

--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -113,7 +113,10 @@ func serve(confPath string) error {
 		}
 	}
 	if conf.TermsPublicKey != nil {
-		ring.AddPublicKeyForLocation(cfg.TermsLocation, false, conf.TermsPublicKey)
+		err = ring.AddPublicKeyForLocation(cfg.TermsLocation, false, conf.TermsPublicKey)
+		if err != nil {
+			return errgo.Mask(err)
+		}
 	} else if cfg.TermsLocation != "" {
 		pubKey, err := httpbakery.PublicKeyForLocation(http.DefaultClient, cfg.TermsLocation)
 		if err != nil {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,7 +21,7 @@ gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:
 gopkg.in/juju/charm.v6-unstable	git	a3d228ef5292531219d17d47679b260580fba1a8	2015-11-19T07:39:58Z
 gopkg.in/juju/charmrepo.v2-unstable	git	0d5460e217f3d9d9f687afe03953cc496ad329b0	2015-11-17T14:54:43Z
 gopkg.in/juju/jujusvg.v1	git	2c97ff517dee12dc48bb3c2d2b113e5045a75b71	2015-11-19T14:54:17Z
-gopkg.in/macaroon-bakery.v1	git	e569eb58bf9977eb8a1f20d405535d45c66035be	2015-10-22T13:30:53Z
+gopkg.in/macaroon-bakery.v1	git	7b63aca524cc3f7b1ad0171e54cb78b33ce1e747	2015-12-01T10:11:23Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -1124,7 +1124,7 @@ func (h *ReqHandler) serveDelegatableMacaroon(_ http.Header, req *http.Request) 
 		if err != nil {
 			return nil, errgo.WithCausef(err, params.ErrBadRequest, `bad "id" parameter`)
 		}
-		resolvedURL, err := ResolveURL(h.Store, charmRef)
+		resolvedURL, err := h.resolveURL(charmRef)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -1111,7 +1111,7 @@ func (h *ReqHandler) serveDelegatableMacaroon(_ http.Header, req *http.Request) 
 		m, err := h.Store.Bakery.NewMacaroon("", nil, []checkers.Caveat{
 			checkers.DeclaredCaveat(usernameAttr, auth.Username),
 			checkers.TimeBeforeCaveat(time.Now().Add(delegatableMacaroonExpiry)),
-			checkers.DenyCaveat(opReadArchive),
+			checkers.DenyCaveat(opAccessCharmWithTerms),
 		})
 		if err != nil {
 			return nil, errgo.Mask(err)
@@ -1152,7 +1152,7 @@ func (h *ReqHandler) serveDelegatableMacaroon(_ http.Header, req *http.Request) 
 	m, err := h.Store.Bakery.NewMacaroon("", nil, []checkers.Caveat{
 		checkers.DeclaredCaveat(usernameAttr, auth.Username),
 		checkers.TimeBeforeCaveat(time.Now().Add(delegatableMacaroonExpiry)),
-		checkers.AllowCaveat(opReadArchive, opOther),
+		checkers.AllowCaveat(opAccessCharmWithTerms, opOther),
 		checkers.Caveat{Condition: "is-entity " + strings.Join(resolvedURLstrings, " ")},
 	})
 	if err != nil {

--- a/internal/v4/auth.go
+++ b/internal/v4/auth.go
@@ -20,11 +20,11 @@ import (
 )
 
 const (
-	basicRealm            = "CharmStore4"
-	promulgatorsGroup     = "promulgators"
-	opReadArchive         = "read-archive"
-	opOther               = "other-operation"
-	defaultMacaroonExpiry = 24 * time.Hour
+	basicRealm             = "CharmStore4"
+	promulgatorsGroup      = "promulgators"
+	opAccessCharmWithTerms = "access-operation"
+	opOther                = "other-operation"
+	defaultMacaroonExpiry  = 24 * time.Hour
 )
 
 // authorize checks that the current user is authorized based on the provided
@@ -73,10 +73,10 @@ func (h *ReqHandler) authorize(req *http.Request, acl []string, alwaysAuth bool,
 	}
 
 	// Macaroon verification failed: mint a new macaroon.
-	// We need to deny access for opReadArchive operations because they
+	// We need to deny access for opAccessCharmWithTerms operations because they
 	// may require more specific checks that terms and conditions have been
 	// satisfied.
-	m, err := h.newMacaroon(checkers.DenyCaveat(opReadArchive))
+	m, err := h.newMacaroon(checkers.DenyCaveat(opAccessCharmWithTerms))
 	if err != nil {
 		return authorization{}, errgo.Notef(err, "cannot mint macaroon")
 	}
@@ -158,7 +158,7 @@ func (h *ReqHandler) authorizeEntityAndTerms(req *http.Request, entityIds []*rou
 		return authorization{}, errgo.WithCausef(nil, params.ErrUnauthorized, "charmstore not configured to serve charms with terms and conditions")
 	}
 
-	auth, verr := h.checkRequest(req, entityIds, opReadArchive)
+	auth, verr := h.checkRequest(req, entityIds, opAccessCharmWithTerms)
 	if verr == nil {
 		for _, acl := range ACLs {
 			if err := h.checkACLMembership(auth, acl); err != nil {
@@ -173,7 +173,7 @@ func (h *ReqHandler) authorizeEntityAndTerms(req *http.Request, entityIds []*rou
 	}
 
 	caveats := []checkers.Caveat{
-		checkers.AllowCaveat(opReadArchive, opOther),
+		checkers.AllowCaveat(opAccessCharmWithTerms, opOther),
 	}
 	if len(requiredTerms) > 0 {
 		terms := []string{}
@@ -222,9 +222,8 @@ func (h *ReqHandler) checkRequest(req *http.Request, entityIds []*router.Resolve
 		checkers.CheckerFunc{
 			Condition_: "is-entity",
 			Check_: func(_, args string) error {
-				tokens := strings.Split(args, " ")
 				allowedEntities := make(map[string]struct{})
-				for _, token := range tokens {
+				for _, token := range strings.Fields(args) {
 					allowedEntities[strings.TrimSpace(token)] = struct{}{}
 				}
 				if len(entityIds) == 0 {
@@ -245,7 +244,38 @@ func (h *ReqHandler) checkRequest(req *http.Request, entityIds []*router.Resolve
 				return nil
 			},
 		},
-		checkers.OperationChecker(operation),
+		checkers.CheckerFunc{
+			Condition_: "",
+			Check_: func(cond, args string) error {
+				if operation != opAccessCharmWithTerms {
+					return nil
+				}
+				allowAccessCharmWithTerms := false
+				switch cond {
+				case checkers.CondAllow:
+					for _, op := range strings.Fields(args) {
+						if op == opAccessCharmWithTerms {
+							allowAccessCharmWithTerms = true
+						}
+					}
+				case checkers.CondDeny:
+				default:
+					return checkers.ErrCaveatNotRecognized
+				}
+				if !allowAccessCharmWithTerms {
+					for _, entityId := range entityIds {
+						entity, err := h.Store.FindEntity(entityId)
+						if err != nil {
+							return errgo.Mask(err, errgo.Is(params.ErrNotFound))
+						}
+						if len(entity.CharmMeta.Terms) > 0 {
+							return errgo.New("access denied")
+						}
+					}
+				}
+				return nil
+			},
+		},
 	))
 	if err != nil {
 		return authorization{}, errgo.Mask(err, errgo.Any)


### PR DESCRIPTION
Fixes to allow older clients to obtain a valid delegatable macaroon that
will allow juju controller to deploy charms that do not require agreement
to terms and conditions.
