### PR TITLE
internal/entitycache: new package

### DIFF
--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -255,7 +255,7 @@ func (s *StoreSearchSuite) addCharmsToStore(c *gc.C) {
 		}
 		err = s.store.SetPerms(&url.URL, "read", url.URL.User, params.Everyone)
 		c.Assert(err, gc.IsNil)
-		err = s.store.UpdateSearchBaseURL(baseURL(&url.URL))
+		err = s.store.UpdateSearchBaseURL(mongodoc.BaseURL(&url.URL))
 		c.Assert(err, gc.IsNil)
 	}
 	for name, url := range exportTestBundles {
@@ -269,7 +269,7 @@ func (s *StoreSearchSuite) addCharmsToStore(c *gc.C) {
 		}
 		err = s.store.SetPerms(&url.URL, "read", url.URL.User, params.Everyone)
 		c.Assert(err, gc.IsNil)
-		err = s.store.UpdateSearchBaseURL(baseURL(&url.URL))
+		err = s.store.UpdateSearchBaseURL(mongodoc.BaseURL(&url.URL))
 		c.Assert(err, gc.IsNil)
 	}
 	s.store.pool.statsCache.EvictAll()
@@ -625,7 +625,7 @@ func (s *StoreSearchSuite) TestPromulgatedRank(c *gc.C) {
 	s.store.AddCharmWithArchive(url, charmArchive)
 	err := s.store.SetPerms(&url.URL, "read", url.URL.User, params.Everyone)
 	c.Assert(err, gc.IsNil)
-	err = s.store.UpdateSearchBaseURL(baseURL(&url.URL))
+	err = s.store.UpdateSearchBaseURL(mongodoc.BaseURL(&url.URL))
 	c.Assert(err, gc.IsNil)
 	s.store.ES.Database.RefreshIndex(s.TestIndex)
 	sp := SearchParams{

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -120,7 +120,7 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool, url *r
 	c.Assert(charmArchive.Revision(), jc.DeepEquals, ch.Revision())
 
 	// Check that the base entity has been properly created.
-	assertBaseEntity(c, store, baseURL(&url.URL), url.PromulgatedRevision != -1)
+	assertBaseEntity(c, store, mongodoc.BaseURL(&url.URL), url.PromulgatedRevision != -1)
 
 	// Try inserting the charm again - it should fail because the charm is
 	// already there.
@@ -205,7 +205,7 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bool, 
 	c.Assert(bundleArchive.ReadMe(), jc.DeepEquals, bundle.ReadMe())
 
 	// Check that the base entity has been properly created.
-	assertBaseEntity(c, store, baseURL(&url.URL), url.PromulgatedRevision != -1)
+	assertBaseEntity(c, store, mongodoc.BaseURL(&url.URL), url.PromulgatedRevision != -1)
 
 	// Try inserting the bundle again - it should fail because the bundle is
 	// already there.
@@ -1629,7 +1629,7 @@ func (s *StoreSuite) TestAddCharmWithUser(c *gc.C) {
 	url := newResolvedURL("cs:~who/precise/wordpress-23", -1)
 	err := store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
-	assertBaseEntity(c, store, baseURL(&url.URL), false)
+	assertBaseEntity(c, store, mongodoc.BaseURL(&url.URL), false)
 }
 
 func (s *StoreSuite) TestOpenCachedBlobFileWithNotFoundContent(c *gc.C) {

--- a/internal/entitycache/bench_test.go
+++ b/internal/entitycache/bench_test.go
@@ -1,0 +1,47 @@
+package entitycache_test
+
+import (
+	"testing"
+
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/entitycache"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+)
+
+func BenchmarkSingleRequest(b *testing.B) {
+	// This benchmarks the common case of getting a single entity and its
+	// base entity, so that we get an idea of the baseline overhead
+	// in this simple case.
+	entity := &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-1"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w1",
+	}
+	baseEntity := &mongodoc.BaseEntity{
+		URL:  charm.MustParseURL("~bob/wordpress"),
+		Name: "wordpress",
+	}
+	store := &callbackStore{
+		findBestEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error) {
+			return entity, nil
+		},
+		findBaseEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+			return baseEntity, nil
+		},
+	}
+	url := charm.MustParseURL("~bob/wordpress-1")
+	baseURL := charm.MustParseURL("~bob/wordpress")
+	for i := 0; i < b.N; i++ {
+		c := entitycache.New(store)
+		c.AddEntityFields("size", "blobname")
+		e, err := c.Entity(url)
+		if err != nil || e != entity {
+			b.Fatalf("get returned unexpected entity (err %v)", err)
+		}
+		be, err := c.BaseEntity(baseURL)
+		if err != nil || be != baseEntity {
+			b.Fatalf("get returned unexpected base entity (err %v)", err)
+		}
+	}
+}

--- a/internal/entitycache/cache.go
+++ b/internal/entitycache/cache.go
@@ -1,0 +1,664 @@
+// Package entitycache provides a cache of charmstore entities and
+// base-entities, designed to be used for individual charmstore API
+// requests.
+package entitycache
+
+import (
+	"sync"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+	"gopkg.in/mgo.v2"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+)
+
+// TODO it might be better to represent the field selection with
+// a uint64 bitmask instead of a map[string]int.
+
+// Store holds the underlying storage used by the entity cache.
+// It is implemented by *charmstore.Store.
+type Store interface {
+	FindBestEntity(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error)
+	FindBaseEntity(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error)
+}
+
+const (
+	// entityThreshold holds the maximum number
+	// of entities that will be batched up before
+	// requesting their base entities.
+	entityThreshold = 100
+
+	// baseEntityThreshold holds the maximum number
+	// of base entities that will be batched up before
+	// requesting them.
+	baseEntityThreshold = 20
+)
+
+// Cache holds a cache of entities and base entities. Whenever an entity
+// is fetched, its base entity is fetched too. It is OK to call methods
+// on Cache concurrently.
+type Cache struct {
+	// store holds the store used by the cache.
+	store Store
+
+	// wg represents the set of running goroutines.
+	wg sync.WaitGroup
+
+	// entities holds all the cached *mongodoc.Entity entries,
+	// A given entity always has an entry with its canonical URL as key,
+	// but also may have other entries for other unambiguous names.
+	//
+	// Note that if an entity is in the entities stash, it does
+	// not imply that its base entity necessarily in the base entities
+	// stash.
+	entities stash
+
+	// entities holds all the cached *mongodoc.BaseEntity entries,
+	// keyed by the canonical base URL string, and also its
+	// promulgated URL.
+	baseEntities stash
+}
+
+// New returns a new cache that uses the given store
+// for fetching entities.
+func New(store Store) *Cache {
+	var c Cache
+	c.entities.init(c.getEntity, &c.wg)
+	c.baseEntities.init(c.getBaseEntity, &c.wg)
+	c.store = store
+	return &c
+}
+
+// Close closes the cache, ensuring that there are
+// no currently outstanding goroutines in progress.
+func (c *Cache) Close() {
+	c.wg.Wait()
+}
+
+// AddEntityFields arranges that any entity subsequently
+// returned from Entity will have the given fields populated.
+//
+// If all the required fields are added before retrieving any entities,
+// fewer database round trips will be required.
+func (c *Cache) AddEntityFields(fields ...string) {
+	c.entities.mu.Lock()
+	defer c.entities.mu.Unlock()
+	c.entities.addFields(fields)
+}
+
+// AddBaseEntityFields arranges that any value subsequently
+// returned from BaseEntity will have the given fields populated.
+//
+// If all the required fields are added before retrieving any base entities,
+// less database round trips will be required.
+func (c *Cache) AddBaseEntityFields(fields ...string) {
+	c.baseEntities.mu.Lock()
+	defer c.baseEntities.mu.Unlock()
+	c.baseEntities.addFields(fields)
+}
+
+// StartFetch starts to fetch entities for all the given ids. The
+// entities can be accessed by calling Entity and their associated base
+// entities found by calling BaseEntity.
+// This method does not wait for the entities to actually be fetched.
+func (c *Cache) StartFetch(ids []*charm.URL) {
+	c.entities.mu.Lock()
+	defer c.entities.mu.Unlock()
+	for _, id := range ids {
+		c.baseEntities.startFetch(mongodoc.BaseURL(id))
+		c.entities.startFetch(id)
+	}
+}
+
+// Entity returns the entity with the given id. If the entity is not
+// found, it returns an error with a params.ErrNotFound cause.
+// The returned entity will have at least the given fields filled out.
+func (c *Cache) Entity(id *charm.URL, fields ...string) (*mongodoc.Entity, error) {
+	// Start the base entity fetch asynchronously.
+	// Note that it's valid to do this because we can always tell
+	// the base entity from any URL that we can look up.
+	c.baseEntities.mu.Lock()
+	c.baseEntities.startFetch(mongodoc.BaseURL(id))
+	c.baseEntities.mu.Unlock()
+	e, err := c.entities.entity(id, fields...)
+	if err != nil {
+		return nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
+	}
+	return e.(*mongodoc.Entity), nil
+}
+
+// BaseEntity returns the base entity with the given id. If the entity is not
+// found, it returns an error with a params.ErrNotFound cause.
+// The returned entity will have at least the given fields filled out.
+func (c *Cache) BaseEntity(id *charm.URL, fields ...string) (*mongodoc.BaseEntity, error) {
+	e, err := c.baseEntities.entity(mongodoc.BaseURL(id), fields...)
+	if err != nil {
+		return nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
+	}
+	return e.(*mongodoc.BaseEntity), nil
+}
+
+// getEntity is used by c.entities to fetch entities.
+func (c *Cache) getEntity(id *charm.URL, fields map[string]int) (stashEntity, error) {
+	e, err := c.store.FindBestEntity(id, fields)
+	if err != nil {
+		return nil, errgo.Mask(err, errgo.Any)
+	}
+	return e, nil
+}
+
+// getBaseEntity is used by c.baseEntities to fetch entities.
+func (c *Cache) getBaseEntity(id *charm.URL, fields map[string]int) (stashEntity, error) {
+	e, err := c.store.FindBaseEntity(id, fields)
+	if err != nil {
+		return nil, errgo.Mask(err, errgo.Any)
+	}
+	return e, nil
+}
+
+// stash holds a set of one kind of entity (either entities or base entities).
+type stash struct {
+	// get fetches the entity with the given URL.
+	get func(id *charm.URL, fields map[string]int) (stashEntity, error)
+
+	// wg represents the set of running goroutines.
+	wg *sync.WaitGroup
+
+	// mu guards the fields below
+	mu sync.Mutex
+
+	// changed is signalled every time the entities map has changed.
+	// This means that each waiter can potentially be woken up many
+	// times before it finds the entity that it's waiting for, but
+	// saves us having a channel or condition per entity.
+	//
+	// Note that in the usual pattern we expect to see, callers
+	// will ask for entities in the same order that they arrive
+	// in the cache, so won't iterate many times.
+	changed sync.Cond
+
+	// entities holds at least one entry for each cached entity,
+	// keyed by the entity id string. A given entity always has an
+	// entry with its canonical URL as key, but also may have other
+	// entries for other unambiguous names.
+	//
+	// A nil entry indicates that the entity has been scheduled to
+	// be fetched. Entries that have been fetched but that were not
+	// found are indicated with a notFoundEntity value.
+	entities map[charm.URL]stashEntity
+
+	// fields holds the set of fields required when fetching an
+	// entity. This map is never changed after it is first populated
+	// - it is replaced instead, which means that it's OK to pass it
+	// to concurrent goroutines that access it without the mutex
+	// locked.
+	//
+	// When it does change, the entity cache is invalidated. Fields
+	// are never deleted.
+	fields map[string]int
+
+	// version is incremented every time fields is modified.
+	version int
+
+	// err holds any database fetch error (other than "not found")
+	// that has occurred while fetching entities.
+	err error
+}
+
+// stashEntity represents an entity stored in a stash.
+// It is implemented by both Entity and BaseEntity.
+type stashEntity interface {
+	CanonicalURL() *charm.URL
+}
+
+// init initializes the stash with the given entity get function.
+func (s *stash) init(get func(id *charm.URL, fields map[string]int) (stashEntity, error), wg *sync.WaitGroup) {
+	s.changed.L = &s.mu
+	s.get = get
+	s.wg = wg
+	s.entities = make(map[charm.URL]stashEntity)
+}
+
+// entity returns the entity with the given id. If the entity is not
+// found, it returns an error with a params.ErrNotFound cause.
+func (s *stash) entity(id *charm.URL, fields ...string) (stashEntity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.addFields(fields)
+	e, hasEntry := s.entities[*id]
+	for {
+		if e != nil {
+			if e == notFoundEntity {
+				return nil, params.ErrNotFound
+			}
+			return e, nil
+		}
+		if s.err != nil {
+			return nil, errgo.Notef(s.err, "cannot fetch %q", id)
+		}
+		if hasEntry {
+			// The entity is already being fetched. Wait for the fetch
+			// to complete and try again.
+			s.changed.Wait()
+			e, hasEntry = s.entities[*id]
+			continue
+		}
+		// Fetch synchronously (any other goroutines will be
+		// notified when we've retrieved the entity). After the
+		// fetch has completed, the entry in the cache will either
+		// be set to the retrieved entity, or deleted (if the
+		// selected fields have changed).
+		s.entities[*id] = nil
+		version := s.version
+		fields := s.fields
+		s.mu.Unlock()
+		e = s.fetch(id, fields, version)
+		s.mu.Lock()
+		// Invariant (from fetch): e != nil || s.err != nil
+	}
+}
+
+// addFields adds the given fields to those that will be fetched
+// when an entity is fetched.
+//
+// Called with s.mu locked.
+func (s *stash) addFields(fields []string) {
+	changed := false
+	for _, field := range fields {
+		if _, ok := s.fields[field]; !ok {
+			changed = true
+			break
+		}
+	}
+	if !changed {
+		return
+	}
+	if len(s.entities) > 0 {
+		// The fields have changed, invalidating our current
+		// cache, so delete all entries.
+		s.entities = make(map[charm.URL]stashEntity)
+		s.version++
+		// There may be several goroutines waiting for pending
+		// entities. Notify them so that they can start a new
+		// fetch.
+		s.changed.Broadcast()
+	}
+	newFields := make(map[string]int)
+	for field := range s.fields {
+		newFields[field] = 1
+	}
+	for _, field := range fields {
+		newFields[field] = 1
+	}
+	s.fields = newFields
+}
+
+// startFetch starts an asynchronous fetch for the given id.
+// If a fetch is already in progress, it does nothing.
+//
+// Called with s.mu locked.
+func (s *stash) startFetch(id *charm.URL) {
+	if _, ok := s.entities[*id]; ok {
+		return
+	}
+	s.entities[*id] = nil
+	// Note that it's only OK to pass s.fields here because
+	// it's never mutated, only replaced.
+	s.wg.Add(1)
+	go s.fetchAsync(id, s.fields, s.version)
+}
+
+// fetchAsync is like fetch except that it is expected to be called
+// in a separate goroutine, with s.wg.Add called appropriately
+// beforehand.
+func (s *stash) fetchAsync(url *charm.URL, fields map[string]int, version int) stashEntity {
+	defer s.wg.Done()
+	return s.fetch(url, fields, version)
+}
+
+// fetch fetches the entity with the given id, including the given
+// fields, adds it to the stash and notifies any waiters that the stash
+// has changed.
+//
+// The given entity version holds the version at the time the
+// fetch was started. If the entity version has changed when the result is received,
+// the result is discarded.
+//
+// fetch returns the entity as it would be stored in the cache (notFoundEntity
+// implies not found). It returns nil if and only if some other kind of error has
+// been encountered (in this case the error will be stored in s.err).
+//
+// Called with no locks held.
+func (s *stash) fetch(url *charm.URL, fields map[string]int, version int) stashEntity {
+	e, err := s.get(url, fields)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		if errgo.Cause(err) != params.ErrNotFound {
+			if s.err == nil {
+				// Only set the error if we haven't encountered one already.
+				// We assume that if we're getting several errors, they're
+				// almost certainly caused by the same thing, so there's
+				// no point in logging them all.
+				s.err = errgo.Mask(err)
+
+				// Let other waiters know about the fact that
+				// we got an error.
+				s.changed.Broadcast()
+			}
+			return nil
+		}
+		e = notFoundEntity
+	}
+	if s.version != version {
+		// The entity version has changed, implying the selected
+		// fields have changed, so the entity we've just fetched
+		// is not valid to put in the cache because we haven't
+		// fetched all the fields that are required.
+		//
+		// We return the entity that we've just fetched (our
+		// caller, at least, wanted the fields we've just got).
+		// There's no need to delete the "pending" entry from the
+		// cache because all entries will have been cleared out
+		// when the version changed.
+		return e
+	}
+	return s.addEntity(e, url)
+}
+
+// addEntity adds the given entity to the stash, adds the given lookupId
+// as an alias for it, and notifies any listeners if there has been a
+// change.
+//
+// It returns the cached entity - this may be different from e if
+// an entry is already present in the cache.
+//
+// Called with s.mu locked.
+func (s *stash) addEntity(e stashEntity, lookupId *charm.URL) stashEntity {
+	var key *charm.URL
+	if e == notFoundEntity {
+		key = lookupId
+		lookupId = nil
+	} else {
+		key = e.CanonicalURL()
+	}
+	if e := s.entities[*key]; e != nil {
+		// The entity has already been fetched.
+		if lookupId != nil && s.entities[*lookupId] == nil {
+			// The lookupId is not present, so add it.
+			s.entities[*lookupId] = e
+			s.changed.Broadcast()
+		}
+		return e
+	}
+	s.entities[*key] = e
+	if lookupId != nil {
+		// This assumes that the lookupId can only
+		// result in the same entity being added.
+		s.entities[*lookupId] = e
+	}
+	s.changed.Broadcast()
+	return e
+}
+
+type notFoundEntityT struct{}
+
+func (notFoundEntityT) CanonicalURL() *charm.URL {
+	panic("CanonicalURL called on not-found sentinel value")
+}
+
+// notFoundEntity is a sentinel value that is stored
+// in the entities map when the value has been fetched
+// but was not found.
+var notFoundEntity = notFoundEntityT{}
+
+// Iter returns an iterator that iterates through
+// all the entities found by the given query, which must
+// be a query on the entities collection.
+// The entities produced by the returned iterator
+// will have at least the given fields populated.
+func (c *Cache) Iter(q *mgo.Query, fields ...string) *Iter {
+	// Implementation note: as we iterate through the
+	// entries, we also arrange for their corresponding
+	// base entities to be fetched because we'll almost
+	// certainly need them. Strictly speaking this is an
+	// optimization, because the entitycache API would
+	// remain the same even if this were not true.
+	c.entities.mu.Lock()
+	defer c.entities.mu.Unlock()
+	c.entities.addFields(fields)
+	return c.iter(q.Select(c.entities.fields).Iter())
+}
+
+// iter is the internal version of Iter, using an interface so it can be
+// tested independently of mongo. Called with c.entities.mu locked.
+func (c *Cache) iter(mgoIter mgoIter) *Iter {
+	iter := &Iter{
+		iter:    mgoIter,
+		cache:   c,
+		entityc: make(chan *mongodoc.Entity),
+		closed:  make(chan struct{}),
+		version: c.entities.version,
+	}
+	iter.runWG.Add(1)
+	go iter.run()
+	return iter
+}
+
+// mgoIter represents a mongoDB iterator. It is
+// represented as an interface rather than using
+// *mgo.Iter directly so that we can easily fake it
+// in tests.
+type mgoIter interface {
+	Next(interface{}) bool
+	Close() error
+	Err() error
+}
+
+// Iter holds an iterator over a set of entities.
+type Iter struct {
+	// e holds the current entity. It is nil only
+	// if the iterator has terminated.
+	e       *mongodoc.Entity
+	iter    mgoIter
+	cache   *Cache
+	entityc chan *mongodoc.Entity
+	closed  chan struct{}
+	runWG   sync.WaitGroup
+
+	// err holds any error encountered when iterating.
+	// It is set only after Next has returned false.
+	err error
+
+	// The following fields are owned by Iter.run.
+
+	// entityBatch holds the entities that we have read
+	// from the underlying iterator but haven't yet
+	// sent on iter.entityc.
+	entityBatch []*mongodoc.Entity
+
+	// baseEntityBatch holds the set of base entities that
+	// are required by the entities in entityBatch.
+	baseEntityBatch []*charm.URL
+
+	// version holds cache.entities.version at the time the iterator
+	// was created. If cache.entities.version changes during
+	// iteration, we will still deliver entities to the iterator,
+	// but we cannot store them in the stash because they won't have
+	// the required fields.
+	version int
+}
+
+// Next reports whether there are any more entities available from the
+// iterator. The iterator is automatically closed when Next returns
+// false.
+func (i *Iter) Next() bool {
+	i.e = <-i.entityc
+	if i.e != nil {
+		return true
+	}
+	if err := i.iter.Err(); err != nil {
+		i.err = errgo.Mask(err)
+	}
+	return false
+}
+
+// Entity returns the current entity, or nil if the iterator has reached
+// the end of its iteration. The base entity associated with the entity
+// will be available via the EntityFetcher.BaseEntity method.
+// The caller should treat the returned entity as read-only.
+func (i *Iter) Entity() *mongodoc.Entity {
+	return i.e
+}
+
+// Close closes the iterator. This must be called if the iterator is
+// abandoned without reaching its end.
+func (i *Iter) Close() {
+	close(i.closed)
+	// Wait for the iterator goroutine to complete. Note that we
+	// *could* just wait for i.entityc to be closed, but this would
+	// mean that it would be possible for i.send to complete
+	// successfully even when the iterator has been closed, which
+	// compromises test reproducibility. An alternative to the wait
+	// group might be for iter.send to do a non-blocking receive on
+	// i.closed before trying to send on i.entityc.
+	i.runWG.Wait()
+	i.e = nil
+}
+
+// Err returns any error encountered by the the iterator. If the
+// iterator has not terminated or been closed, it will always
+// return nil.
+func (iter *Iter) Err() error {
+	return iter.err
+}
+
+// run iterates through the underlying iterator, sending
+// entities on iter.entityc, first ensuring that their respective base
+// entities have also been fetched.
+func (iter *Iter) run() {
+	defer iter.runWG.Done()
+	defer close(iter.entityc)
+	defer iter.iter.Close()
+	for {
+		var e mongodoc.Entity
+		if !iter.iter.Next(&e) {
+			break
+		}
+		if iter.addEntity(&e) {
+			if len(iter.baseEntityBatch) >= baseEntityThreshold || len(iter.entityBatch) >= entityThreshold {
+				// We've reached one of the thresholds - send the batch.
+				if !iter.sendBatch() {
+					return
+				}
+			}
+		} else {
+			if !iter.send(&e) {
+				// The iterator has been closed. Remove all our pending
+				// base entity entries because we're no longer going to
+				// fetch them now.
+				iter.clearPendingFetches()
+				return
+			}
+		}
+	}
+	iter.sendBatch()
+}
+
+// clearPendingFetches clears our pending fetch entries from the base
+// entities stash. This will cause anything waiting on those base
+// entities to start its own fetch.
+func (iter *Iter) clearPendingFetches() {
+	if len(iter.baseEntityBatch) == 0 {
+		return
+	}
+	baseEntities := &iter.cache.baseEntities
+	baseEntities.mu.Lock()
+	defer baseEntities.mu.Unlock()
+	for _, id := range iter.baseEntityBatch {
+		delete(baseEntities.entities, *id)
+	}
+	baseEntities.changed.Broadcast()
+}
+
+// addEntity adds an entity that has been received
+// from the underlying iterator. It reports whether the
+// entity has been added to iter.entityBatch.
+//
+// Called from iter.run without any locks held.
+func (iter *Iter) addEntity(e *mongodoc.Entity) bool {
+	entities := &iter.cache.entities
+	entities.mu.Lock()
+	defer entities.mu.Unlock()
+	if _, ok := entities.entities[*e.CanonicalURL()]; ok {
+		// The entity has already been fetched, or is being fetched.
+		// This also implies that its base entity has already been added (or
+		// is in the process of being added) to the cache.
+		return false
+	}
+	if entities.version == iter.version {
+		// The entity we have here is valid to put into the cache, so do that.
+		// Note: we know from the check above that the entity is not
+		// already present in the cache.
+		entities.addEntity(e, nil)
+	}
+	iter.entityBatch = append(iter.entityBatch, e)
+
+	baseEntities := &iter.cache.baseEntities
+	baseEntities.mu.Lock()
+	defer baseEntities.mu.Unlock()
+
+	baseURL := mongodoc.BaseURL(e.URL)
+	if _, ok := baseEntities.entities[*baseURL]; !ok {
+		// We need to fetch the base entity, so add it to our
+		// batch and signal that it will be fetched by adding it
+		// to the map. Note: this assumes that the client doing
+		// the iteration will make progress - it could delay
+		// other base entity reads arbitrarily by not calling
+		// Next. This should not be a problem in practice.
+		iter.baseEntityBatch = append(iter.baseEntityBatch, baseURL)
+		baseEntities.entities[*baseURL] = nil
+	}
+	return true
+}
+
+// sendBatch obtains all the batched base entities and sends all the
+// batched entities on iter.entityc. If it encounters an error, or the
+// iterator is closed, it sets iter.err and returns false.
+//
+// Called from iter.run with no locks held.
+func (iter *Iter) sendBatch() bool {
+	// Start a fetch for all base entities.
+	// TODO use actual batch fetch with $in etc rather
+	// than starting a goroutine for each base entity.
+	baseEntities := &iter.cache.baseEntities
+	baseEntities.mu.Lock()
+	iter.cache.wg.Add(len(iter.baseEntityBatch))
+	for _, id := range iter.baseEntityBatch {
+		go baseEntities.fetchAsync(id, baseEntities.fields, baseEntities.version)
+	}
+	baseEntities.mu.Unlock()
+	iter.baseEntityBatch = iter.baseEntityBatch[:0]
+
+	for _, e := range iter.entityBatch {
+		if !iter.send(e) {
+			return false
+		}
+	}
+	iter.entityBatch = iter.entityBatch[:0]
+	return true
+}
+
+// send sends the given entity on iter.entityc.
+// It reports whether that entity was sent OK (that is,
+// the iterator has not been closed).
+func (iter *Iter) send(e *mongodoc.Entity) bool {
+	select {
+	case iter.entityc <- e:
+		return true
+	case <-iter.closed:
+		return false
+	}
+}

