### PR TITLE
expand multi-series charm Ids in charm-related

### DIFF
--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -1,0 +1,170 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package v4 // import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
+
+import (
+	"net/http"
+	"net/url"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+	"gopkg.in/mgo.v2/bson"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
+)
+
+// GET id/meta/charm-related[?include=meta[&include=meta…]]
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetacharm-related
+func (h *ReqHandler) metaCharmRelated(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
+	if id.URL.Series == "bundle" {
+		return nil, nil
+	}
+	// If the charm does not define any relation we can just return without
+	// hitting the db.
+	if len(entity.CharmProvidedInterfaces)+len(entity.CharmRequiredInterfaces) == 0 {
+		return &params.RelatedResponse{}, nil
+	}
+	q := h.Store.MatchingInterfacesQuery(entity.CharmProvidedInterfaces, entity.CharmRequiredInterfaces)
+
+	fields := bson.D{
+		{"_id", 1},
+		{"supportedseries", 1},
+		{"development", 1},
+		{"charmrequiredinterfaces", 1},
+		{"charmprovidedinterfaces", 1},
+		{"promulgated-url", 1},
+		{"promulgated-revision", 1},
+	}
+
+	var entities []*mongodoc.Entity
+	if err := q.Select(fields).Sort("_id").All(&entities); err != nil {
+		return nil, errgo.Notef(err, "cannot retrieve the related charms")
+	}
+
+	// If no entities are found there is no need for further processing the
+	// results.
+	if len(entities) == 0 {
+		return &params.RelatedResponse{}, nil
+	}
+
+	// Build the results, by grouping entities based on their relations' roles
+	// and interfaces.
+	includes := flags["include"]
+	requires, err := h.getRelatedCharmsResponse(entity.CharmProvidedInterfaces, entities, func(e *mongodoc.Entity) []string {
+		return e.CharmRequiredInterfaces
+	}, includes, req)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot retrieve the charm requires")
+	}
+	provides, err := h.getRelatedCharmsResponse(entity.CharmRequiredInterfaces, entities, func(e *mongodoc.Entity) []string {
+		return e.CharmProvidedInterfaces
+	}, includes, req)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot retrieve the charm provides")
+	}
+
+	// Return the response.
+	return &params.RelatedResponse{
+		Requires: requires,
+		Provides: provides,
+	}, nil
+}
+
+type entityRelatedInterfacesGetter func(*mongodoc.Entity) []string
+
+// getRelatedCharmsResponse returns a response mapping interfaces to related
+// charms. For instance:
+//   map[string][]params.MetaAnyResponse{
+//       "http": []params.MetaAnyResponse{
+//           {Id: "cs:utopic/django-42", Meta: ...},
+//           {Id: "cs:trusty/wordpress-47", Meta: ...},
+//       },
+//       "memcache": []params.MetaAnyResponse{
+//           {Id: "cs:utopic/memcached-0", Meta: ...},
+//       },
+//   }
+func (h *ReqHandler) getRelatedCharmsResponse(
+	ifaces []string,
+	entities []*mongodoc.Entity,
+	getInterfaces entityRelatedInterfacesGetter,
+	includes []string,
+	req *http.Request,
+) (map[string][]params.MetaAnyResponse, error) {
+	results := make(map[string][]params.MetaAnyResponse, len(ifaces))
+	for _, iface := range ifaces {
+		responses, err := h.getRelatedIfaceResponses(iface, entities, getInterfaces, includes, req)
+		if err != nil {
+			return nil, err
+		}
+		if len(responses) > 0 {
+			results[iface] = responses
+		}
+	}
+	return results, nil
+}
+
+func (h *ReqHandler) getRelatedIfaceResponses(
+	iface string,
+	entities []*mongodoc.Entity,
+	getInterfaces entityRelatedInterfacesGetter,
+	includes []string,
+	req *http.Request,
+) ([]params.MetaAnyResponse, error) {
+	// Build a list of responses including only entities which are related
+	// to the given interface.
+	usesInterface := func(e *mongodoc.Entity) bool {
+		for _, entityIface := range getInterfaces(e) {
+			if entityIface == iface {
+				return true
+			}
+		}
+		return false
+	}
+
+	resp, err := h.getMetadataForEntities(entities, includes, req, usesInterface)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return resp, nil
+}
+
+func (h *ReqHandler) getMetadataForEntities(entities []*mongodoc.Entity, includes []string, req *http.Request, includeEntity func(*mongodoc.Entity) bool) ([]params.MetaAnyResponse, error) {
+	response := make([]params.MetaAnyResponse, 0, len(entities))
+	err := expandMultiSeries(entities, func(series string, e *mongodoc.Entity) error {
+		if includeEntity != nil && !includeEntity(e) {
+			return nil
+		}
+		meta, err := h.getMetadataForEntity(e, includes, req)
+		if err == errMetadataUnauthorized {
+			return nil
+		}
+		if err != nil {
+			return errgo.Mask(err)
+		}
+		id := e.PreferredURL(true)
+		id.Series = series
+		response = append(response, params.MetaAnyResponse{
+			Id:   id,
+			Meta: meta,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return response, nil
+}
+
+var errMetadataUnauthorized = errgo.Newf("metadata unauthorized")
+
+func (h *ReqHandler) getMetadataForEntity(e *mongodoc.Entity, includes []string, req *http.Request) (map[string]interface{}, error) {
+	rurl := charmstore.EntityResolvedURL(e)
+	// Ignore entities that aren't readable by the current user.
+	if err := h.AuthorizeEntity(rurl, req); err != nil {
+		return nil, errMetadataUnauthorized
+	}
+	return h.Router.GetMetadata(rurl, includes, req)
+}

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -163,16 +163,16 @@ func RouterHandlers(h *ReqHandler) *router.Handlers {
 			"resources":   resolveId(authId(h.serveResources)),
 		},
 		Meta: map[string]router.BulkIncludeHandler{
-			"archive-size":         h.entityHandler(h.metaArchiveSize, "size"),
-			"archive-upload-time":  h.entityHandler(h.metaArchiveUploadTime, "uploadtime"),
-			"bundle-machine-count": h.entityHandler(h.metaBundleMachineCount, "bundlemachinecount"),
-			"bundle-metadata":      h.entityHandler(h.metaBundleMetadata, "bundledata"),
-			"bundles-containing":   h.entityHandler(h.metaBundlesContaining),
-			"bundle-unit-count":    h.entityHandler(h.metaBundleUnitCount, "bundleunitcount"),
-			"charm-actions":        h.entityHandler(h.metaCharmActions, "charmactions"),
-			"charm-config":         h.entityHandler(h.metaCharmConfig, "charmconfig"),
-			"charm-metadata":       h.entityHandler(h.metaCharmMetadata, "charmmeta"),
-			"charm-related":        h.entityHandler(h.metaCharmRelated, "charmprovidedinterfaces", "charmrequiredinterfaces"),
+			"archive-size":         h.EntityHandler(h.metaArchiveSize, "size"),
+			"archive-upload-time":  h.EntityHandler(h.metaArchiveUploadTime, "uploadtime"),
+			"bundle-machine-count": h.EntityHandler(h.metaBundleMachineCount, "bundlemachinecount"),
+			"bundle-metadata":      h.EntityHandler(h.metaBundleMetadata, "bundledata"),
+			"bundles-containing":   h.EntityHandler(h.metaBundlesContaining),
+			"bundle-unit-count":    h.EntityHandler(h.metaBundleUnitCount, "bundleunitcount"),
+			"charm-actions":        h.EntityHandler(h.metaCharmActions, "charmactions"),
+			"charm-config":         h.EntityHandler(h.metaCharmConfig, "charmconfig"),
+			"charm-metadata":       h.EntityHandler(h.metaCharmMetadata, "charmmeta"),
+			"charm-related":        h.EntityHandler(h.metaCharmRelated, "charmprovidedinterfaces", "charmrequiredinterfaces"),
 			"extra-info": h.puttableEntityHandler(
 				h.metaExtraInfo,
 				h.putMetaExtraInfo,
@@ -193,21 +193,21 @@ func RouterHandlers(h *ReqHandler) *router.Handlers {
 				h.putMetaCommonInfoWithKey,
 				"commoninfo",
 			),
-			"hash":             h.entityHandler(h.metaHash, "blobhash"),
-			"hash256":          h.entityHandler(h.metaHash256, "blobhash256"),
-			"id":               h.entityHandler(h.metaId, "_id"),
-			"id-name":          h.entityHandler(h.metaIdName, "_id"),
-			"id-user":          h.entityHandler(h.metaIdUser, "_id"),
-			"id-revision":      h.entityHandler(h.metaIdRevision, "_id"),
-			"id-series":        h.entityHandler(h.metaIdSeries, "_id"),
-			"manifest":         h.entityHandler(h.metaManifest, "blobname"),
+			"hash":             h.EntityHandler(h.metaHash, "blobhash"),
+			"hash256":          h.EntityHandler(h.metaHash256, "blobhash256"),
+			"id":               h.EntityHandler(h.metaId, "_id"),
+			"id-name":          h.EntityHandler(h.metaIdName, "_id"),
+			"id-user":          h.EntityHandler(h.metaIdUser, "_id"),
+			"id-revision":      h.EntityHandler(h.metaIdRevision, "_id"),
+			"id-series":        h.EntityHandler(h.metaIdSeries, "_id"),
+			"manifest":         h.EntityHandler(h.metaManifest, "blobname"),
 			"perm":             h.puttableBaseEntityHandler(h.metaPerm, h.putMetaPerm, "acls", "developmentacls"),
 			"perm/":            h.puttableBaseEntityHandler(h.metaPermWithKey, h.putMetaPermWithKey, "acls", "developmentacls"),
 			"promulgated":      h.baseEntityHandler(h.metaPromulgated, "promulgated"),
 			"revision-info":    router.SingleIncludeHandler(h.metaRevisionInfo),
-			"stats":            h.entityHandler(h.metaStats),
-			"supported-series": h.entityHandler(h.metaSupportedSeries, "supportedseries"),
-			"tags":             h.entityHandler(h.metaTags, "charmmeta", "bundledata"),
+			"stats":            h.EntityHandler(h.metaStats),
+			"supported-series": h.EntityHandler(h.metaSupportedSeries, "supportedseries"),
+			"tags":             h.EntityHandler(h.metaTags, "charmmeta", "bundledata"),
 
 			// endpoints not yet implemented:
 			// "color": router.SingleIncludeHandler(h.metaColor),
@@ -301,17 +301,17 @@ func noMatchingURLError(url *charm.URL) error {
 	return errgo.WithCausef(nil, params.ErrNotFound, "no matching charm or bundle for %q", url)
 }
 
-type entityHandlerFunc func(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error)
+type EntityHandlerFunc func(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error)
 
 type baseEntityHandlerFunc func(entity *mongodoc.BaseEntity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error)
 
-// entityHandler returns a Handler that calls f with a *mongodoc.Entity that
+// EntityHandler returns a Handler that calls f with a *mongodoc.Entity that
 // contains at least the given fields. It allows only GET requests.
-func (h *ReqHandler) entityHandler(f entityHandlerFunc, fields ...string) router.BulkIncludeHandler {
+func (h *ReqHandler) EntityHandler(f EntityHandlerFunc, fields ...string) router.BulkIncludeHandler {
 	return h.puttableEntityHandler(f, nil, fields...)
 }
 
-func (h *ReqHandler) puttableEntityHandler(get entityHandlerFunc, handlePut router.FieldPutFunc, fields ...string) router.BulkIncludeHandler {
+func (h *ReqHandler) puttableEntityHandler(get EntityHandlerFunc, handlePut router.FieldPutFunc, fields ...string) router.BulkIncludeHandler {
 	handleGet := func(doc interface{}, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
 		edoc := doc.(*mongodoc.Entity)
 		val, err := get(edoc, id, path, flags, req)


### PR DESCRIPTION
Make the /v4 version of charm-related response contain charm ids that always contain a series.
