### PR TITLE
internal/v5: make charm-related always check permissions and never return dev charms

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -558,7 +558,6 @@ func (r *Router) serveBulkMeta(w http.ResponseWriter, req *http.Request) error {
 // GET meta/$endpoint?id=$id0[&id=$id1...][$otherflags]
 // See https://github.com/juju/charmstore/blob/v4/docs/API.md#get-metaendpoint
 func (r *Router) serveBulkMetaGet(req *http.Request) (interface{}, error) {
-	// TODO get the metadata concurrently for each id.
 	ids := req.Form["id"]
 	if len(ids) == 0 {
 		return nil, errgo.WithCausef(nil, params.ErrBadRequest, "no ids specified in meta request")

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -701,7 +701,7 @@ var metaBundlesContainingTests = []struct {
 	querystring:  "?include=no-such",
 	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
-		Message: `cannot retrieve bundle metadata: unrecognized metadata name "no-such"`,
+		Message: `unrecognized metadata name "no-such"`,
 	},
 }}
 

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -338,7 +338,6 @@ func (h *ReqHandler) addEntity(id *router.ResolvedURL, r io.ReadSeeker, blobName
 		BlobHash:    hash,
 		BlobHash256: hash256,
 		BlobSize:    contentLength,
-		Development: id.Development,
 	}
 	if id.URL.Series == "bundle" {
 		b, err := charm.ReadBundleArchiveFromReader(readerAt, contentLength)


### PR DESCRIPTION
Also:
- remove the Development field from AddCharmParams because
  it was redundantly specified with the ResolvedURL Development field.
- factor out MatchingInterfacesQuery from v5 so that we'll be able to
  use it in v4 too.