--- a/internal/entitycache/cache_test.go
+++ b/internal/entitycache/cache_test.go
@@ -1,0 +1,1145 @@
+package entitycache_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/entitycache"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+)
+
+var _ = gc.Suite(&suite{})
+
+type suite struct{}
+
+type entityQuery struct {
+	url    *charm.URL
+	fields map[string]int
+	reply  chan entityReply
+}
+
+type entityReply struct {
+	entity *mongodoc.Entity
+	err    error
+}
+
+type baseEntityQuery struct {
+	url    *charm.URL
+	fields map[string]int
+	reply  chan baseEntityReply
+}
+
+type baseEntityReply struct {
+	entity *mongodoc.BaseEntity
+	err    error
+}
+
+func (*suite) TestEntityIssuesBaseEntityQueryConcurrently(c *gc.C) {
+	store := newChanStore()
+	cache := entitycache.New(store)
+	defer cache.Close()
+	cache.AddBaseEntityFields("url", "name")
+
+	entity := &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-1"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w1",
+		Size:     99,
+	}
+	baseEntity := &mongodoc.BaseEntity{
+		URL:  charm.MustParseURL("~bob/wordpress"),
+		Name: "wordpress",
+	}
+	queryDone := make(chan struct{})
+	go func() {
+		defer close(queryDone)
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl", "blobname")
+		c.Check(err, gc.IsNil)
+		c.Check(e, gc.Equals, entity)
+	}()
+
+	// Acquire both the queries before replying so that we know they've been
+	// issued concurrently.
+	query1 := <-store.entityqc
+	c.Assert(query1.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(query1.fields, jc.DeepEquals, map[string]int{
+		"url":      1,
+		"baseurl":  1,
+		"blobname": 1,
+	})
+	query2 := <-store.baseEntityqc
+	c.Assert(query2.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress"))
+	c.Assert(query2.fields, jc.DeepEquals, map[string]int{
+		"url":  1,
+		"name": 1,
+	})
+	query1.reply <- entityReply{
+		entity: entity,
+	}
+	query2.reply <- baseEntityReply{
+		entity: baseEntity,
+	}
+	<-queryDone
+
+	// Accessing the same entity again and the base entity should
+	// not call any method on the store, so close the query channels
+	// to ensure it doesn't.
+	close(store.entityqc)
+	close(store.baseEntityqc)
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl", "blobname")
+	c.Check(err, gc.IsNil)
+	c.Check(e, gc.Equals, entity)
+
+	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), "url", "name")
+	c.Check(err, gc.IsNil)
+	c.Check(be, gc.Equals, baseEntity)
+}
+
+func (*suite) TestFetchWhenFieldsChangeBeforeQueryResult(c *gc.C) {
+	store := newChanStore()
+	cache := entitycache.New(store)
+	defer cache.Close()
+	cache.AddBaseEntityFields("url", "name")
+
+	entity := &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-1"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w1",
+	}
+	baseEntity := &mongodoc.BaseEntity{
+		URL:  charm.MustParseURL("~bob/wordpress"),
+		Name: "wordpress",
+	}
+	store.findBaseEntity = func(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+		c.Check(url, jc.DeepEquals, baseEntity.URL)
+		c.Check(fields, jc.DeepEquals, map[string]int{
+			"url":  1,
+			"name": 1,
+		})
+		return baseEntity, nil
+	}
+
+	queryDone := make(chan struct{})
+	go func() {
+		defer close(queryDone)
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl")
+		c.Check(err, gc.IsNil)
+		c.Check(e, gc.Equals, entity)
+	}()
+
+	query1 := <-store.entityqc
+	c.Assert(query1.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(query1.fields, jc.DeepEquals, map[string]int{
+		"url":     1,
+		"baseurl": 1,
+	})
+	// Before we send the reply, make another query with different fields,
+	// so the version changes.
+	entity2 := &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-1"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w1",
+		Size:     99,
+	}
+	query2Done := make(chan struct{})
+	go func() {
+		defer close(query2Done)
+		// Note the extra "size" field.
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl", "size")
+		c.Check(err, gc.IsNil)
+		c.Check(e, gc.Equals, entity2)
+	}()
+	// The second query should be sent immediately without waiting
+	// for the first because it invalidates the cache..
+	query2 := <-store.entityqc
+	c.Assert(query2.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(query2.fields, jc.DeepEquals, map[string]int{
+		"url":     1,
+		"baseurl": 1,
+		"size":    1,
+	})
+	query2.reply <- entityReply{
+		entity: entity2,
+	}
+	<-query2Done
+
+	// Reply to the first query and make sure that it completed.
+	query1.reply <- entityReply{
+		entity: entity,
+	}
+	<-queryDone
+
+	// Accessing the same entity again not call any method on the store, so close the query channels
+	// to ensure it doesn't.
+	close(store.entityqc)
+	close(store.baseEntityqc)
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl")
+	c.Check(err, gc.IsNil)
+	c.Check(e, gc.Equals, entity2)
+}
+
+func (*suite) TestSecondFetchesWaitForFirst(c *gc.C) {
+	store := newChanStore()
+	cache := entitycache.New(store)
+	defer cache.Close()
+	cache.AddBaseEntityFields("url", "name")
+
+	entity := &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-1"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w1",
+	}
+	baseEntity := &mongodoc.BaseEntity{
+		URL:  charm.MustParseURL("~bob/wordpress"),
+		Name: "wordpress",
+	}
+	store.findBaseEntity = func(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+		c.Check(url, jc.DeepEquals, baseEntity.URL)
+		c.Check(fields, jc.DeepEquals, map[string]int{
+			"url":  1,
+			"name": 1,
+		})
+		return baseEntity, nil
+	}
+
+	var initialRequestGroup sync.WaitGroup
+	initialRequestGroup.Add(1)
+	go func() {
+		defer initialRequestGroup.Done()
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl")
+		c.Check(err, gc.IsNil)
+		c.Check(e, gc.Equals, entity)
+	}()
+
+	query1 := <-store.entityqc
+	c.Assert(query1.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(query1.fields, jc.DeepEquals, map[string]int{
+		"url":     1,
+		"baseurl": 1,
+	})
+
+	// Send some more queries for the same charm. These should not send a
+	// store request but instead wait for the first one.
+	for i := 0; i < 5; i++ {
+		initialRequestGroup.Add(1)
+		go func() {
+			defer initialRequestGroup.Done()
+			e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl")
+			c.Check(err, gc.IsNil)
+			c.Check(e, gc.Equals, entity)
+		}()
+	}
+	select {
+	case q := <-store.entityqc:
+		c.Fatalf("unexpected store query %#v", q)
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	entity2 := &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-2"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w2",
+	}
+	// Send another query for a different charm. This will cause the
+	// waiting goroutines to be woken up but go back to sleep again
+	// because their entry isn't yet available.
+	otherRequestDone := make(chan struct{})
+	go func() {
+		defer close(otherRequestDone)
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-2"), "url", "baseurl")
+		c.Check(err, gc.IsNil)
+		c.Check(e, gc.Equals, entity2)
+	}()
+	query2 := <-store.entityqc
+	c.Assert(query2.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress-2"))
+	c.Assert(query2.fields, jc.DeepEquals, map[string]int{
+		"url":     1,
+		"baseurl": 1,
+	})
+	query2.reply <- entityReply{
+		entity: entity2,
+	}
+
+	// Now reply to the initial store request, which should make
+	// everything complete.
+	query1.reply <- entityReply{
+		entity: entity,
+	}
+	initialRequestGroup.Wait()
+}
+
+func (*suite) TestGetEntityNotFound(c *gc.C) {
+	entityFetchCount := 0
+	baseEntityFetchCount := 0
+	store := &callbackStore{
+		findBestEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error) {
+			entityFetchCount++
+			return nil, errgo.NoteMask(params.ErrNotFound, "entity", errgo.Any)
+		},
+		findBaseEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+			baseEntityFetchCount++
+			return nil, errgo.NoteMask(params.ErrNotFound, "base entity", errgo.Any)
+		},
+	}
+	cache := entitycache.New(store)
+	defer cache.Close()
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(e, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "not found")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
+
+	// Make sure that the not-found result has been cached.
+	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(e, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "not found")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
+
+	c.Assert(entityFetchCount, gc.Equals, 1)
+
+	// Make sure fetching the base entity works the same way.
+	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+	c.Assert(be, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "not found")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
+
+	c.Assert(baseEntityFetchCount, gc.Equals, 1)
+	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+	c.Assert(be, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "not found")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
+}
+
+func (*suite) TestFetchError(c *gc.C) {
+	entityFetchCount := 0
+	baseEntityFetchCount := 0
+	store := &callbackStore{
+		findBestEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error) {
+			entityFetchCount++
+			return nil, errgo.New("entity error")
+		},
+		findBaseEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+			baseEntityFetchCount++
+			return nil, errgo.New("base entity error")
+		},
+	}
+	cache := entitycache.New(store)
+	defer cache.Close()
+
+	// Check that we get the entity fetch error from cache.Entity.
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(e, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `cannot fetch "cs:~bob/wordpress-1": entity error`)
+
+	// Check that the error is cached.
+	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(e, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `cannot fetch "cs:~bob/wordpress-1": entity error`)
+
+	c.Assert(entityFetchCount, gc.Equals, 1)
+
+	// Check that we get the base-entity fetch error from cache.BaseEntity.
+	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+	c.Assert(be, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `cannot fetch "cs:~bob/wordpress": base entity error`)
+
+	// Check that the error is cached.
+	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+	c.Assert(be, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `cannot fetch "cs:~bob/wordpress": base entity error`)
+	c.Assert(baseEntityFetchCount, gc.Equals, 1)
+}
+
+func (*suite) TestStartFetch(c *gc.C) {
+	store := newChanStore()
+	cache := entitycache.New(store)
+
+	url := charm.MustParseURL("~bob/wordpress-1")
+	baseURL := charm.MustParseURL("~bob/wordpress")
+	cache.StartFetch([]*charm.URL{url})
+
+	entity := &mongodoc.Entity{
+		URL:      url,
+		BaseURL:  baseURL,
+		BlobName: "foo",
+	}
+	baseEntity := &mongodoc.BaseEntity{
+		URL: baseURL,
+	}
+
+	// Both queries should be issued concurrently.
+	query1 := <-store.entityqc
+	c.Assert(query1.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress-1"))
+	query2 := <-store.baseEntityqc
+	c.Assert(query2.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress"))
+
+	entityQueryDone := make(chan struct{})
+	go func() {
+		defer close(entityQueryDone)
+		e, err := cache.Entity(url)
+		c.Check(err, gc.IsNil)
+		c.Check(e, jc.DeepEquals, entity)
+	}()
+	baseEntityQueryDone := make(chan struct{})
+	go func() {
+		defer close(baseEntityQueryDone)
+		e, err := cache.BaseEntity(baseURL)
+		c.Check(err, gc.IsNil)
+		c.Check(e, jc.DeepEquals, baseEntity)
+	}()
+
+	// Reply to the entity query.
+	// This should cause the extra entity query to complete.
+	query1.reply <- entityReply{
+		entity: entity,
+	}
+	<-entityQueryDone
+
+	// Reply to the base entity query.
+	// This should cause the extra base entity query to complete.
+	query2.reply <- baseEntityReply{
+		entity: &mongodoc.BaseEntity{
+			URL: baseURL,
+		},
+	}
+	<-baseEntityQueryDone
+}
+
+func (*suite) TestAddEntityFields(c *gc.C) {
+	store := newChanStore()
+	baseEntity := &mongodoc.BaseEntity{
+		URL: charm.MustParseURL("cs:~bob/wordpress"),
+	}
+	entity := &mongodoc.Entity{
+		URL:      charm.MustParseURL("cs:~bob/wordpress-1"),
+		BlobName: "foo",
+		Size:     999,
+		BlobHash: "ffff",
+	}
+	baseEntityCount := 0
+	store.findBaseEntity = func(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+		baseEntityCount++
+		if url.String() != "cs:~bob/wordpress" {
+			return nil, params.ErrNotFound
+		}
+		return baseEntity, nil
+	}
+	cache := entitycache.New(store)
+	cache.AddEntityFields("blobname", "size")
+	queryDone := make(chan struct{})
+	go func() {
+		defer close(queryDone)
+		e, err := cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), "blobname")
+		c.Check(err, gc.IsNil)
+		expect := *entity
+		selectFields(&expect, "url", "blobname", "size")
+		c.Check(e, jc.DeepEquals, &expect)
+
+		// Adding existing entity fields should have no effect.
+		cache.AddEntityFields("blobname", "size")
+
+		e, err = cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), "size")
+		c.Check(err, gc.IsNil)
+		expect = *entity
+		selectFields(&expect, "url", "blobname", "size")
+		c.Check(e, jc.DeepEquals, &expect)
+
+		// Adding a new field should will cause the cache to be invalidated
+		// and a new fetch to take place.
+
+		cache.AddEntityFields("blobhash")
+		e, err = cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"))
+		c.Check(err, gc.IsNil)
+		expect = *entity
+		selectFields(&expect, "url", "blobname", "size", "blobhash")
+		c.Check(e, jc.DeepEquals, &expect)
+	}()
+
+	query1 := <-store.entityqc
+	c.Assert(query1.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(query1.fields, jc.DeepEquals, map[string]int{
+		"blobname": 1,
+		"size":     1,
+	})
+	e := *entity
+	selectFields(&e, "url", "blobname", "size")
+	query1.reply <- entityReply{
+		entity: &e,
+	}
+
+	// When the entity fields are added, we expect another query
+	// because that invalidates the cache.
+	query2 := <-store.entityqc
+	c.Assert(query2.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(query2.fields, jc.DeepEquals, map[string]int{
+		"blobhash": 1,
+		"blobname": 1,
+		"size":     1,
+	})
+	e = *entity
+	selectFields(&e, "url", "blobhash", "blobname", "size")
+	query2.reply <- entityReply{
+		entity: &e,
+	}
+	<-queryDone
+}
+
+func (*suite) TestLookupByDifferentKey(c *gc.C) {
+	entityFetchCount := 0
+	entity := &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-1"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w1",
+	}
+	baseEntity := &mongodoc.BaseEntity{
+		URL:  charm.MustParseURL("~bob/wordpress"),
+		Name: "wordpress",
+	}
+	store := &callbackStore{
+		findBestEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error) {
+			entityFetchCount++
+			return entity, nil
+		},
+		findBaseEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+			if url.String() != "cs:~bob/wordpress" {
+				return nil, params.ErrNotFound
+			}
+			return baseEntity, nil
+		},
+	}
+	cache := entitycache.New(store)
+	defer cache.Close()
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(err, gc.IsNil)
+	c.Assert(e, gc.Equals, entity)
+
+	oldEntity := entity
+
+	// The second fetch will trigger another query because
+	// we can't tell whether it's the same entity or not,
+	// but it should return the cached entity anyway.
+	entity = &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-1"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w2",
+	}
+	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress"))
+	c.Assert(err, gc.IsNil)
+	c.Logf("got %p; old entity %p; new entity %p", e, oldEntity, entity)
+	c.Assert(e, gc.Equals, oldEntity)
+	c.Assert(entityFetchCount, gc.Equals, 2)
+}
+
+func (s *suite) TestIterSingle(c *gc.C) {
+	store := newChanStore()
+	store.findBestEntity = func(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error) {
+		c.Errorf("store query made unexpectedly")
+		return nil, errgo.New("no queries expected during iteration")
+	}
+	cache := entitycache.New(store)
+	defer cache.Close()
+	fakeIter := newFakeIter()
+	iter := entitycache.CacheIter(cache, fakeIter, "size", "blobsize")
+	nextDone := make(chan struct{})
+	go func() {
+		defer close(nextDone)
+		ok := iter.Next()
+		c.Assert(ok, gc.Equals, true)
+	}()
+	iterq := <-fakeIter.req
+	entity := &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-1"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w1",
+	}
+	*iterq.entity = *entity
+	expectCached := iterq.entity
+	iterq.reply <- nil
+
+	// The iterator should batch up entities so make sure that
+	// it does not return the entry immediately.
+	select {
+	case <-nextDone:
+		c.Fatalf("Next returned early - no batching?")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	// Get the next iterator query and reply to signal that
+	// the iterator has completed.
+	iterq = <-fakeIter.req
+	iterq.reply <- errIterFinished
+
+	// The base entity should be requested asynchronously now.
+	baseQuery := <-store.baseEntityqc
+
+	// ... but the initial reply shouldn't be held up by that.
+	<-nextDone
+
+	// Check that the entity is the one we expect and that it hasn't
+	// changed from the original.
+	c.Assert(iter.Entity(), gc.Equals, expectCached)
+	c.Assert(iter.Entity(), jc.DeepEquals, entity)
+
+	// Check that the entity can now be fetched from the cache.
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(err, gc.IsNil)
+	c.Assert(e, gc.Equals, expectCached)
+
+	// A request for the base entity should now block
+	// until the initial base entity request has been satisfied.
+	baseEntity := &mongodoc.BaseEntity{
+		URL:  charm.MustParseURL("~bob/wordpress"),
+		Name: "wordpress",
+	}
+	queryDone := make(chan struct{})
+	go func() {
+		defer close(queryDone)
+		e, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+		c.Check(err, gc.IsNil)
+		c.Check(e, gc.Equals, baseEntity)
+	}()
+
+	// Check that no additional base entity query is made.
+	select {
+	case <-queryDone:
+		c.Fatalf("Next returned early - no batching?")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	// Reply to the base entity query ...
+	baseQuery.reply <- baseEntityReply{
+		entity: baseEntity,
+	}
+	// ... which should result in the one we just made
+	// being satisfied too.
+	<-queryDone
+}
+
+func (*suite) TestIterWithEntryAlreadyInCache(c *gc.C) {
+	store := &staticStore{
+		entities: []*mongodoc.Entity{{
+			URL:      charm.MustParseURL("~bob/wordpress-1"),
+			BaseURL:  charm.MustParseURL("~bob/wordpress"),
+			BlobName: "w1",
+		}, {
+			URL:      charm.MustParseURL("~bob/wordpress-2"),
+			BaseURL:  charm.MustParseURL("~bob/wordpress"),
+			BlobName: "w2",
+		}, {
+			URL:      charm.MustParseURL("~alice/mysql-1"),
+			BaseURL:  charm.MustParseURL("~alice/mysql"),
+			BlobName: "a1",
+		}},
+		baseEntities: []*mongodoc.BaseEntity{{
+			URL: charm.MustParseURL("~bob/wordpress"),
+		}, {
+			URL: charm.MustParseURL("~alice/mysql"),
+		}},
+	}
+	cache := entitycache.New(store)
+	defer cache.Close()
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "size", "blobsize")
+	c.Assert(err, gc.IsNil)
+	c.Assert(e, gc.Equals, store.entities[0])
+
+	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), "size", "blobsize")
+	c.Assert(err, gc.IsNil)
+	c.Assert(be, gc.Equals, store.baseEntities[0])
+
+	iterEntity := &mongodoc.Entity{
+		URL:      charm.MustParseURL("~bob/wordpress-1"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w2",
+	}
+
+	fakeIter := newFakeIter()
+	iter := entitycache.CacheIter(cache, fakeIter, "size", "blobsize")
+	iterDone := make(chan struct{})
+	go func() {
+		defer close(iterDone)
+		ok := iter.Next()
+		c.Check(ok, gc.Equals, true)
+		// Even though the entity is in the cache, we still
+		// receive the entity returned from the iterator.
+		// Strictly speaking this is implementation-dependent,
+		// so we just check with DeepEquals rather than equality.
+		c.Check(iter.Entity(), jc.DeepEquals, iterEntity)
+
+		ok = iter.Next()
+		c.Check(ok, gc.Equals, false)
+	}()
+
+	// Provide the iterator request with an entity that's already
+	// in the cache.
+	iterq := <-fakeIter.req
+	*iterq.entity = *iterEntity
+	iterq.reply <- nil
+
+	iterq = <-fakeIter.req
+	iterq.reply <- errIterFinished
+
+	<-iterDone
+
+	// The original cached entities should still be there.
+	cache = entitycache.New(store)
+	defer cache.Close()
+	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	c.Assert(err, gc.IsNil)
+	c.Assert(e, gc.Equals, store.entities[0])
+
+	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+	c.Assert(err, gc.IsNil)
+	c.Assert(be, gc.Equals, store.baseEntities[0])
+}
+
+func (*suite) TestIterCloseEarlyWhenBatchLimitExceeded(c *gc.C) {
+	// The iterator gets closed when the batch limit has been
+	// exceeded.
+
+	entities := make([]*mongodoc.Entity, entitycache.BaseEntityThreshold)
+	baseEntities := make([]*mongodoc.BaseEntity, entitycache.BaseEntityThreshold)
+	for i := range entities {
+		entities[i] = &mongodoc.Entity{
+			URL: &charm.URL{
+				Schema:   "cs",
+				Name:     fmt.Sprintf("wordpress%d", i),
+				User:     "bob",
+				Revision: i,
+			},
+			BaseURL: &charm.URL{
+				Name: fmt.Sprintf("wordpress%d", i),
+				User: "bob",
+			},
+			BlobName: fmt.Sprintf("w%d", i),
+		}
+		baseEntities[i] = &mongodoc.BaseEntity{
+			URL: entities[i].BaseURL,
+		}
+	}
+	store := &staticStore{
+		baseEntities: baseEntities,
+	}
+	cache := entitycache.New(store)
+	fakeIter := &sliceIter{
+		entities: entities,
+	}
+	iter := entitycache.CacheIter(cache, fakeIter, "blobname")
+	iter.Close()
+	c.Assert(iter.Next(), gc.Equals, false)
+}
+
+func (*suite) TestIterCloseEarlyBeforeBatchLimitExceeded(c *gc.C) {
+	// The iterator gets closed before the batch limit has
+	// been exceeded (this can only be found out
+	// when there's an entry already cached)
+
+	// prime the store with base entities, but no entities.
+	// The entities should be satisfied from the iterator.
+	store := &staticStore{
+		entities: []*mongodoc.Entity{{
+			URL:      charm.MustParseURL("~bob/wordpress-2"),
+			BaseURL:  charm.MustParseURL("~bob/wordpress"),
+			BlobName: "w2",
+		}},
+		baseEntities: []*mongodoc.BaseEntity{{
+			URL: charm.MustParseURL("~bob/wordpress"),
+		}, {
+			URL:    charm.MustParseURL("~alice/mysql"),
+			Public: true,
+		}},
+	}
+	cache := entitycache.New(store)
+	cache.AddBaseEntityFields("public")
+	// Ask for one of the entities that will be iterated over,
+	// so that the Iter.run loop will send an entity without
+	// starting the base URL fetch.
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-2"), "blobname")
+	c.Assert(err, gc.IsNil)
+	c.Assert(e, jc.DeepEquals, store.entities[0])
+
+	entities := []*mongodoc.Entity{{
+		URL:      charm.MustParseURL("~alice/mysql-1"),
+		BaseURL:  charm.MustParseURL("~alice/mysql"),
+		BlobName: "a1",
+	}, {
+		URL:      charm.MustParseURL("~bob/wordpress-2"),
+		BaseURL:  charm.MustParseURL("~bob/wordpress"),
+		BlobName: "w1",
+	}}
+
+	fakeIter := newFakeIter()
+	iter := entitycache.CacheIter(cache, fakeIter, "blobname")
+	iterDone := make(chan struct{})
+	go func() {
+		defer close(iterDone)
+		// Close the iterator early without reading any entries.
+		iter.Close()
+	}()
+
+	// Wait for the first Next request and reply to it,
+	// so that we have added a pending base entity
+	iterq := <-fakeIter.req
+	*iterq.entity = *entities[0]
+	iterq.reply <- nil
+
+	// Wait for another Next request and reply with the entry that
+	// we caused to be cached earlier. This will cause the entity to
+	// be sent directly, which will result in iter.send returning
+	// false because nothing is reading on iter.entityc and we have
+	// called iter.Close. This in turn should cause the pending
+	// base entity fetches to be cleared out and Iter.run to terminate
+	// and thus the Close to finish.
+	iterq = <-fakeIter.req
+	*iterq.entity = *entities[1]
+	iterq.reply <- nil
+
+	// Wait for the Close to complete.
+	select {
+	case <-iterDone:
+	case <-fakeIter.req:
+		c.Fatalf("unexpected extra request made")
+	}
+
+	// Ensure that we can still retrieve the base entity that
+	// was added (and then removed) by the iterator.
+	be, err := cache.BaseEntity(charm.MustParseURL("~alice/mysql-1"), "public")
+	c.Assert(err, gc.IsNil)
+	c.Assert(be, jc.DeepEquals, store.baseEntities[1])
+}
+
+func (*suite) TestIterEntityBatchLimitExceeded(c *gc.C) {
+	entities := make([]*mongodoc.Entity, entitycache.EntityThreshold)
+	for i := range entities {
+		entities[i] = &mongodoc.Entity{
+			URL: &charm.URL{
+				Schema:   "cs",
+				Name:     "wordpress",
+				User:     "bob",
+				Revision: i,
+			},
+			BaseURL:  charm.MustParseURL("~bob/wordpress"),
+			BlobName: fmt.Sprintf("w%d", i),
+		}
+	}
+	entities = append(entities, &mongodoc.Entity{
+		URL:     charm.MustParseURL("~alice/mysql1-1"),
+		BaseURL: charm.MustParseURL("~alice/mysql1"),
+	})
+	store := newChanStore()
+	cache := entitycache.New(store)
+	fakeIter := &sliceIter{
+		entities: entities,
+	}
+	iter := entitycache.CacheIter(cache, fakeIter, "blobname")
+
+	// The iterator should fetch up to entityThreshold entities
+	// from the underlying iterator before sending
+	// the batched base-entity request, then it
+	// will make all those entries available.
+	query := <-store.baseEntityqc
+	c.Assert(query.url, jc.DeepEquals, charm.MustParseURL("~bob/wordpress"))
+	query.reply <- baseEntityReply{
+		entity: &mongodoc.BaseEntity{
+			URL: charm.MustParseURL("~bob/wordpress"),
+		},
+	}
+	for i := 0; i < entitycache.EntityThreshold; i++ {
+		ok := iter.Next()
+		c.Assert(ok, gc.Equals, true)
+		c.Assert(iter.Entity(), jc.DeepEquals, entities[i])
+	}
+	// When the iterator reaches its end, the
+	// remaining entity and base entity are fetched.
+	query = <-store.baseEntityqc
+	c.Assert(query.url, jc.DeepEquals, charm.MustParseURL("~alice/mysql1"))
+	query.reply <- baseEntityReply{
+		entity: &mongodoc.BaseEntity{
+			URL: charm.MustParseURL("~alice/mysql1"),
+		},
+	}
+
+	ok := iter.Next()
+	c.Assert(ok, gc.Equals, true)
+	c.Assert(iter.Entity(), jc.DeepEquals, entities[entitycache.EntityThreshold])
+
+	// Check that all the entities and base entities are in fact cached.
+	for _, want := range entities {
+		got, err := cache.Entity(want.URL)
+		c.Assert(err, gc.IsNil)
+		c.Assert(got, jc.DeepEquals, want)
+		gotBase, err := cache.BaseEntity(want.URL)
+		c.Assert(err, gc.IsNil)
+		c.Assert(gotBase, jc.DeepEquals, &mongodoc.BaseEntity{
+			URL: want.BaseURL,
+		})
+	}
+}
+
+func (*suite) TestIterError(c *gc.C) {
+	cache := entitycache.New(&staticStore{})
+	fakeIter := newFakeIter()
+	iter := entitycache.CacheIter(cache, fakeIter)
+	// Err returns nil while the iteration is in progress.
+	err := iter.Err()
+	c.Assert(err, gc.IsNil)
+
+	iterq := <-fakeIter.req
+	iterq.reply <- errgo.New("iterator error")
+
+	ok := iter.Next()
+	c.Assert(ok, gc.Equals, false)
+	err = iter.Err()
+	c.Assert(err, gc.ErrorMatches, "iterator error")
+}
+
+type iterQuery struct {
+	// entity holds the entity to be filled by the Next request.
+	entity *mongodoc.Entity
+	// reply should be send on when the Next request has
+	// completed. When the iteration is complete,
+	// errIterFinished should be sent.
+	reply chan error
+}
+
+// fakeIter provides a mock iterator implementation
+// that sends each request for an entity to
+// another goroutine for a result.
+type fakeIter struct {
+	closed bool
+	err    error
+
+	// req holds a channel that is sent a value
+	// whenever the Next method is called.
+	req chan iterQuery
+}
+
+func newFakeIter() *fakeIter {
+	return &fakeIter{
+		req: make(chan iterQuery, 1),
+	}
+}
+
+// Next implements mgoIter.Next. The
+// x parameter must be a *mongodoc.Entity.
+func (i *fakeIter) Next(x interface{}) bool {
+	if i.closed {
+		panic("Next called after Close")
+	}
+	if i.err != nil {
+		return false
+	}
+	reply := make(chan error)
+	i.req <- iterQuery{
+		entity: x.(*mongodoc.Entity),
+		reply:  reply,
+	}
+	i.err = <-reply
+	return i.err == nil
+}
+
+var errIterFinished = errgo.New("iteration finished")
+
+// Close implements mgoIter.Close.
+func (i *fakeIter) Close() error {
+	i.closed = true
+	if i.err == errIterFinished {
+		return nil
+	}
+	return i.err
+}
+
+// Close implements mgoIter.Err.
+func (i *fakeIter) Err() error {
+	if i.err == errIterFinished {
+		return nil
+	}
+	return i.err
+}
+
+// sliceIter implements mgoIter over a slice of entities,
+// returning each one in turn.
+type sliceIter struct {
+	entities []*mongodoc.Entity
+	closed   bool
+}
+
+func (iter *sliceIter) Next(x interface{}) bool {
+	if iter.closed {
+		panic("Next called after Close")
+	}
+	if len(iter.entities) == 0 {
+		return false
+	}
+	e := x.(*mongodoc.Entity)
+	*e = *iter.entities[0]
+	iter.entities = iter.entities[1:]
+	return true
+}
+
+func (iter *sliceIter) Err() error {
+	return nil
+}
+
+func (iter *sliceIter) Close() error {
+	iter.closed = true
+	return nil
+}
+
+type chanStore struct {
+	entityqc     chan entityQuery
+	baseEntityqc chan baseEntityQuery
+	*callbackStore
+}
+
+func newChanStore() *chanStore {
+	entityqc := make(chan entityQuery, 1)
+	baseEntityqc := make(chan baseEntityQuery, 1)
+	return &chanStore{
+		entityqc:     entityqc,
+		baseEntityqc: baseEntityqc,
+		callbackStore: &callbackStore{
+			findBestEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error) {
+				reply := make(chan entityReply)
+				entityqc <- entityQuery{
+					url:    url,
+					fields: fields,
+					reply:  reply,
+				}
+				r := <-reply
+				return r.entity, r.err
+			},
+			findBaseEntity: func(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+				reply := make(chan baseEntityReply)
+				baseEntityqc <- baseEntityQuery{
+					url:    url,
+					fields: fields,
+					reply:  reply,
+				}
+				r := <-reply
+				return r.entity, r.err
+			},
+		},
+	}
+}
+
+type callbackStore struct {
+	findBestEntity func(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error)
+	findBaseEntity func(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error)
+}
+
+func (s *callbackStore) FindBestEntity(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error) {
+	return s.findBestEntity(url, fields)
+}
+
+func (s *callbackStore) FindBaseEntity(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+	return s.findBaseEntity(url, fields)
+}
+
+type staticStore struct {
+	entities     []*mongodoc.Entity
+	baseEntities []*mongodoc.BaseEntity
+}
+
+func (s *staticStore) FindBestEntity(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error) {
+	for _, e := range s.entities {
+		if *url == *e.URL {
+			return e, nil
+		}
+	}
+	return nil, params.ErrNotFound
+}
+
+func (s *staticStore) FindBaseEntity(url *charm.URL, fields map[string]int) (*mongodoc.BaseEntity, error) {
+	for _, e := range s.baseEntities {
+		if *url == *e.URL {
+			return e, nil
+		}
+	}
+	return nil, params.ErrNotFound
+}
+
+// selectFields zeros out all fields in x (which must be a pointer to
+// struct) that are not mentioned in sel.
+func selectFields(x interface{}, fields ...string) {
+	sel := make(map[string]int)
+	for _, f := range fields {
+		sel[f] = 1
+	}
+	xv := reflect.ValueOf(x).Elem()
+	xt := xv.Type()
+	for i := 0; i < xt.NumField(); i++ {
+		if _, ok := sel[strings.ToLower(xt.Field(i).Name)]; ok {
+			continue
+		}
+		xv.Field(i).Set(reflect.Zero(xt.Field(i).Type))
+	}
+}
+
+func denormalizeAll(es []*mongodoc.Entity, bs []*mongodoc.BaseEntity) {
+	for _, e := range es {
+		denormalizeEntity(e)
+	}
+	for _, e := range bs {
+		denormalizeBaseEntity(e)
+	}
+}
+
+// denormalizedEntity is a convenience function that returns
+// a copy of e with its denormalized fields filled out.
+func denormalizedEntity(e *mongodoc.Entity) *mongodoc.Entity {
+	e1 := *e
+	denormalizeEntity(&e1)
+	return &e1
+}
+
+// denormalizeEntity sets all denormalized fields in e
+// from their associated canonical fields.
+//
+// It is the responsibility of the caller to set e.SupportedSeries
+// if the entity URL does not contain a series. If the entity
+// URL *does* contain a series, e.SupportedSeries will
+// be overwritten.
+//
+// This is exported for the purposes of tests that
+// need to create directly into the database.
+func denormalizeEntity(e *mongodoc.Entity) {
+	if e.URL.User == "" {
+		panic("entity with no user")
+	}
+	e.BaseURL = mongodoc.BaseURL(e.URL)
+	e.Name = e.URL.Name
+	e.User = e.URL.User
+	e.Revision = e.URL.Revision
+	e.Series = e.URL.Series
+	if e.URL.Series != "" {
+		if e.URL.Series == "bundle" {
+			e.SupportedSeries = nil
+		} else {
+			e.SupportedSeries = []string{e.URL.Series}
+		}
+	}
+	if e.PromulgatedURL == nil {
+		e.PromulgatedRevision = -1
+	} else {
+		e.PromulgatedRevision = e.PromulgatedURL.Revision
+	}
+}
+
+func denormalizeBaseEntity(e *mongodoc.BaseEntity) {
+	if e.URL.Revision != -1 {
+		panic("base entity with revision")
+	}
+	if e.URL.User == "" {
+		panic("base entity with no user")
+	}
+	e.Name = e.URL.Name
+	e.User = e.URL.User
+}

