### PR TITLE
internal/v4: implement custom ResolveURL

### DIFF
--- a/internal/charmstore/stats.go
+++ b/internal/charmstore/stats.go
@@ -638,7 +638,7 @@ func (s *Store) IncrementDownloadCountsAtTime(id *router.ResolvedURL, t time.Tim
 		id.PromulgatedRevision = entity.PromulgatedRevision
 	}
 	if id.PromulgatedRevision != -1 {
-		key := EntityStatsKey(id.PreferredURL(), params.StatsArchiveDownloadPromulgated)
+		key := EntityStatsKey(id.PromulgatedURL(), params.StatsArchiveDownloadPromulgated)
 		if err := s.IncCounterAtTime(key, t); err != nil {
 			return errgo.Notef(err, "cannot increase stats counter for %v", key)
 		}

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -164,7 +164,7 @@ func (h *reqHandler) serveCharm(w http.ResponseWriter, req *http.Request) error 
 	if err != nil {
 		return errgo.WithCausef(err, params.ErrNotFound, "")
 	}
-	return h.v4.Handlers().Id["archive"](curl, w, req)
+	return h.v4.Router.Handlers().Id["archive"](curl, w, req)
 }
 
 // charmStatsKey returns a stats key for the given charm reference and kind.

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -8,8 +8,10 @@ import (
 
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mempool"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 )
@@ -22,6 +24,15 @@ const (
 	ArchiveCachePublicMaxAge  = v5.ArchiveCachePublicMaxAge
 )
 
+// reqHandlerPool holds a cache of ReqHandlers to save
+// on allocation time. When a handler is done with,
+// it is put back into the pool.
+var reqHandlerPool = mempool.Pool{
+	New: func() interface{} {
+		return newReqHandler()
+	},
+}
+
 type Handler struct {
 	*v5.Handler
 }
@@ -31,25 +42,105 @@ type ReqHandler struct {
 }
 
 func New(pool *charmstore.Pool, config charmstore.ServerParams) Handler {
-	h := Handler{
+	return Handler{
 		Handler: v5.New(pool, config),
 	}
-	// TODO Set h.ResolveURL here.
-	return h
+}
+
+func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// When requests in this handler use router.RelativeURL, we want
+	// the "absolute path" there to be interpreted relative to the
+	// root of this handler, not the absolute root of the web server,
+	// which may be abitrarily many levels up.
+	req.RequestURI = req.URL.Path
+
+	rh, err := h.NewReqHandler()
+	if err != nil {
+		router.WriteError(w, err)
+		return
+	}
+	defer rh.Close()
+	rh.ServeHTTP(w, req)
 }
 
 func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams) charmstore.HTTPCloseHandler {
 	return New(pool, config)
 }
 
+// NewReqHandler fetchs a new instance of ReqHandler
+// from h.Pool and returns it. The ReqHandler must
+// be closed when finished with.
 func (h *Handler) NewReqHandler() (ReqHandler, error) {
-	v5h, err := h.Handler.NewReqHandler()
+	store, err := h.Pool.RequestStore()
 	if err != nil {
-		return ReqHandler{}, errgo.Mask(err, errgo.Is(charmstore.ErrTooManySessions))
+		if errgo.Cause(err) == charmstore.ErrTooManySessions {
+			return ReqHandler{}, errgo.WithCausef(err, params.ErrServiceUnavailable, "")
+		}
+		return ReqHandler{}, errgo.Mask(err)
 	}
-	return ReqHandler{
-		ReqHandler: v5h,
-	}, nil
+	rh := reqHandlerPool.Get().(ReqHandler)
+	rh.Handler = h.Handler
+	rh.Store = store
+	return rh, nil
+}
+
+func newReqHandler() ReqHandler {
+	h := ReqHandler{
+		ReqHandler: new(v5.ReqHandler),
+	}
+	handlers := v5.RouterHandlers(h.ReqHandler)
+	// TODO mutate handlers appropriately.
+
+	h.Router = router.New(handlers, h)
+	return h
+}
+
+// ResolveURL implements router.Context.ResolveURL,
+// ensuring that any resulting ResolvedURL always
+// has a non-empty PreferredSeries field.
+func (h ReqHandler) ResolveURL(url *charm.URL) (*router.ResolvedURL, error) {
+	return resolveURL(h.Store, url)
+}
+
+// resolveURL implements URL resolving for the ReqHandler.
+// It's defined as a separate function so it can be more
+// easily unit-tested.
+func resolveURL(store *charmstore.Store, url *charm.URL) (*router.ResolvedURL, error) {
+	entity, err := store.FindBestEntity(url, "_id", "promulgated-revision", "supportedseries")
+	if err != nil && errgo.Cause(err) != params.ErrNotFound {
+		return nil, errgo.Mask(err)
+	}
+	if errgo.Cause(err) == params.ErrNotFound {
+		return nil, noMatchingURLError(url)
+	}
+	rurl := &router.ResolvedURL{
+		URL:                 *entity.URL,
+		PromulgatedRevision: -1,
+		Development:         url.Channel == charm.DevelopmentChannel,
+	}
+	if url.User == "" {
+		rurl.PromulgatedRevision = entity.PromulgatedRevision
+	}
+	if rurl.URL.Series != "" {
+		return rurl, nil
+	}
+	if url.Series != "" {
+		rurl.PreferredSeries = url.Series
+		return rurl, nil
+	}
+	if len(entity.SupportedSeries) == 0 {
+		return nil, errgo.Newf("entity %q has no supported series", &rurl.URL)
+	}
+	rurl.PreferredSeries = entity.SupportedSeries[0]
+	return rurl, nil
+}
+
+// Close closes the ReqHandler. This should always be called when the
+// ReqHandler is done with.
+func (h ReqHandler) Close() {
+	h.Store.Close()
+	h.Reset()
+	reqHandlerPool.Put(h)
 }
 
 // StatsEnabled reports whether statistics should be gathered for
