### PR TITLE
internal/v4: implement revision-info and expand-id

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -124,15 +124,19 @@ type Entity struct {
 // PreferredURL returns the preferred way to refer to this entity. If
 // the entity has a promulgated URL and usePromulgated is true then the
 // promulgated URL will be used, otherwise the standard URL is used.
+//
+// The returned URL may be modified freely.
 func (e *Entity) PreferredURL(usePromulgated bool) *charm.URL {
-	u := e.URL
+	var u charm.URL
 	if usePromulgated && e.PromulgatedURL != nil {
-		u = e.PromulgatedURL
+		u = *e.PromulgatedURL
+	} else {
+		u = *e.URL
 	}
 	if e.Development {
-		u = u.WithChannel(charm.DevelopmentChannel)
+		u.Channel = charm.DevelopmentChannel
 	}
-	return u
+	return &u
 }
 
 // BaseEntity holds metadata for a charm or bundle

--- a/internal/mongodoc/doc_test.go
+++ b/internal/mongodoc/doc_test.go
@@ -101,5 +101,8 @@ func (s *DocSuite) TestPreferredURL(c *gc.C) {
 		c.Logf("test %d: %#v", i, test.entity)
 		c.Assert(test.entity.PreferredURL(false).String(), gc.Equals, test.expectURLFalse)
 		c.Assert(test.entity.PreferredURL(true).String(), gc.Equals, test.expectURLTrue)
+		// Ensure no aliasing
+		test.entity.PreferredURL(false).Series = "foo"
+		c.Assert(test.entity.PreferredURL(false).Series, gc.Not(gc.Equals), "foo")
 	}
 }

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -1562,39 +1562,67 @@ var serveExpandIdTests = []struct {
 	about: "fully qualified URL",
 	url:   "~charmers/trusty/wordpress-47",
 	expect: []params.ExpandedId{
+		// V4 SPECIFIC
 		{Id: "cs:~charmers/utopic/wordpress-42"},
 		{Id: "cs:~charmers/trusty/wordpress-47"},
-		{Id: "cs:~charmers/wordpress-5"},
+		{Id: "cs:~charmers/trusty/wordpress-5"},
+		{Id: "cs:~charmers/utopic/wordpress-5"},
+		{Id: "cs:~charmers/vivid/wordpress-5"},
+		{Id: "cs:~charmers/wily/wordpress-5"},
 	},
 }, {
 	about: "fully qualified development URL",
 	url:   "~charmers/development/trusty/wordpress-47",
 	expect: []params.ExpandedId{
+		// V4 SPECIFIC
 		{Id: "cs:~charmers/utopic/wordpress-42"},
 		{Id: "cs:~charmers/development/trusty/wordpress-48"},
 		{Id: "cs:~charmers/trusty/wordpress-47"},
-		{Id: "cs:~charmers/development/wordpress-7"},
-		{Id: "cs:~charmers/development/wordpress-6"},
-		{Id: "cs:~charmers/wordpress-5"},
+		{Id: "cs:~charmers/development/trusty/wordpress-7"},
+		{Id: "cs:~charmers/development/utopic/wordpress-7"},
+		{Id: "cs:~charmers/development/vivid/wordpress-7"},
+		{Id: "cs:~charmers/development/wily/wordpress-7"},
+		{Id: "cs:~charmers/development/trusty/wordpress-6"},
+		{Id: "cs:~charmers/development/utopic/wordpress-6"},
+		{Id: "cs:~charmers/development/vivid/wordpress-6"},
+		{Id: "cs:~charmers/development/wily/wordpress-6"},
+		{Id: "cs:~charmers/trusty/wordpress-5"},
+		{Id: "cs:~charmers/utopic/wordpress-5"},
+		{Id: "cs:~charmers/vivid/wordpress-5"},
+		{Id: "cs:~charmers/wily/wordpress-5"},
 	},
 }, {
 	about: "promulgated URL",
 	url:   "trusty/wordpress-47",
 	expect: []params.ExpandedId{
+		// V4 SPECIFIC
 		{Id: "cs:utopic/wordpress-42"},
 		{Id: "cs:trusty/wordpress-47"},
-		{Id: "cs:wordpress-49"},
+		{Id: "cs:trusty/wordpress-49"},
+		{Id: "cs:utopic/wordpress-49"},
+		{Id: "cs:vivid/wordpress-49"},
+		{Id: "cs:wily/wordpress-49"},
 	},
 }, {
 	about: "development promulgated URL",
 	url:   "development/trusty/wordpress-48",
 	expect: []params.ExpandedId{
+		// V4 SPECIFIC
 		{Id: "cs:utopic/wordpress-42"},
 		{Id: "cs:development/trusty/wordpress-48"},
 		{Id: "cs:trusty/wordpress-47"},
-		{Id: "cs:development/wordpress-51"},
-		{Id: "cs:development/wordpress-50"},
-		{Id: "cs:wordpress-49"},
+		{Id: "cs:development/trusty/wordpress-51"},
+		{Id: "cs:development/utopic/wordpress-51"},
+		{Id: "cs:development/vivid/wordpress-51"},
+		{Id: "cs:development/wily/wordpress-51"},
+		{Id: "cs:development/trusty/wordpress-50"},
+		{Id: "cs:development/utopic/wordpress-50"},
+		{Id: "cs:development/vivid/wordpress-50"},
+		{Id: "cs:development/wily/wordpress-50"},
+		{Id: "cs:trusty/wordpress-49"},
+		{Id: "cs:utopic/wordpress-49"},
+		{Id: "cs:vivid/wordpress-49"},
+		{Id: "cs:wily/wordpress-49"},
 	},
 }, {
 	about: "non-promulgated charm",
@@ -1696,7 +1724,8 @@ var serveMetaRevisionInfoTests = []struct {
 			charm.MustParseURL("cs:trusty/wordpress-42"),
 			charm.MustParseURL("cs:trusty/wordpress-41"),
 			charm.MustParseURL("cs:trusty/wordpress-9"),
-		}},
+		},
+	},
 }, {
 	about: "partial url uses a default series",
 	url:   "wordpress",
@@ -1706,7 +1735,8 @@ var serveMetaRevisionInfoTests = []struct {
 			charm.MustParseURL("cs:trusty/wordpress-42"),
 			charm.MustParseURL("cs:trusty/wordpress-41"),
 			charm.MustParseURL("cs:trusty/wordpress-9"),
-		}},
+		},
+	},
 }, {
 	about: "non-promulgated URL gives non-promulgated revisions (~charmers)",
 	url:   "~charmers/trusty/cinder",
@@ -1719,7 +1749,8 @@ var serveMetaRevisionInfoTests = []struct {
 			charm.MustParseURL("cs:~charmers/trusty/cinder-2"),
 			charm.MustParseURL("cs:~charmers/trusty/cinder-1"),
 			charm.MustParseURL("cs:~charmers/trusty/cinder-0"),
-		}},
+		},
+	},
 }, {
 	about: "non-promulgated URL gives non-promulgated revisions (~openstack-charmers)",
 	url:   "~openstack-charmers/trusty/cinder",
@@ -1727,7 +1758,8 @@ var serveMetaRevisionInfoTests = []struct {
 		[]*charm.URL{
 			charm.MustParseURL("cs:~openstack-charmers/trusty/cinder-1"),
 			charm.MustParseURL("cs:~openstack-charmers/trusty/cinder-0"),
-		}},
+		},
+	},
 }, {
 	about: "promulgated URL gives promulgated revisions",
 	url:   "trusty/cinder",
@@ -1739,7 +1771,72 @@ var serveMetaRevisionInfoTests = []struct {
 			charm.MustParseURL("cs:trusty/cinder-2"),
 			charm.MustParseURL("cs:trusty/cinder-1"),
 			charm.MustParseURL("cs:trusty/cinder-0"),
-		}},
+		},
+	},
+}, {
+	about: "multi-series charm expands to all revisions of that charm",
+	url:   "multi-series",
+	expect: params.RevisionInfoResponse{
+		// V4 SPECIFIC
+		[]*charm.URL{
+			charm.MustParseURL("cs:trusty/multi-series-41"),
+			charm.MustParseURL("cs:trusty/multi-series-40"),
+		},
+	},
+}, {
+	about: "multi-series charm with series specified",
+	url:   "trusty/multi-series",
+	expect: params.RevisionInfoResponse{
+		// V4 SPECIFIC
+		[]*charm.URL{
+			charm.MustParseURL("cs:trusty/multi-series-41"),
+			charm.MustParseURL("cs:trusty/multi-series-40"),
+		},
+	},
+}, {
+	about: "multi-series charm with non-promulgated URL",
+	url:   "~charmers/multi-series",
+	expect: params.RevisionInfoResponse{
+		// V4 SPECIFIC
+		[]*charm.URL{
+			charm.MustParseURL("cs:~charmers/trusty/multi-series-2"),
+			charm.MustParseURL("cs:~charmers/trusty/multi-series-1"),
+		},
+	},
+}, {
+	about: "multi-series charm with non-promulgated URL and series specified",
+	url:   "~charmers/utopic/multi-series",
+	expect: params.RevisionInfoResponse{
+		// V4 SPECIFIC
+		[]*charm.URL{
+			charm.MustParseURL("cs:~charmers/utopic/multi-series-2"),
+			charm.MustParseURL("cs:~charmers/utopic/multi-series-1"),
+		},
+	},
+}, {
+	about: "mixed multi/single series charm, latest rev",
+	url:   "mixed",
+	expect: params.RevisionInfoResponse{
+		// V4 SPECIFIC
+		[]*charm.URL{
+			charm.MustParseURL("cs:trusty/mixed-43"),
+			charm.MustParseURL("cs:trusty/mixed-42"),
+			charm.MustParseURL("cs:trusty/mixed-41"),
+			charm.MustParseURL("cs:trusty/mixed-40"),
+		},
+	},
+}, {
+	about: "mixed multi/single series charm with series",
+	url:   "trusty/mixed-40",
+	expect: params.RevisionInfoResponse{
+		// V4 SPECIFIC
+		[]*charm.URL{
+			charm.MustParseURL("cs:trusty/mixed-43"),
+			charm.MustParseURL("cs:trusty/mixed-42"),
+			charm.MustParseURL("cs:trusty/mixed-41"),
+			charm.MustParseURL("cs:trusty/mixed-40"),
+		},
+	},
 }, {
 	about: "no entities found",
 	url:   "precise/no-such-33",
@@ -1764,6 +1861,14 @@ func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-4", -1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-5", 4))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-6", 5))
+
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-1", 40))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-2", 41))
+
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-1", 40))
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-2", 41))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-3", 42))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-4", 43))
 
 	for i, test := range serveMetaRevisionInfoTests {
 		c.Logf("test %d: %s", i, test.about)

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -35,7 +35,7 @@ import (
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 )
 
-var logger = loggo.GetLogger("charmstore.internal.v4")
+var logger = loggo.GetLogger("charmstore.internal.v5")
 
 // reqHandlerPool holds a cache of ReqHandlers to save
 // on allocation time. When a handler is done with,
@@ -131,6 +131,8 @@ func (h *Handler) NewReqHandler() (*ReqHandler, error) {
 // can override selected parts of the handlers to serve their own API
 // while still using ReqHandler to serve the majority of the API.
 func RouterHandlers(h *ReqHandler) *router.Handlers {
+	resolveId := h.ResolvedIdHandler
+	authId := h.AuthIdHandler
 	return &router.Handlers{
 		Global: map[string]http.Handler{
 			"changes/published":    router.HandleJSON(h.serveChangesPublished),
@@ -151,14 +153,14 @@ func RouterHandlers(h *ReqHandler) *router.Handlers {
 		},
 		Id: map[string]router.IdHandler{
 			"archive":     h.serveArchive,
-			"archive/":    h.resolveId(h.authId(h.serveArchiveFile)),
-			"diagram.svg": h.resolveId(h.authId(h.serveDiagram)),
-			"expand-id":   h.resolveId(h.authId(h.serveExpandId)),
-			"icon.svg":    h.resolveId(h.authId(h.serveIcon)),
-			"promulgate":  h.resolveId(h.serveAdminPromulgate),
+			"archive/":    resolveId(authId(h.serveArchiveFile)),
+			"diagram.svg": resolveId(authId(h.serveDiagram)),
+			"expand-id":   resolveId(authId(h.serveExpandId)),
+			"icon.svg":    resolveId(authId(h.serveIcon)),
+			"promulgate":  resolveId(h.serveAdminPromulgate),
 			"publish":     h.servePublish,
-			"readme":      h.resolveId(h.authId(h.serveReadMe)),
-			"resources":   h.resolveId(h.authId(h.serveResources)),
+			"readme":      resolveId(authId(h.serveReadMe)),
+			"resources":   resolveId(authId(h.serveResources)),
 		},
 		Meta: map[string]router.BulkIncludeHandler{
 			"archive-size":         h.entityHandler(h.metaArchiveSize, "size"),
@@ -508,13 +510,6 @@ func (h *ReqHandler) serveExpandId(id *router.ResolvedURL, w http.ResponseWriter
 	err := q.All(&docs)
 	if err != nil && errgo.Cause(err) != mgo.ErrNotFound {
 		return errgo.Mask(err)
-	}
-
-	// A not found error should have been already returned by the router in the
-	// case a partial id is provided. Here we do the same for the case when
-	// a fully qualified URL is provided, but no matching entities are found.
-	if len(docs) == 0 {
-		return noMatchingURLError(id.PreferredURL())
 	}
 
 	// Collect all the expanded identifiers for each entity.
@@ -1285,14 +1280,19 @@ func (h *ReqHandler) serveSetAuthCookie(w http.ResponseWriter, req *http.Request
 	return nil
 }
 
-type resolvedIdHandler func(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error
+// ResolvedIdHandler represents a HTTP handler that is invoked
+// on a resolved entity id.
+type ResolvedIdHandler func(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error
 
-// authId returns a resolvedIdHandler that checks that the client
-// is authorized to perform the HTTP request method before
+// AuthIdHandler returns a ResolvedIdHandler that uses h.Router.Context.AuthorizeEntity to
+// check that the client is authorized to perform the HTTP request method before
 // invoking f.
-func (h *ReqHandler) authId(f resolvedIdHandler) resolvedIdHandler {
+//
+// Note that it only accesses h.Router.Context when the returned
+// handler is called.
+func (h *ReqHandler) AuthIdHandler(f ResolvedIdHandler) ResolvedIdHandler {
 	return func(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error {
-		if err := h.AuthorizeEntity(id, req); err != nil {
+		if err := h.Router.Context.AuthorizeEntity(id, req); err != nil {
 			return errgo.Mask(err, errgo.Any)
 		}
 		if err := f(id, w, req); err != nil {
@@ -1302,9 +1302,12 @@ func (h *ReqHandler) authId(f resolvedIdHandler) resolvedIdHandler {
 	}
 }
 
-// resolveId returns an id handler that resolves any non-fully-specified
-// entity ids using h.resolveURL before calling f with the resolved id.
-func (h *ReqHandler) resolveId(f resolvedIdHandler) router.IdHandler {
+// ResolvedIdHandler returns an id handler that uses h.Router.Context.ResolveURL
+// to resolves any entity ids before calling f with the resolved id.
+//
+// Note that it only accesses h.Router.Context when the returned
+// handler is called.
+func (h *ReqHandler) ResolvedIdHandler(f ResolvedIdHandler) router.IdHandler {
 	return func(id *charm.URL, w http.ResponseWriter, req *http.Request) error {
 		rid, err := h.Router.Context.ResolveURL(id)
 		if err != nil {

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -1741,7 +1741,8 @@ var serveMetaRevisionInfoTests = []struct {
 			charm.MustParseURL("cs:trusty/wordpress-42"),
 			charm.MustParseURL("cs:trusty/wordpress-41"),
 			charm.MustParseURL("cs:trusty/wordpress-9"),
-		}},
+		},
+	},
 }, {
 	about: "partial url uses a default series",
 	url:   "wordpress",
@@ -1751,7 +1752,8 @@ var serveMetaRevisionInfoTests = []struct {
 			charm.MustParseURL("cs:trusty/wordpress-42"),
 			charm.MustParseURL("cs:trusty/wordpress-41"),
 			charm.MustParseURL("cs:trusty/wordpress-9"),
-		}},
+		},
+	},
 }, {
 	about: "non-promulgated URL gives non-promulgated revisions (~charmers)",
 	url:   "~charmers/trusty/cinder",
@@ -1764,7 +1766,8 @@ var serveMetaRevisionInfoTests = []struct {
 			charm.MustParseURL("cs:~charmers/trusty/cinder-2"),
 			charm.MustParseURL("cs:~charmers/trusty/cinder-1"),
 			charm.MustParseURL("cs:~charmers/trusty/cinder-0"),
-		}},
+		},
+	},
 }, {
 	about: "non-promulgated URL gives non-promulgated revisions (~openstack-charmers)",
 	url:   "~openstack-charmers/trusty/cinder",
@@ -1772,7 +1775,8 @@ var serveMetaRevisionInfoTests = []struct {
 		[]*charm.URL{
 			charm.MustParseURL("cs:~openstack-charmers/trusty/cinder-1"),
 			charm.MustParseURL("cs:~openstack-charmers/trusty/cinder-0"),
-		}},
+		},
+	},
 }, {
 	about: "promulgated URL gives promulgated revisions",
 	url:   "trusty/cinder",
@@ -1784,7 +1788,66 @@ var serveMetaRevisionInfoTests = []struct {
 			charm.MustParseURL("cs:trusty/cinder-2"),
 			charm.MustParseURL("cs:trusty/cinder-1"),
 			charm.MustParseURL("cs:trusty/cinder-0"),
-		}},
+		},
+	},
+}, {
+	about: "multi-series charm expands to all revisions of that charm",
+	url:   "multi-series",
+	expect: params.RevisionInfoResponse{
+		[]*charm.URL{
+			charm.MustParseURL("cs:multi-series-41"),
+			charm.MustParseURL("cs:multi-series-40"),
+		},
+	},
+}, {
+	about: "multi-series charm with series specified",
+	url:   "trusty/multi-series",
+	expect: params.RevisionInfoResponse{
+		[]*charm.URL{
+			charm.MustParseURL("cs:multi-series-41"),
+			charm.MustParseURL("cs:multi-series-40"),
+		},
+	},
+}, {
+	about: "multi-series charm with non-promulgated URL",
+	url:   "~charmers/multi-series",
+	expect: params.RevisionInfoResponse{
+		[]*charm.URL{
+			charm.MustParseURL("cs:~charmers/multi-series-2"),
+			charm.MustParseURL("cs:~charmers/multi-series-1"),
+		},
+	},
+}, {
+	about: "multi-series charm with non-promulgated URL and series specified",
+	url:   "~charmers/utopic/multi-series",
+	expect: params.RevisionInfoResponse{
+		[]*charm.URL{
+			charm.MustParseURL("cs:~charmers/multi-series-2"),
+			charm.MustParseURL("cs:~charmers/multi-series-1"),
+		},
+	},
+}, {
+	about: "mixed multi/single series charm, latest rev",
+	url:   "mixed",
+	expect: params.RevisionInfoResponse{
+		[]*charm.URL{
+			charm.MustParseURL("cs:mixed-43"),
+			charm.MustParseURL("cs:mixed-42"),
+			charm.MustParseURL("cs:trusty/mixed-41"),
+			charm.MustParseURL("cs:trusty/mixed-40"),
+		},
+	},
+}, {
+	about: "mixed multi/single series charm with series",
+	url:   "trusty/mixed-40",
+	expect: params.RevisionInfoResponse{
+		[]*charm.URL{
+			charm.MustParseURL("cs:mixed-43"),
+			charm.MustParseURL("cs:mixed-42"),
+			charm.MustParseURL("cs:trusty/mixed-41"),
+			charm.MustParseURL("cs:trusty/mixed-40"),
+		},
+	},
 }, {
 	about: "no entities found",
 	url:   "precise/no-such-33",
@@ -1809,6 +1872,14 @@ func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-4", -1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-5", 4))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-6", 5))
+
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-1", 40))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-2", 41))
+
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-1", 40))
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-2", 41))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-3", 42))
+	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-4", 43))
 
 	for i, test := range serveMetaRevisionInfoTests {
 		c.Logf("test %d: %s", i, test.about)

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -47,11 +47,13 @@ import (
 // ingestion methods, and will be removed in the future, it has no entry
 // in the specification.
 func (h *ReqHandler) serveArchive(id *charm.URL, w http.ResponseWriter, req *http.Request) error {
+	resolveId := h.ResolvedIdHandler
+	authId := h.AuthIdHandler
 	switch req.Method {
 	case "DELETE":
-		return h.resolveId(h.authId(h.serveDeleteArchive))(id, w, req)
+		return resolveId(authId(h.serveDeleteArchive))(id, w, req)
 	case "GET":
-		return h.resolveId(h.authId(h.serveGetArchive))(id, w, req)
+		return resolveId(authId(h.serveGetArchive))(id, w, req)
 	case "POST", "PUT":
 		// Make sure we consume the full request body, before responding.
 		//


### PR DESCRIPTION
This involves exporting a few more things from v5 too, and
adding some more tests.
