### PR TITLE
Use charm URLs with series in v4 search.

### DIFF
--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -10,7 +10,7 @@ var (
 	esMapping = mustParseJSON(esMappingJSON)
 )
 
-const esSettingsVersion = 7
+const esSettingsVersion = 8
 
 func mustParseJSON(s string) interface{} {
 	var j json.RawMessage
@@ -342,6 +342,18 @@ const esMappingJSON = `
       "ReadACLs" : {
         "type" : "string",
         "index": "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+      "SingleSeries": {
+        "type": "boolean",
+        "index" : "not_analyzed",
+        "omit_norms" : true,
+        "index_options" : "docs"
+      },
+      "AllSeries": {
+        "type": "boolean",
+        "index" : "not_analyzed",
         "omit_norms" : true,
         "index_options" : "docs"
       }

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -1586,15 +1586,8 @@ func (store *Store) List(sp SearchParams) (ListResult, error) {
 	}
 
 	pipe := store.DB.Entities().Pipe(q)
-	r := ListResult{
-		Results: make([]*router.ResolvedURL, 0),
-	}
-	var entity mongodoc.Entity
-	iter := pipe.Iter()
-	for iter.Next(&entity) {
-		r.Results = append(r.Results, EntityResolvedURL(&entity))
-	}
-	if err := iter.Close(); err != nil {
+	var r ListResult
+	if err := pipe.All(&r.Results); err != nil {
 		return ListResult{}, errgo.Mask(err)
 	}
 	return r, nil

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -666,7 +666,7 @@ func (s *StoreSuite) TestAddCharmWithFailedESInsert(c *gc.C) {
 	defer store.Close()
 	store.ES = &SearchIndex{esdb, "no-index"}
 
-	url := newResolvedURL("~charmers/precise/wordpress-12", -1)
+	url := router.MustNewResolvedURL("~charmers/precise/wordpress-12", -1)
 	err := store.AddCharmWithArchive(url, storetesting.Charms.CharmDir("wordpress"))
 	c.Assert(err, gc.ErrorMatches, "cannot index cs:~charmers/precise/wordpress-12 to ElasticSearch: .*")
 
@@ -681,12 +681,12 @@ func (s *StoreSuite) TestAddCharmsWithTheSameBaseEntity(c *gc.C) {
 
 	// Add a charm to the database.
 	ch := storetesting.Charms.CharmDir("wordpress")
-	url := newResolvedURL("~charmers/trusty/wordpress-12", 12)
+	url := router.MustNewResolvedURL("~charmers/trusty/wordpress-12", 12)
 	err := store.AddCharmWithArchive(url, ch)
 	c.Assert(err, gc.IsNil)
 
 	// Add a second charm to the database, sharing the same base URL.
-	err = store.AddCharmWithArchive(newResolvedURL("~charmers/utopic/wordpress-13", -1), ch)
+	err = store.AddCharmWithArchive(router.MustNewResolvedURL("~charmers/utopic/wordpress-13", -1), ch)
 	c.Assert(err, gc.IsNil)
 
 	// Ensure a single base entity has been created.
@@ -774,7 +774,7 @@ func (s *StoreSuite) TestBundleUnitCount(c *gc.C) {
 	entities := store.DB.Entities()
 	for i, test := range bundleUnitCountTests {
 		c.Logf("test %d: %s", i, test.about)
-		url := newResolvedURL("cs:~charmers/bundle/django-0", -1)
+		url := router.MustNewResolvedURL("cs:~charmers/bundle/django-0", -1)
 		url.URL.Revision = i
 		url.PromulgatedRevision = i
 
@@ -1099,7 +1099,7 @@ func (s *StoreSuite) TestBundleMachineCount(c *gc.C) {
 	entities := store.DB.Entities()
 	for i, test := range bundleMachineCountTests {
 		c.Logf("test %d: %s", i, test.about)
-		url := newResolvedURL("cs:~charmers/bundle/django-0", -1)
+		url := router.MustNewResolvedURL("cs:~charmers/bundle/django-0", -1)
 		url.URL.Revision = i
 		url.PromulgatedRevision = i
 		err := test.data.Verify(nil, nil)
@@ -1167,33 +1167,33 @@ func MustParseResolvedURLs(urlStrs []string) []*router.ResolvedURL {
 
 func (s *StoreSuite) TestAddPromulgatedCharmDir(c *gc.C) {
 	charmDir := storetesting.Charms.CharmDir("wordpress")
-	s.checkAddCharm(c, charmDir, false, newResolvedURL("~charmers/precise/wordpress-1", 1))
+	s.checkAddCharm(c, charmDir, false, router.MustNewResolvedURL("~charmers/precise/wordpress-1", 1))
 }
 
 func (s *StoreSuite) TestAddPromulgatedCharmArchive(c *gc.C) {
 	charmArchive := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
-	s.checkAddCharm(c, charmArchive, false, newResolvedURL("~charmers/precise/wordpress-1", 1))
+	s.checkAddCharm(c, charmArchive, false, router.MustNewResolvedURL("~charmers/precise/wordpress-1", 1))
 }
 
 func (s *StoreSuite) TestAddUserOwnedCharmDir(c *gc.C) {
 	charmDir := storetesting.Charms.CharmDir("wordpress")
-	s.checkAddCharm(c, charmDir, false, newResolvedURL("~charmers/precise/wordpress-1", -1))
+	s.checkAddCharm(c, charmDir, false, router.MustNewResolvedURL("~charmers/precise/wordpress-1", -1))
 }
 
 func (s *StoreSuite) TestAddUserOwnedCharmArchive(c *gc.C) {
 	charmArchive := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
-	s.checkAddCharm(c, charmArchive, false, newResolvedURL("~charmers/precise/wordpress-1", -1))
+	s.checkAddCharm(c, charmArchive, false, router.MustNewResolvedURL("~charmers/precise/wordpress-1", -1))
 }
 
 func (s *StoreSuite) TestAddDevelopmentCharmArchive(c *gc.C) {
 	charmArchive := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
-	url := newResolvedURL("~charmers/development/precise/wordpress-1", 1)
+	url := router.MustNewResolvedURL("~charmers/development/precise/wordpress-1", 1)
 	s.checkAddCharm(c, charmArchive, false, url)
 }
 
 func (s *StoreSuite) TestAddBundleDir(c *gc.C) {
 	bundleDir := storetesting.Charms.BundleDir("wordpress-simple")
-	s.checkAddBundle(c, bundleDir, false, newResolvedURL("~charmers/bundle/wordpress-simple-2", 3))
+	s.checkAddBundle(c, bundleDir, false, router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 3))
 }
 
 func (s *StoreSuite) TestAddBundleArchive(c *gc.C) {
@@ -1201,12 +1201,12 @@ func (s *StoreSuite) TestAddBundleArchive(c *gc.C) {
 		storetesting.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
 	)
 	c.Assert(err, gc.IsNil)
-	s.checkAddBundle(c, bundleArchive, false, newResolvedURL("~charmers/bundle/wordpress-simple-2", 3))
+	s.checkAddBundle(c, bundleArchive, false, router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 3))
 }
 
 func (s *StoreSuite) TestAddUserOwnedBundleDir(c *gc.C) {
 	bundleDir := storetesting.Charms.BundleDir("wordpress-simple")
-	s.checkAddBundle(c, bundleDir, false, newResolvedURL("~charmers/bundle/wordpress-simple-1", -1))
+	s.checkAddBundle(c, bundleDir, false, router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", -1))
 }
 
 func (s *StoreSuite) TestAddUserOwnedBundleArchive(c *gc.C) {
@@ -1214,7 +1214,7 @@ func (s *StoreSuite) TestAddUserOwnedBundleArchive(c *gc.C) {
 		storetesting.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
 	)
 	c.Assert(err, gc.IsNil)
-	s.checkAddBundle(c, bundleArchive, false, newResolvedURL("~charmers/bundle/wordpress-simple-1", -1))
+	s.checkAddBundle(c, bundleArchive, false, router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", -1))
 }
 
 func (s *StoreSuite) TestAddDevelopmentBundleArchive(c *gc.C) {
@@ -1222,7 +1222,7 @@ func (s *StoreSuite) TestAddDevelopmentBundleArchive(c *gc.C) {
 		storetesting.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
 	)
 	c.Assert(err, gc.IsNil)
-	url := newResolvedURL("~charmers/development/bundle/wordpress-simple-2", 3)
+	url := router.MustNewResolvedURL("~charmers/development/bundle/wordpress-simple-2", 3)
 	s.checkAddBundle(c, bundleArchive, false, url)
 }
 
@@ -1243,7 +1243,7 @@ func (s *StoreSuite) TestAddCharmWithBundleSeries(c *gc.C) {
 	defer store.Close()
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	err := store.AddCharm(ch, AddParams{
-		URL: newResolvedURL("~charmers/bundle/wordpress-2", -1),
+		URL: router.MustNewResolvedURL("~charmers/bundle/wordpress-2", -1),
 	})
 	c.Assert(err, gc.ErrorMatches, `charm added with invalid id cs:~charmers/bundle/wordpress-2`)
 }
@@ -1252,18 +1252,18 @@ func (s *StoreSuite) TestAddCharmWithMultiSeries(c *gc.C) {
 	store := s.newStore(c, false)
 	defer store.Close()
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), "multi-series")
-	s.checkAddCharm(c, ch, false, newResolvedURL("~charmers/multi-series-1", 1))
+	s.checkAddCharm(c, ch, false, router.MustNewResolvedURL("~charmers/multi-series-1", 1))
 	// Make sure it can be accessed with a number of names
-	e, err := store.FindEntity(newResolvedURL("~charmers/multi-series-1", 1), nil)
+	e, err := store.FindEntity(router.MustNewResolvedURL("~charmers/multi-series-1", 1), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.URL.String(), gc.Equals, "cs:~charmers/multi-series-1")
-	e, err = store.FindEntity(newResolvedURL("~charmers/trusty/multi-series-1", 1), nil)
+	e, err = store.FindEntity(router.MustNewResolvedURL("~charmers/trusty/multi-series-1", 1), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.URL.String(), gc.Equals, "cs:~charmers/multi-series-1")
-	e, err = store.FindEntity(newResolvedURL("~charmers/wily/multi-series-1", 1), nil)
+	e, err = store.FindEntity(router.MustNewResolvedURL("~charmers/wily/multi-series-1", 1), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.URL.String(), gc.Equals, "cs:~charmers/multi-series-1")
-	_, err = store.FindEntity(newResolvedURL("~charmers/precise/multi-series-1", 1), nil)
+	_, err = store.FindEntity(router.MustNewResolvedURL("~charmers/precise/multi-series-1", 1), nil)
 	c.Assert(err, gc.ErrorMatches, "entity not found")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 }
@@ -1273,12 +1273,12 @@ func (s *StoreSuite) TestAddCharmWithSeriesWhenThereIsAnExistingMultiSeriesVersi
 	defer store.Close()
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), "multi-series")
 	err := store.AddCharm(ch, AddParams{
-		URL: newResolvedURL("~charmers/multi-series-1", -1),
+		URL: router.MustNewResolvedURL("~charmers/multi-series-1", -1),
 	})
 	c.Assert(err, gc.IsNil)
 	ch = storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	err = store.AddCharm(ch, AddParams{
-		URL: newResolvedURL("~charmers/trusty/multi-series-2", -1),
+		URL: router.MustNewResolvedURL("~charmers/trusty/multi-series-2", -1),
 	})
 	c.Assert(err, gc.ErrorMatches, `charm name duplicates multi-series charm name cs:~charmers/multi-series-1`)
 }
@@ -1287,7 +1287,7 @@ func (s *StoreSuite) TestAddCharmWithMultiSeriesToES(c *gc.C) {
 	store := s.newStore(c, true)
 	defer store.Close()
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), "multi-series")
-	s.checkAddCharm(c, ch, true, newResolvedURL("~charmers/juju-gui-1", 1))
+	s.checkAddCharm(c, ch, true, router.MustNewResolvedURL("~charmers/juju-gui-1", 1))
 }
 
 var addInvalidCharmURLTests = []string{
@@ -1339,11 +1339,11 @@ func (s *StoreSuite) TestAddBundleDuplicatingCharm(c *gc.C) {
 	store := s.newStore(c, false)
 	defer store.Close()
 	ch := storetesting.Charms.CharmDir("wordpress")
-	err := store.AddCharmWithArchive(newResolvedURL("~charmers/precise/wordpress-2", -1), ch)
+	err := store.AddCharmWithArchive(router.MustNewResolvedURL("~charmers/precise/wordpress-2", -1), ch)
 	c.Assert(err, gc.IsNil)
 
 	b := storetesting.Charms.BundleDir("wordpress-simple")
-	err = store.AddBundleWithArchive(newResolvedURL("~charmers/bundle/wordpress-5", -1), b)
+	err = store.AddBundleWithArchive(router.MustNewResolvedURL("~charmers/bundle/wordpress-5", -1), b)
 	c.Assert(err, gc.ErrorMatches, "bundle name duplicates charm name cs:~charmers/precise/wordpress-2")
 }
 
@@ -1352,11 +1352,11 @@ func (s *StoreSuite) TestAddCharmDuplicatingBundle(c *gc.C) {
 	defer store.Close()
 
 	b := storetesting.Charms.BundleDir("wordpress-simple")
-	err := store.AddBundleWithArchive(newResolvedURL("~charmers/bundle/wordpress-2", -1), b)
+	err := store.AddBundleWithArchive(router.MustNewResolvedURL("~charmers/bundle/wordpress-2", -1), b)
 	c.Assert(err, gc.IsNil)
 
 	ch := storetesting.Charms.CharmDir("wordpress")
-	err = store.AddCharmWithArchive(newResolvedURL("~charmers/precise/wordpress-5", -1), ch)
+	err = store.AddCharmWithArchive(router.MustNewResolvedURL("~charmers/precise/wordpress-5", -1), ch)
 	c.Assert(err, gc.ErrorMatches, "charm name duplicates bundle name cs:~charmers/bundle/wordpress-2")
 }
 
@@ -1364,7 +1364,7 @@ func (s *StoreSuite) TestOpenBlob(c *gc.C) {
 	charmArchive := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	store := s.newStore(c, false)
 	defer store.Close()
-	url := newResolvedURL("cs:~charmers/precise/wordpress-23", 23)
+	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-23", 23)
 	err := store.AddCharmWithArchive(url, charmArchive)
 	c.Assert(err, gc.IsNil)
 
@@ -1390,7 +1390,7 @@ func (s *StoreSuite) TestBlobNameAndHash(c *gc.C) {
 
 	store := s.newStore(c, false)
 	defer store.Close()
-	url := newResolvedURL("cs:~charmers/precise/wordpress-23", 23)
+	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-23", 23)
 	err := store.AddCharmWithArchive(url, charmArchive)
 	c.Assert(err, gc.IsNil)
 
@@ -1562,7 +1562,7 @@ func (s *StoreSuite) TestOpenCachedBlobFileWithInvalidEntity(c *gc.C) {
 	defer store.Close()
 
 	wordpress := storetesting.Charms.CharmDir("wordpress")
-	url := newResolvedURL("cs:~charmers/precise/wordpress-23", 23)
+	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-23", 23)
 	err := store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
 
@@ -1578,7 +1578,7 @@ func (s *StoreSuite) TestOpenCachedBlobFileWithFoundContent(c *gc.C) {
 	defer store.Close()
 
 	wordpress := storetesting.Charms.CharmDir("wordpress")
-	url := newResolvedURL("cs:~charmers/precise/wordpress-23", 23)
+	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-23", 23)
 	err := store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
 
@@ -1626,7 +1626,7 @@ func (s *StoreSuite) TestAddCharmWithUser(c *gc.C) {
 	defer store.Close()
 
 	wordpress := storetesting.Charms.CharmDir("wordpress")
-	url := newResolvedURL("cs:~who/precise/wordpress-23", -1)
+	url := router.MustNewResolvedURL("cs:~who/precise/wordpress-23", -1)
 	err := store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
 	assertBaseEntity(c, store, mongodoc.BaseURL(&url.URL), false)
@@ -1637,7 +1637,7 @@ func (s *StoreSuite) TestOpenCachedBlobFileWithNotFoundContent(c *gc.C) {
 	defer store.Close()
 
 	wordpress := storetesting.Charms.CharmDir("wordpress")
-	url := newResolvedURL("cs:~charmers/precise/wordpress-23", 23)
+	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-23", 23)
 	err := store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
 
@@ -1738,17 +1738,17 @@ func (s *StoreSuite) TestSESPutDoesNotErrorWithNoESConfigured(c *gc.C) {
 
 func (s *StoreSuite) TestAddCharmDirIndexed(c *gc.C) {
 	charmDir := storetesting.Charms.CharmDir("wordpress")
-	s.checkAddCharm(c, charmDir, true, newResolvedURL("cs:~charmers/precise/wordpress-2", -1))
+	s.checkAddCharm(c, charmDir, true, router.MustNewResolvedURL("cs:~charmers/precise/wordpress-2", -1))
 }
 
 func (s *StoreSuite) TestAddCharmArchiveIndexed(c *gc.C) {
 	charmArchive := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
-	s.checkAddCharm(c, charmArchive, true, newResolvedURL("cs:~charmers/precise/wordpress-2", -1))
+	s.checkAddCharm(c, charmArchive, true, router.MustNewResolvedURL("cs:~charmers/precise/wordpress-2", -1))
 }
 
 func (s *StoreSuite) TestAddBundleDirIndexed(c *gc.C) {
 	bundleDir := storetesting.Charms.BundleDir("wordpress-simple")
-	s.checkAddBundle(c, bundleDir, true, newResolvedURL("cs:~charmers/bundle/baboom-2", -1))
+	s.checkAddBundle(c, bundleDir, true, router.MustNewResolvedURL("cs:~charmers/bundle/baboom-2", -1))
 }
 
 func (s *StoreSuite) TestAddBundleArchiveIndexed(c *gc.C) {
@@ -1756,22 +1756,22 @@ func (s *StoreSuite) TestAddBundleArchiveIndexed(c *gc.C) {
 		storetesting.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
 	)
 	c.Assert(err, gc.IsNil)
-	s.checkAddBundle(c, bundleArchive, true, newResolvedURL("cs:~charmers/bundle/baboom-2", -1))
+	s.checkAddBundle(c, bundleArchive, true, router.MustNewResolvedURL("cs:~charmers/bundle/baboom-2", -1))
 }
 
 func (s *StoreSuite) TestAddCharmDirIndexedAndPromulgated(c *gc.C) {
 	charmDir := storetesting.Charms.CharmDir("wordpress")
-	s.checkAddCharm(c, charmDir, true, newResolvedURL("cs:~charmers/precise/wordpress-2", -1))
+	s.checkAddCharm(c, charmDir, true, router.MustNewResolvedURL("cs:~charmers/precise/wordpress-2", -1))
 }
 
 func (s *StoreSuite) TestAddCharmArchiveIndexedAndPromulgated(c *gc.C) {
 	charmArchive := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
-	s.checkAddCharm(c, charmArchive, true, newResolvedURL("cs:~charmers/precise/wordpress-2", 2))
+	s.checkAddCharm(c, charmArchive, true, router.MustNewResolvedURL("cs:~charmers/precise/wordpress-2", 2))
 }
 
 func (s *StoreSuite) TestAddBundleDirIndexedAndPromulgated(c *gc.C) {
 	bundleDir := storetesting.Charms.BundleDir("wordpress-simple")
-	s.checkAddBundle(c, bundleDir, true, newResolvedURL("cs:~charmers/bundle/baboom-2", 2))
+	s.checkAddBundle(c, bundleDir, true, router.MustNewResolvedURL("cs:~charmers/bundle/baboom-2", 2))
 }
 
 func (s *StoreSuite) TestAddBundleArchiveIndexedAndPromulgated(c *gc.C) {
@@ -1779,7 +1779,7 @@ func (s *StoreSuite) TestAddBundleArchiveIndexedAndPromulgated(c *gc.C) {
 		storetesting.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
 	)
 	c.Assert(err, gc.IsNil)
-	s.checkAddBundle(c, bundleArchive, true, newResolvedURL("cs:~charmers/bundle/baboom-2", 2))
+	s.checkAddBundle(c, bundleArchive, true, router.MustNewResolvedURL("cs:~charmers/bundle/baboom-2", 2))
 }
 
 var findBestEntityTests = []struct {
@@ -2158,7 +2158,7 @@ func (s *StoreSuite) TestUpdateEntity(c *gc.C) {
 	defer store.Close()
 	for i, test := range updateEntityTests {
 		c.Logf("test %d. %s", i, test.url)
-		url := newResolvedURL(test.url, 10)
+		url := router.MustNewResolvedURL(test.url, 10)
 		_, err := store.DB.Entities().RemoveAll(nil)
 		c.Assert(err, gc.IsNil)
 		err = store.DB.Entities().Insert(denormalizedEntity(&mongodoc.Entity{
@@ -2193,7 +2193,7 @@ func (s *StoreSuite) TestUpdateBaseEntity(c *gc.C) {
 	defer store.Close()
 	for i, test := range updateBaseEntityTests {
 		c.Logf("test %d. %s", i, test.url)
-		url := newResolvedURL(test.url, 10)
+		url := router.MustNewResolvedURL(test.url, 10)
 		_, err := store.DB.BaseEntities().RemoveAll(nil)
 		c.Assert(err, gc.IsNil)
 		err = store.DB.BaseEntities().Insert(&mongodoc.BaseEntity{
@@ -2429,7 +2429,7 @@ func (s *StoreSuite) TestSetPromulgated(c *gc.C) {
 	defer store.Close()
 	for i, test := range promulgateTests {
 		c.Logf("test %d. %s", i, test.about)
-		url := newResolvedURL(test.url, -1)
+		url := router.MustNewResolvedURL(test.url, -1)
 		_, err := store.DB.Entities().RemoveAll(nil)
 		c.Assert(err, gc.IsNil)
 		_, err = store.DB.BaseEntities().RemoveAll(nil)
@@ -2484,7 +2484,7 @@ func (s *StoreSuite) TestSetPromulgatedUpdateSearch(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	err = store.DB.BaseEntities().Insert(baseEntity("~openstack-charmers/wordpress", false))
 	c.Assert(err, gc.IsNil)
-	url := newResolvedURL("~openstack-charmers/trusty/wordpress-0", -1)
+	url := router.MustNewResolvedURL("~openstack-charmers/trusty/wordpress-0", -1)
 
 	// Change the promulgated mysql version to openstack-charmers.
 	err = store.SetPromulgated(url, true)
@@ -2574,7 +2574,7 @@ func (s *StoreSuite) TestSetDevelopment(c *gc.C) {
 		if test.existingDevelopment {
 			url.Channel = charm.DevelopmentChannel
 		}
-		rurl := newResolvedURL(url.Path(), -1)
+		rurl := router.MustNewResolvedURL(url.Path(), -1)
 		err := store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("wordpress"))
 		c.Assert(err, gc.IsNil)
 
@@ -2601,7 +2601,7 @@ func (s *StoreSuite) TestSetDevelopmentErrorNotFound(c *gc.C) {
 	store := s.newStore(c, false)
 	defer store.Close()
 
-	err := store.SetDevelopment(newResolvedURL("~who/wily/no-such-42", -1), true)
+	err := store.SetDevelopment(router.MustNewResolvedURL("~who/wily/no-such-42", -1), true)
 	c.Assert(err, gc.ErrorMatches, `cannot update "cs:~who/wily/no-such-42": not found`)
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 }

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -106,6 +106,7 @@ func newReqHandler() ReqHandler {
 	resolveId := h.ResolvedIdHandler
 	authId := h.AuthIdHandler
 	handlers := v5.RouterHandlers(h.ReqHandler)
+	handlers.Global["search"] = router.HandleJSON(h.serveSearch)
 	handlers.Meta["charm-related"] = h.EntityHandler(h.metaCharmRelated, "charmprovidedinterfaces", "charmrequiredinterfaces")
 	handlers.Meta["revision-info"] = router.SingleIncludeHandler(h.metaRevisionInfo)
 	handlers.Id["expand-id"] = resolveId(authId(h.serveExpandId))

--- a/internal/v4/list_test.go
+++ b/internal/v4/list_test.go
@@ -287,8 +287,9 @@ func (s *ListSuite) TestListIncludeError(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	var resp params.ListResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &resp)
-	// cs:riak will not be found because it is not visible to "everyone".
-	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)-1)
+	// cs:riak will not be found because it is not visible to
+	// "everyone".
+	c.Assert(resp.Results, gc.HasLen, len(exportListTestCharms)-1)
 
 	// Now remove one of the blobs. The list should still
 	// work, but only return a single result.
@@ -316,7 +317,7 @@ func (s *ListSuite) TestListIncludeError(c *gc.C) {
 	err = json.Unmarshal(rec.Body.Bytes(), &resp)
 	// cs:riak will not be found because it is not visible to "everyone".
 	// cs:wordpress will not be found because it has no manifest.
-	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)-2)
+	c.Assert(resp.Results, gc.HasLen, len(exportListTestCharms)-2)
 
 	c.Assert(tw.Log(), jc.LogMatches, []string{"cannot retrieve metadata for cs:precise/wordpress-23: cannot open archive data for cs:precise/wordpress-23: .*"})
 }

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -1,0 +1,36 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package v4 // import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
+
+import (
+	"net/http"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"
+)
+
+const maxConcurrency = 20
+
+// GET search[?text=text][&autocomplete=1][&filter=value…][&limit=limit][&include=meta][&skip=count][&sort=field[+dir]]
+// https://github.com/juju/charmstore/blob/v4/docs/API.md#get-search
+func (h *ReqHandler) serveSearch(_ http.Header, req *http.Request) (interface{}, error) {
+	sp, err := v5.ParseSearchParams(req)
+	if err != nil {
+		return "", err
+	}
+	sp.ExpandedMultiSeries = true
+	auth, err := h.CheckRequest(req, nil, v5.OpOther)
+	if err != nil {
+		logger.Infof("authorization failed on search request, granting no privileges: %v", err)
+	}
+	sp.Admin = auth.Admin
+	if auth.Username != "" {
+		sp.Groups = append(sp.Groups, auth.Username)
+		groups, err := h.GroupsForUser(auth.Username)
+		if err != nil {
+			logger.Infof("cannot get groups for user %q, assuming no groups: %v", auth.Username, err)
+		}
+		sp.Groups = append(sp.Groups, groups...)
+	}
+	return h.Search(sp, req)
+}

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -34,10 +34,11 @@ type SearchSuite struct {
 var _ = gc.Suite(&SearchSuite{})
 
 var exportTestCharms = map[string]*router.ResolvedURL{
-	"wordpress": newResolvedURL("cs:~charmers/precise/wordpress-23", 23),
-	"mysql":     newResolvedURL("cs:~openstack-charmers/trusty/mysql-7", 7),
-	"varnish":   newResolvedURL("cs:~foo/trusty/varnish-1", -1),
-	"riak":      newResolvedURL("cs:~charmers/trusty/riak-67", 67),
+	"multi-series": newResolvedURL("cs:~charmers/multi-series-0", 0),
+	"wordpress":    newResolvedURL("cs:~charmers/precise/wordpress-23", 23),
+	"mysql":        newResolvedURL("cs:~openstack-charmers/trusty/mysql-7", 7),
+	"varnish":      newResolvedURL("cs:~foo/trusty/varnish-1", -1),
+	"riak":         newResolvedURL("cs:~charmers/trusty/riak-67", 67),
 }
 
 var exportTestBundles = map[string]*router.ResolvedURL{
@@ -109,6 +110,11 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		about: "bare search",
 		query: "",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
@@ -132,6 +138,11 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		about: "blank text search",
 		query: "text=",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
@@ -166,12 +177,19 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		about: "requires filter search",
 		query: "requires=mysql",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 		},
 	}, {
 		about: "series filter search",
 		query: "series=trusty",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
 		},
@@ -199,6 +217,11 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		about: "multiple type filter search",
 		query: "type=bundle&type=charm",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
@@ -208,12 +231,22 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		about: "provides multiple interfaces filter search",
 		query: "provides=monitoring+http",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 		},
 	}, {
 		about: "requires multiple interfaces filter search",
 		query: "requires=mysql+varnish",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 		},
 	}, {
@@ -226,6 +259,11 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		about: "blank owner",
 		query: "owner=",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 			exportTestCharms["mysql"],
 			exportTestBundles["wordpress-simple"],
@@ -237,6 +275,11 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		about: "promulgated",
 		query: "promulgated=1",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 			exportTestCharms["mysql"],
 			exportTestBundles["wordpress-simple"],
@@ -407,8 +450,10 @@ func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	var resp params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	// V4 SPECIFIC
 	// cs:riak will not be found because it is not visible to "everyone".
-	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)-1)
+	// cs:multi-series will be expanded to 4 different results.
+	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)+3-1)
 
 	// Now remove one of the blobs. The search should still
 	// work, but only return a single result.
@@ -434,9 +479,11 @@ func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	resp = params.SearchResponse{}
 	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	// V4 SPECIFIC
 	// cs:riak will not be found because it is not visible to "everyone".
+	// cs:multi-series will be expanded to 4 different results.
 	// cs:wordpress will not be found because it has no manifest.
-	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)-2)
+	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)+3-2)
 
 	c.Assert(tw.Log(), jc.LogMatches, []string{"cannot retrieve metadata for cs:precise/wordpress-23: cannot open archive data for cs:precise/wordpress-23: .*"})
 }
@@ -450,6 +497,11 @@ func (s *SearchSuite) TestSorting(c *gc.C) {
 		about: "name ascending",
 		query: "sort=name",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
 			exportTestCharms["wordpress"],
@@ -459,24 +511,39 @@ func (s *SearchSuite) TestSorting(c *gc.C) {
 		about: "name descending",
 		query: "sort=-name",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
 			exportTestBundles["wordpress-simple"],
 			exportTestCharms["wordpress"],
 			exportTestCharms["varnish"],
 			exportTestCharms["mysql"],
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 		},
 	}, {
 		about: "series ascending",
 		query: "sort=series,name",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
 			exportTestBundles["wordpress-simple"],
 			exportTestCharms["wordpress"],
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 		},
 	}, {
 		about: "series descending",
 		query: "sort=-series&sort=name",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
 			exportTestCharms["wordpress"],
@@ -486,6 +553,11 @@ func (s *SearchSuite) TestSorting(c *gc.C) {
 		about: "owner ascending",
 		query: "sort=owner,name",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 			exportTestBundles["wordpress-simple"],
 			exportTestCharms["varnish"],
@@ -495,8 +567,13 @@ func (s *SearchSuite) TestSorting(c *gc.C) {
 		about: "owner descending",
 		query: "sort=-owner&sort=name",
 		results: []*router.ResolvedURL{
+			// V4 SPECIFIC
 			exportTestCharms["mysql"],
 			exportTestCharms["varnish"],
+			router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+			router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 			exportTestCharms["wordpress"],
 			exportTestBundles["wordpress-simple"],
 		},
@@ -607,6 +684,11 @@ func (s *SearchSuite) TestSearchWithAdminCredentials(c *gc.C) {
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	expected := []*router.ResolvedURL{
+		// V4 SPECIFIC
+		router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 		exportTestCharms["mysql"],
 		exportTestCharms["wordpress"],
 		exportTestCharms["riak"],
@@ -633,6 +715,11 @@ func (s *SearchSuite) TestSearchWithUserMacaroon(c *gc.C) {
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	expected := []*router.ResolvedURL{
+		// V4 SPECIFIC
+		router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 		exportTestCharms["mysql"],
 		exportTestCharms["wordpress"],
 		exportTestCharms["riak"],
@@ -662,6 +749,11 @@ func (s *SearchSuite) TestSearchWithUserInGroups(c *gc.C) {
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	expected := []*router.ResolvedURL{
+		// V4 SPECIFIC
+		router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 		exportTestCharms["mysql"],
 		exportTestCharms["wordpress"],
 		exportTestCharms["riak"],
@@ -690,6 +782,11 @@ func (s *SearchSuite) TestSearchWithBadAdminCredentialsAndACookie(c *gc.C) {
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	expected := []*router.ResolvedURL{
+		// V4 SPECIFIC
+		router.MustNewResolvedURL("cs:~charmers/trusty/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/utopic/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/vivid/multi-series-0", 0),
+		router.MustNewResolvedURL("cs:~charmers/wily/multi-series-0", 0),
 		exportTestCharms["mysql"],
 		exportTestCharms["wordpress"],
 		exportTestCharms["varnish"],

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -1171,7 +1171,7 @@ func (h *ReqHandler) serveDelegatableMacaroon(_ http.Header, req *http.Request) 
 		m, err := h.Store.Bakery.NewMacaroon("", nil, []checkers.Caveat{
 			checkers.DeclaredCaveat(UsernameAttr, auth.Username),
 			checkers.TimeBeforeCaveat(time.Now().Add(DelegatableMacaroonExpiry)),
-			checkers.DenyCaveat(opAccessCharmWithTerms),
+			checkers.DenyCaveat(OpAccessCharmWithTerms),
 		})
 		if err != nil {
 			return nil, errgo.Mask(err)
@@ -1230,7 +1230,7 @@ func (h *ReqHandler) serveWhoAmI(_ http.Header, req *http.Request) (interface{},
 	if auth.Admin {
 		return nil, errgo.WithCausef(nil, params.ErrForbidden, "admin credentials used")
 	}
-	groups, err := h.groupsForUser(auth.Username)
+	groups, err := h.GroupsForUser(auth.Username)
 	if err != nil {
 		return nil, errgo.Mask(err, errgo.Any)
 	}

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -988,7 +988,7 @@ func (s *authSuite) TestGroupsForUserSuccess(c *gc.C) {
 	s.idM.groups = map[string][]string{
 		"bob": {"one", "two"},
 	}
-	groups, err := v5.GroupsForUser(h, "bob")
+	groups, err := h.GroupsForUser("bob")
 	c.Assert(err, gc.IsNil)
 	c.Assert(groups, jc.DeepEquals, []string{"one", "two"})
 }
@@ -996,7 +996,7 @@ func (s *authSuite) TestGroupsForUserSuccess(c *gc.C) {
 func (s *authSuite) TestGroupsForUserWithNoIdentity(c *gc.C) {
 	h := s.handler(c)
 	defer h.Close()
-	groups, err := v5.GroupsForUser(h, "someone")
+	groups, err := h.GroupsForUser("someone")
 	c.Assert(err, gc.IsNil)
 	c.Assert(groups, gc.HasLen, 0)
 }
@@ -1005,7 +1005,7 @@ func (s *authSuite) TestGroupsForUserWithInvalidIdentityURL(c *gc.C) {
 	s.PatchValue(&s.srvParams.IdentityAPIURL, ":::::")
 	h := s.handler(c)
 	defer h.Close()
-	groups, err := v5.GroupsForUser(h, "someone")
+	groups, err := h.GroupsForUser("someone")
 	c.Assert(err, gc.ErrorMatches, `cannot get groups for someone: cannot GET \"/v1/u/someone/groups\": cannot create request for \":::::/v1/u/someone/groups\": parse :::::/v1/u/someone/groups: missing protocol scheme`)
 	c.Assert(groups, gc.HasLen, 0)
 }
