### PR TITLE
internal/v1: fix expand-id for development channels

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -118,6 +118,9 @@ signifying true, or empty or "0", signifying false.
 The expand-id path expands a general id into a set of specific ids. It strips
 any revision number and series from id, and returns a slice of all the possible
 ids matched by that, including all the versions and series.
+If *id* is in the development channel, all development and non-development
+revisions will be returned; if it is not, then only non-development
+revisions will be returned.
 
 ```go
 []Id
@@ -131,10 +134,10 @@ Example: `GET wordpress/expand-id`
 
 ```json
 [
-    {"Id": "precise/wordpress-1"},
-    {"Id": "precise/wordpress-2"},
-    {"Id": "trusty/wordpress-1"},
     {"Id": "trusty/wordpress-2"}
+    {"Id": "trusty/wordpress-1"},
+    {"Id": "precise/wordpress-2"},
+    {"Id": "precise/wordpress-1"},
 ]
 ```
 
@@ -142,11 +145,23 @@ Example: `GET precise/wordpress-34/expand-id`
 
 ```json
 [
-    {"Id": "precise/wordpress-1"},
-    {"Id": "precise/wordpress-2"},
-    {"Id": "trusty/wordpress-1"},
     {"Id": "trusty/wordpress-2"}
+    {"Id": "trusty/wordpress-1"},
+    {"Id": "precise/wordpress-2"},
+    {"Id": "precise/wordpress-1"},
 ]
+```
+
+Example: `GET development/precise/wordpress-34/expand-id`
+
+```json
+[
+    {"Id": "development/trusty/wordpress-3"},
+    {"Id": "trusty/wordpress-2"},
+    {"Id": "trusty/wordpress-1"},
+    {"Id": "precise/wordpress-2"},
+    {"Id": "precise/wordpress-1"},
+ ]
 ```
 
 

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -125,10 +125,14 @@ type Entity struct {
 // the entity has a promulgated URL and usePromulgated is true then the
 // promulgated URL will be used, otherwise the standard URL is used.
 func (e *Entity) PreferredURL(usePromulgated bool) *charm.URL {
+	u := e.URL
 	if usePromulgated && e.PromulgatedURL != nil {
-		return e.PromulgatedURL
+		u = e.PromulgatedURL
 	}
-	return e.URL
+	if e.Development {
+		u = u.WithChannel(charm.DevelopmentChannel)
+	}
+	return u
 }
 
 // BaseEntity holds metadata for a charm or bundle

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -468,7 +468,16 @@ func (h *ReqHandler) serveExpandId(id *router.ResolvedURL, w http.ResponseWriter
 	// to return entities that match appropriately.
 
 	// Retrieve all the entities with the same base URL.
-	q := h.Store.EntitiesQuery(baseURL).Select(bson.D{{"_id", 1}, {"promulgated-url", 1}})
+	// Note that we don't do any permission checking of the returned URLs.
+	// This is because we know that the user is allowed to read at
+	// least the resolved URL passed into serveExpandId.
+	// If this does not specify "development", then no development
+	// revisions will be chosen, so the single ACL already checked
+	// is sufficient. If it *does* specify "development", then we assume
+	// that the development ACLs are more restrictive than the
+	// non-development ACLs, and given that, we can allow all
+	// the URLs.
+	q := h.Store.EntitiesQuery(baseURL).Select(bson.D{{"_id", 1}, {"promulgated-url", 1}, {"development", 1}})
 	if id.PromulgatedRevision != -1 {
 		q = q.Sort("-series", "-promulgated-revision")
 	} else {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -1602,6 +1602,50 @@ var serveExpandIdTests = []struct {
 	expect: []params.ExpandedId{
 		{Id: "cs:~charmers/utopic/wordpress-42"},
 		{Id: "cs:~charmers/trusty/wordpress-47"},
+		{Id: "cs:~charmers/wordpress-5"},
+	},
+}, {
+	about: "fully qualified development URL",
+	url:   "~charmers/development/trusty/wordpress-47",
+	expect: []params.ExpandedId{
+		{Id: "cs:~charmers/utopic/wordpress-42"},
+		{Id: "cs:~charmers/development/trusty/wordpress-48"},
+		{Id: "cs:~charmers/trusty/wordpress-47"},
+		{Id: "cs:~charmers/development/wordpress-7"},
+		{Id: "cs:~charmers/development/wordpress-6"},
+		{Id: "cs:~charmers/wordpress-5"},
+	},
+}, {
+	about: "promulgated URL",
+	url:   "trusty/wordpress-47",
+	expect: []params.ExpandedId{
+		{Id: "cs:utopic/wordpress-42"},
+		{Id: "cs:trusty/wordpress-47"},
+		{Id: "cs:wordpress-49"},
+	},
+}, {
+	about: "development promulgated URL",
+	url:   "development/trusty/wordpress-48",
+	expect: []params.ExpandedId{
+		{Id: "cs:utopic/wordpress-42"},
+		{Id: "cs:development/trusty/wordpress-48"},
+		{Id: "cs:trusty/wordpress-47"},
+		{Id: "cs:development/wordpress-51"},
+		{Id: "cs:development/wordpress-50"},
+		{Id: "cs:wordpress-49"},
+	},
+}, {
+	about: "non-promulgated charm",
+	url:   "~bob/precise/builder",
+	expect: []params.ExpandedId{
+		{Id: "cs:~bob/precise/builder-5"},
+	},
+}, {
+	about: "non-promulgated charm with development URL",
+	url:   "~bob/development/precise/builder",
+	expect: []params.ExpandedId{
+		{Id: "cs:~bob/development/precise/builder-6"},
+		{Id: "cs:~bob/precise/builder-5"},
 	},
 }, {
 	about: "partial URL",
@@ -1638,8 +1682,17 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	// so it is ok to reuse the same charm for all the entities.
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-42", 42))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/development/trusty/wordpress-48", 48))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/development/wordpress-6", 50))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/development/wordpress-7", 51))
+
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/haproxy-1", 1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/haproxy-1", 1))
+
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/builder-5", -1))
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/precise/builder-6", -1))
+
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/mongo-0", 0))
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-0", 0))
 


### PR DESCRIPTION
The implementation is technically wrong if the permissions on the non-development
revisions are more restrictive than those on the development revisions, but
we reckon this is sufficiently unusual that it shouldn't matter.