--- a/internal/entitycache/export_test.go
+++ b/internal/entitycache/export_test.go
@@ -1,0 +1,15 @@
+package entitycache
+
+func CacheIter(c *Cache, mgoIter mgoIter, fields ...string) *Iter {
+	c.entities.mu.Lock()
+	defer c.entities.mu.Unlock()
+	// Note: this is exactly the same as Cache.Iter except that
+	// it doesn't actually call the Query methods.
+	c.entities.addFields(fields)
+	return c.iter(mgoIter)
+}
+
+const (
+	EntityThreshold     = entityThreshold
+	BaseEntityThreshold = baseEntityThreshold
+)

--- a/internal/entitycache/package_test.go
+++ b/internal/entitycache/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package entitycache_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -121,6 +121,10 @@ type Entity struct {
 	Development bool
 }
 
+func (e *Entity) CanonicalURL() *charm.URL {
+	return e.URL
+}
+
 // PreferredURL returns the preferred way to refer to this entity. If
 // the entity has a promulgated URL and usePromulgated is true then the
 // promulgated URL will be used, otherwise the standard URL is used.
@@ -175,6 +179,10 @@ type BaseEntity struct {
 	// the base entity. Thhose data apply to all revisions.
 	// The byte slices hold JSON-encoded data.
 	CommonInfo map[string][]byte `bson:",omitempty" json:",omitempty"`
+}
+
+func (e *BaseEntity) CanonicalURL() *charm.URL {
+	return e.URL
 }
 
 // ACL holds lists of users and groups that are