@@ -1015,7 +1015,7 @@ func (s *authSuite) TestGroupsForUserWithInvalidBody(c *gc.C) {
 	defer h.Close()
 	s.idM.body = "bad"
 	s.idM.contentType = "application/json"
-	groups, err := v5.GroupsForUser(h, "someone")
+	groups, err := h.GroupsForUser("someone")
 	c.Assert(err, gc.ErrorMatches, `cannot get groups for someone: cannot unmarshal response: invalid character 'b' looking for beginning of value`)
 	c.Assert(groups, gc.HasLen, 0)
 }
@@ -1026,7 +1026,7 @@ func (s *authSuite) TestGroupsForUserWithErrorResponse(c *gc.C) {
 	s.idM.body = `{"message":"some error","code":"some code"}`
 	s.idM.status = http.StatusUnauthorized
 	s.idM.contentType = "application/json"
-	groups, err := v5.GroupsForUser(h, "someone")
+	groups, err := h.GroupsForUser("someone")
 	c.Assert(err, gc.ErrorMatches, `cannot get groups for someone: some error`)
 	c.Assert(groups, gc.HasLen, 0)
 }
@@ -1037,7 +1037,7 @@ func (s *authSuite) TestGroupsForUserWithBadErrorResponse(c *gc.C) {
 	s.idM.body = `{"message":"some error"`
 	s.idM.status = http.StatusUnauthorized
 	s.idM.contentType = "application/json"
-	groups, err := v5.GroupsForUser(h, "someone")
+	groups, err := h.GroupsForUser("someone")
 	c.Assert(err, gc.ErrorMatches, `cannot get groups for someone: bad status "401 Unauthorized"`)
 	c.Assert(groups, gc.HasLen, 0)
 }

--- a/internal/v5/export_test.go
+++ b/internal/v5/export_test.go
@@ -4,13 +4,12 @@
 package v5 // import "gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 
 var (
-	ParseSearchParams    = parseSearchParams
 	ProcessIcon          = processIcon
 	ErrProbablyNotXML    = errProbablyNotXML
 	TestAddAuditCallback = &testAddAuditCallback
 
 	BundleCharms              = (*ReqHandler).bundleCharms
 	GetNewPromulgatedRevision = (*ReqHandler).getNewPromulgatedRevision
-	GroupsForUser             = (*ReqHandler).groupsForUser
-	ResolveURL                = resolveURL
+
+	ResolveURL = resolveURL
 )


### PR DESCRIPTION
In order to stay compatible with old juju versions, all URLs returned
from the v4 search will contain a series, even for multi-series
charms. Multi-series charms are expanded to one entry per series.
