### PR TITLE
v4, v5: add cache (step 1)

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -88,7 +88,7 @@ func (s *Store) UpdateSearch(r *router.ResolvedURL) error {
 		}
 		return errgo.Notef(err, "cannot get %s", r)
 	}
-	baseEntity, err := s.FindBaseEntity(entity.BaseURL)
+	baseEntity, err := s.FindBaseEntity(entity.BaseURL, nil)
 	if err != nil {
 		return errgo.Notef(err, "cannot get %s", entity.BaseURL)
 	}

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -81,7 +81,7 @@ var charmDownloadCounts = map[string]int{
 func (s *StoreSearchSuite) TestSuccessfulExport(c *gc.C) {
 	s.store.pool.statsCache.EvictAll()
 	for name, ref := range exportTestCharms {
-		entity, err := s.store.FindEntity(ref)
+		entity, err := s.store.FindEntity(ref, nil)
 		c.Assert(err, gc.IsNil)
 		var actual json.RawMessage
 		err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL), &actual)

--- a/internal/charmstore/stats.go
+++ b/internal/charmstore/stats.go
@@ -548,7 +548,7 @@ func (s *Store) statsCacheFetch(id *charm.URL) (interface{}, error) {
 // TODO (frankban): remove this method when removing the legacy counts logic.
 func (s *Store) legacyDownloadCounts(id *charm.URL) (AggregatedCounts, error) {
 	counts := AggregatedCounts{}
-	entities, err := s.FindEntities(id, "extrainfo")
+	entities, err := s.FindEntities(id, FieldSelector("extrainfo"))
 	if err != nil {
 		return counts, errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
@@ -631,7 +631,7 @@ func (s *Store) IncrementDownloadCountsAtTime(id *router.ResolvedURL, t time.Tim
 		// This unfortunately adds an extra round trip to the database,
 		// but as incrementing statistics is performed asynchronously
 		// it will not be in the critical path.
-		entity, err := s.FindEntity(id, "promulgated-revision")
+		entity, err := s.FindEntity(id, FieldSelector("promulgated-revision"))
 		if err != nil {
 			return errgo.Notef(err, "cannot find entity %v", &id.URL)
 		}

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -188,7 +188,7 @@ func (h *reqHandler) serveCharmInfo(_ http.Header, req *http.Request) (interface
 		}
 		var entity *mongodoc.Entity
 		if err == nil {
-			entity, err = h.store.FindBestEntity(curl)
+			entity, err = h.store.FindBestEntity(curl, nil)
 			if errgo.Cause(err) == params.ErrNotFound {
 				// The old API actually returned "entry not found"
 				// on *any* error, but it seems reasonable to be
@@ -266,7 +266,7 @@ func (h *reqHandler) serveCharmEvent(_ http.Header, req *http.Request) (interfac
 		}
 
 		// Retrieve the charm.
-		entity, err := h.store.FindBestEntity(id, "_id", "uploadtime", "extrainfo")
+		entity, err := h.store.FindBestEntity(id, charmstore.FieldSelector("_id", "uploadtime", "extrainfo"))
 		if err != nil {
 			if errgo.Cause(err) == params.ErrNotFound {
 				// The old API actually returned "entry not found"

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -475,9 +475,9 @@ func (s *APISuite) TestServeCharmEvent(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Retrieve the entities.
-	mysql, err := s.store.FindEntity(mysqlUrl)
+	mysql, err := s.store.FindEntity(mysqlUrl, nil)
 	c.Assert(err, gc.IsNil)
-	riak, err := s.store.FindEntity(riakUrl)
+	riak, err := s.store.FindEntity(riakUrl, nil)
 	c.Assert(err, gc.IsNil)
 
 	tests := []struct {
@@ -600,7 +600,7 @@ func (s *APISuite) TestServeCharmEventLastRevision(c *gc.C) {
 	s.addExtraInfoDigest(c, url2, "digest-2")
 
 	// Retrieve the most recent revision of the entity.
-	entity, err := s.store.FindEntity(url2)
+	entity, err := s.store.FindEntity(url2, nil)
 	c.Assert(err, gc.IsNil)
 
 	// Ensure the last revision is correctly returned.

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -498,7 +498,7 @@ func (s *ArchiveSuite) TestUploadAndPublish(c *gc.C) {
 		})
 
 		// Check the development flag of the entity.
-		entity, err := s.store.FindEntity(rurl, "development")
+		entity, err := s.store.FindEntity(rurl, charmstore.FieldSelector("development"))
 		c.Assert(err, gc.IsNil)
 		c.Assert(entity.Development, gc.Equals, test.expectDevelopment)
 

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -34,6 +34,7 @@ import (
 	"gopkg.in/juju/charmstore.v5-unstable/audit"
 	"gopkg.in/juju/charmstore.v5-unstable/elasticsearch"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/entitycache"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
@@ -340,7 +341,7 @@ var metaEndpoints = []metaEndpoint{{
 }, {
 	name: "perm",
 	get: func(store *charmstore.Store, url *router.ResolvedURL) (interface{}, error) {
-		e, err := store.FindBaseEntity(&url.URL)
+		e, err := store.FindBaseEntity(&url.URL, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -359,7 +360,7 @@ var metaEndpoints = []metaEndpoint{{
 }, {
 	name: "perm/read",
 	get: func(store *charmstore.Store, url *router.ResolvedURL) (interface{}, error) {
-		e, err := store.FindBaseEntity(&url.URL)
+		e, err := store.FindBaseEntity(&url.URL, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -447,7 +448,7 @@ var metaEndpoints = []metaEndpoint{{
 }, {
 	name: "promulgated",
 	get: func(store *charmstore.Store, url *router.ResolvedURL) (interface{}, error) {
-		e, err := store.FindBaseEntity(&url.URL)
+		e, err := store.FindBaseEntity(&url.URL, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -648,7 +649,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read:  []string{params.Everyone, "charmers"},
 		Write: []string{"charmers"},
 	})
-	e, err := s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"))
+	e, err := s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.ACLs.Read, gc.DeepEquals, []string{params.Everyone, "charmers"})
 
@@ -675,7 +676,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Write: []string{"charmers"},
 		})
 	}
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"))
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsFalse)
 	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
@@ -701,7 +702,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	})
 	s.assertGet(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
 	s.assertGet(c, "development/wordpress/meta/perm/read", []string{params.Everyone, "charmers"})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"))
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsTrue)
 	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
@@ -726,10 +727,10 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Message: `unauthorized: access denied for user "bob"`,
 		},
 	})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"))
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"))
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsTrue)
 	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{})
@@ -751,7 +752,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Message: `unauthorized: access denied for user "bob"`,
 		},
 	})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"))
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsFalse)
 	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{})
@@ -762,7 +763,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read:  []string{"bob"},
 		Write: []string{"admin"},
 	})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"))
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsFalse)
 	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
@@ -775,7 +776,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read:  []string{"who", params.Everyone},
 		Write: []string{"who"},
 	})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"))
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsFalse)
 	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{
@@ -788,7 +789,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read []string
 	}{Read: []string{"joe"}}
 	s.assertPut(c, "wordpress/meta/perm", readRequest)
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"))
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsFalse)
 	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