@@ -297,4 +305,15 @@ func (b *IntBool) SetBSON(raw bson.Raw) error {
 		return errgo.Newf("invalid value %d", x)
 	}
 	return nil
+}
+
+// BaseURL returns the "base" version of url. If
+// url represents an entity, then the returned URL
+// will represent its base entity.
+func BaseURL(url *charm.URL) *charm.URL {
+	newURL := *url
+	newURL.Revision = -1
+	newURL.Series = ""
+	newURL.Channel = ""
+	return &newURL
 }

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -29,7 +29,7 @@ func NewEntity(url string) EntityBuilder {
 			Series:              URL.Series,
 			Revision:            URL.Revision,
 			User:                URL.User,
-			BaseURL:             baseURL(URL),
+			BaseURL:             mongodoc.BaseURL(URL),
 			PromulgatedRevision: -1,
 		},
 	}
@@ -128,12 +128,4 @@ func AssertBaseEntity(c *gc.C, db *mgo.Collection, expect *mongodoc.BaseEntity) 
 	err := db.FindId(expect.URL).One(&baseEntity)
 	c.Assert(err, gc.IsNil)
 	c.Assert(&baseEntity, jc.DeepEquals, expect)
-}
-
-func baseURL(url *charm.URL) *charm.URL {
-	baseURL := *url
-	baseURL.Series = ""
-	baseURL.Revision = -1
-	baseURL.Channel = ""
-	return &baseURL
 }


### PR DESCRIPTION
This will allow per-request caching of entities without needing to
refactor the internals of the charm store that much.