@@ -58,7 +149,6 @@ func StatsEnabled(req *http.Request) bool {
 	return v5.StatsEnabled(req)
 }
 
-func ResolveURL(store *charmstore.Store, url *charm.URL) (*router.ResolvedURL, error) {
-	// TODO modify this so that it always resolves the series.
-	return v5.ResolveURL(store, url)
+func noMatchingURLError(url *charm.URL) error {
+	return errgo.WithCausef(nil, params.ErrNotFound, "no matching charm or bundle for %q", url)
 }

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -71,6 +71,12 @@ func (s *APISuite) SetUpSuite(c *gc.C) {
 
 var newResolvedURL = router.MustNewResolvedURL
 
+func newResolvedURLWithPreferredSeries(urlStr string, promulgatedRev int, series string) *router.ResolvedURL {
+	rurl := newResolvedURL(urlStr, promulgatedRev)
+	rurl.PreferredSeries = series
+	return rurl
+}
+
 var _ = gc.Suite(&APISuite{})
 
 // patchLegacyDownloadCountsEnabled sets LegacyDownloadCountsEnabled to the
@@ -1505,6 +1511,14 @@ var resolveURLTests = []struct {
 }, {
 	url:      "development/haproxy",
 	notFound: true,
+}, {
+	// V4 SPECIFIC
+	url:    "~bob/multi-series",
+	expect: newResolvedURLWithPreferredSeries("cs:~bob/multi-series-0", -1, "trusty"),
+}, {
+	// V4 SPECIFIC
+	url:    "~bob/utopic/multi-series",
+	expect: newResolvedURLWithPreferredSeries("cs:~bob/multi-series-0", -1, "utopic"),
 }}
 
 func (s *APISuite) TestResolveURL(c *gc.C) {
@@ -1522,6 +1536,7 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/wily/django-47", 27))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
 
 	for i, test := range resolveURLTests {
 		c.Logf("test %d: %s", i, test.url)

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1007,6 +1007,12 @@ func (s *ArchiveSuite) assertCannotUpload(c *gc.C, id string, content io.ReadSee
 func (s *ArchiveSuite) assertUploadCharm(c *gc.C, method string, url *router.ResolvedURL, charmName string) *charm.CharmArchive {
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), charmName)
 	id, size := s.assertUpload(c, method, url, ch.Path)
+	if url.URL.Series == "" {
+		// V4 SPECIFIC:
+		// We're uploading a multi-series charm, but we always
+		// return charm ids with a series.
+		id.Series = ch.Meta().Series[0]
+	}
 	s.assertEntityInfo(c, entityInfo{
 		Id: id,
 		Meta: entityMetaInfo{

--- a/internal/v4/export_test.go
+++ b/internal/v4/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package v4 // import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
+
+var ResolveURL = resolveURL

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v4"

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -1558,6 +1558,12 @@ var resolveURLTests = []struct {
 }, {
 	url:      "development/haproxy",
 	notFound: true,
+}, {
+	url:    "~bob/multi-series",
+	expect: newResolvedURL("cs:~bob/multi-series-0", -1),
+}, {
+	url:    "~bob/utopic/multi-series",
+	expect: newResolvedURL("cs:~bob/multi-series-0", -1),
 }}
 
 func (s *APISuite) TestResolveURL(c *gc.C) {
@@ -1575,6 +1581,7 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/wily/django-47", 27))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
 
 	for i, test := range resolveURLTests {
 		c.Logf("test %d: %s", i, test.url)

--- a/internal/v5/export_test.go
+++ b/internal/v5/export_test.go
@@ -12,4 +12,5 @@ var (
 	BundleCharms              = (*ReqHandler).bundleCharms
 	GetNewPromulgatedRevision = (*ReqHandler).getNewPromulgatedRevision
 	GroupsForUser             = (*ReqHandler).groupsForUser
+	ResolveURL                = resolveURL
 )

--- a/internal/v5/relations.go
+++ b/internal/v5/relations.go
@@ -281,7 +281,7 @@ func (h *ReqHandler) metaBundlesContaining(entity *mongodoc.Entity, id *router.R
 }
 
 func (h *ReqHandler) getMetadataForEntity(e *mongodoc.Entity, includes []string, req *http.Request) (map[string]interface{}, error) {
-	return h.GetMetadata(charmstore.EntityResolvedURL(e), includes, req)
+	return h.Router.GetMetadata(charmstore.EntityResolvedURL(e), includes, req)
 }
 
 // filterEntities deletes all entities from *entities for which

--- a/internal/v5/stats.go
+++ b/internal/v5/stats.go
@@ -134,7 +134,7 @@ func (h *ReqHandler) serveStatsUpdate(w http.ResponseWriter, r *http.Request) er
 
 	errors := make([]error, 0)
 	for _, entry := range req.Entries {
-		rid, err := h.resolveURL(entry.CharmReference)
+		rid, err := h.Router.Context.ResolveURL(entry.CharmReference)
 		if err != nil {
 			errors = append(errors, errgo.Notef(err, "cannot find entity for url %s", entry.CharmReference))
 			continue

--- a/internal/v5/stats_test.go
+++ b/internal/v5/stats_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
-	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"


### PR DESCRIPTION
This ensures that (most) ids returned by the v4 API
will have a series, even for multiple-series charms.

Also pave the way for v4 to be able to override specific
methods in the v5 router (for example, we want search-like
methods to be expand multi-series charms into multiple
result entities).

This required a bunch of shuffling around in internal/v5;
we took this opportunity to factor the various function arguments
to router.New into an interface, and removed the now-redundant
EntityExists function.