@@ -1088,7 +1089,7 @@ func (s *APISuite) TestCommonInfo(c *gc.C) {
 		s.assertGet(c, u+"/meta/common-info", map[string]string{
 			"key": "something",
 		})
-		e, err := s.store.FindBaseEntity(charm.MustParseURL(u))
+		e, err := s.store.FindBaseEntity(charm.MustParseURL(u), nil)
 		c.Assert(err, gc.IsNil)
 		c.Assert(e.CommonInfo, gc.DeepEquals, map[string][]byte{
 			"key": []byte("\"something\""),
@@ -1586,7 +1587,7 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 	for i, test := range resolveURLTests {
 		c.Logf("test %d: %s", i, test.url)
 		url := charm.MustParseURL(test.url)
-		rurl, err := v5.ResolveURL(s.store, url)
+		rurl, err := v5.ResolveURL(entitycache.New(s.store), url)
 		if test.notFound {
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 			c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for ".*"`)
@@ -2472,7 +2473,7 @@ func (s *APISuite) TestHash256Laziness(c *gc.C) {
 	id, _ := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~who/precise/wordpress-0", -1))
 
 	// Retrieve the SHA256 hash.
-	entity, err := s.store.FindEntity(id, "blobhash256")
+	entity, err := s.store.FindEntity(id, charmstore.FieldSelector("blobhash256"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(entity.BlobHash256, gc.Not(gc.Equals), "")
 
@@ -2509,7 +2510,7 @@ func entityFieldGetter(fieldName string) metaEndpointExpectedValueGetter {
 
 func entityGetter(get func(*mongodoc.Entity) interface{}) metaEndpointExpectedValueGetter {
 	return func(store *charmstore.Store, url *router.ResolvedURL) (interface{}, error) {
-		doc, err := store.FindEntity(url)
+		doc, err := store.FindEntity(url, nil)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}
@@ -2519,7 +2520,7 @@ func entityGetter(get func(*mongodoc.Entity) interface{}) metaEndpointExpectedVa
 
 func zipGetter(get func(*zip.Reader) interface{}) metaEndpointExpectedValueGetter {
 	return func(store *charmstore.Store, url *router.ResolvedURL) (interface{}, error) {
-		doc, err := store.FindEntity(url, "blobname")
+		doc, err := store.FindEntity(url, charmstore.FieldSelector("blobname"))
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}
@@ -3386,7 +3387,7 @@ func (s *APISuite) TestPublish(c *gc.C) {
 
 		// Check that the database now includes the expected entities.
 		for _, rurl := range test.expectDB {
-			e, err := s.store.FindEntity(rurl)
+			e, err := s.store.FindEntity(rurl, nil)
 			c.Assert(err, gc.IsNil)
 			c.Assert(charmstore.EntityResolvedURL(e), jc.DeepEquals, rurl)
 		}

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -79,7 +79,7 @@ func (h *ReqHandler) authorizeUpload(id *charm.URL, req *http.Request) error {
 	if id.User == "" {
 		return badRequestf(nil, "user not specified in entity upload URL %q", id)
 	}
-	baseEntity, err := h.Store.FindBaseEntity(id, "acls", "developmentacls")
+	baseEntity, err := h.Store.FindBaseEntity(id, charmstore.FieldSelector("acls", "developmentacls"))
 	// Note that we pass a nil entity URL to authorizeWithPerms, because
 	// we haven't got a resolved URL at this point. At some
 	// point in the future, we may want to be able to allow
@@ -442,7 +442,7 @@ func checkIdAllowed(id *router.ResolvedURL, ch charm.Charm) error {
 }
 
 func (h *ReqHandler) latestRevisionInfo(id *charm.URL) (*router.ResolvedURL, string, error) {
-	entities, err := h.Store.FindEntities(id.WithChannel(charm.DevelopmentChannel), "_id", "blobhash", "promulgated-url", "development")
+	entities, err := h.Store.FindEntities(id.WithChannel(charm.DevelopmentChannel), charmstore.FieldSelector("_id", "blobhash", "promulgated-url", "development"))
 	if err != nil {
 		return nil, "", errgo.Mask(err)
 	}
@@ -512,7 +512,7 @@ func (h *ReqHandler) serveArchiveFile(id *router.ResolvedURL, w http.ResponseWri
 }
 
 func (h *ReqHandler) isPublic(id charm.URL) bool {
-	baseEntity, err := h.Store.FindBaseEntity(&id, "acls")
+	baseEntity, err := h.Store.FindBaseEntity(&id, charmstore.FieldSelector("acls"))
 	if err == nil {
 		for _, p := range baseEntity.ACLs.Read {
 			if p == params.Everyone {
@@ -537,7 +537,7 @@ func (h *ReqHandler) bundleCharms(ids []string) (map[string]charm.Charm, error) 
 			// be returned to the user along with other bundle errors.
 			continue
 		}
-		e, err := h.Store.FindBestEntity(url)
+		e, err := h.Store.FindBestEntity(url, nil)
 		if err != nil {
 			if errgo.Cause(err) == params.ErrNotFound {
 				// Ignore this error too, for the same reasons
@@ -636,7 +636,7 @@ func setArchiveCacheControl(h http.Header, isPublic bool) {
 // to give to a newly uploaded charm with the given id.
 // It returns -1 if the charm is not promulgated.
 func (h *ReqHandler) getNewPromulgatedRevision(id *charm.URL) (int, error) {
-	baseEntity, err := h.Store.FindBaseEntity(id, "promulgated")
+	baseEntity, err := h.Store.FindBaseEntity(id, charmstore.FieldSelector("promulgated"))
 	if err != nil && errgo.Cause(err) != params.ErrNotFound {
 		return 0, errgo.Mask(err)
 	}

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -523,7 +523,7 @@ func (s *ArchiveSuite) TestUploadAndPublish(c *gc.C) {
 		})
 
 		// Check the development flag of the entity.
-		entity, err := s.store.FindEntity(rurl, "development")
+		entity, err := s.store.FindEntity(rurl, charmstore.FieldSelector("development"))
 		c.Assert(err, gc.IsNil)
 		c.Assert(entity.Development, gc.Equals, test.expectDevelopment)
 

--- a/internal/v5/auth.go
+++ b/internal/v5/auth.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
+	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 )
 
@@ -176,11 +177,11 @@ func (h *ReqHandler) entityAuthInfo(entityIds []*router.ResolvedURL) (public boo
 	requiredTerms = make(map[string]bool)
 	public = true
 	for i, entityId := range entityIds {
-		entity, err := h.Store.FindEntity(entityId)
+		entity, err := h.Store.FindEntity(entityId, nil)
 		if err != nil {
 			return false, nil, nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
 		}
-		baseEntity, err := h.Store.FindBaseEntity(&entityId.URL, "acls", "developmentacls")
+		baseEntity, err := h.Store.FindBaseEntity(&entityId.URL, charmstore.FieldSelector("acls", "developmentacls"))
 		if err != nil {
 			return false, nil, nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
 		}
@@ -278,7 +279,7 @@ func areAllowedEntities(entityIds []*router.ResolvedURL, allowedEntities string)
 // AuthorizeEntity checks that the given HTTP request
 // can access the entity with the given id.
 func (h *ReqHandler) AuthorizeEntity(id *router.ResolvedURL, req *http.Request) error {
-	baseEntity, err := h.Store.FindBaseEntity(&id.URL, "acls", "developmentacls")
+	baseEntity, err := h.Store.FindBaseEntity(&id.URL, charmstore.FieldSelector("acls", "developmentacls"))
 	if err != nil {
 		if errgo.Cause(err) == params.ErrNotFound {
 			return errgo.WithCausef(nil, params.ErrNotFound, "entity %q not found", id)

--- a/internal/v5/content.go
+++ b/internal/v5/content.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/juju/jujusvg.v1"
 
+	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 )
@@ -28,7 +29,7 @@ func (h *ReqHandler) serveDiagram(id *router.ResolvedURL, w http.ResponseWriter,
 	if id.URL.Series != "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "diagrams not supported for charms")
 	}
-	entity, err := h.Store.FindEntity(id, "bundledata")
+	entity, err := h.Store.FindEntity(id, charmstore.FieldSelector("bundledata"))
 	if err != nil {
 		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
@@ -71,7 +72,7 @@ var allowedReadMe = map[string]bool{
 // GET id/readme
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idreadme
 func (h *ReqHandler) serveReadMe(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error {
-	entity, err := h.Store.FindEntity(id, "_id", "contents", "blobname")
+	entity, err := h.Store.FindEntity(id, charmstore.FieldSelector("_id", "contents", "blobname"))
 	if err != nil {
 		return errgo.NoteMask(err, "cannot get README", errgo.Is(params.ErrNotFound))
 	}
@@ -97,7 +98,7 @@ func (h *ReqHandler) serveIcon(id *router.ResolvedURL, w http.ResponseWriter, re
 	if id.URL.Series == "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "icons not supported for bundles")
 	}
-	entity, err := h.Store.FindEntity(id, "_id", "contents", "blobname")
+	entity, err := h.Store.FindEntity(id, charmstore.FieldSelector("_id", "contents", "blobname"))
 	if err != nil {
 		return errgo.NoteMask(err, "cannot get icon", errgo.Is(params.ErrNotFound))
 	}


### PR DESCRIPTION
This is a work-in-progress.
We've added the cache (and made the required interface changes)
but we're not properly using it yet, except for ResolveURL(s).

One somewhat invasive change is to pass the map[string]int
to FindEntity and friends rather than the slice of string.
This is to make the interface with the entity cache somewhat
smoother. One alternative might be to represent
all field selections as a bitmask which would be considerably
more efficient, but also more limiting (only 64 fields max,
of which we're currently using ~32).
