### PR TITLE
More cache integration.

### DIFF
--- a/internal/entitycache/bench_test.go
+++ b/internal/entitycache/bench_test.go
@@ -34,12 +34,12 @@ func BenchmarkSingleRequest(b *testing.B) {
 	baseURL := charm.MustParseURL("~bob/wordpress")
 	for i := 0; i < b.N; i++ {
 		c := entitycache.New(store)
-		c.AddEntityFields("size", "blobname")
-		e, err := c.Entity(url)
+		c.AddEntityFields(map[string]int{"size": 1, "blobname": 1})
+		e, err := c.Entity(url, nil)
 		if err != nil || e != entity {
 			b.Fatalf("get returned unexpected entity (err %v)", err)
 		}
-		be, err := c.BaseEntity(baseURL)
+		be, err := c.BaseEntity(baseURL, nil)
 		if err != nil || be != baseEntity {
 			b.Fatalf("get returned unexpected base entity (err %v)", err)
 		}

--- a/internal/entitycache/cache_test.go
+++ b/internal/entitycache/cache_test.go
@@ -47,7 +47,7 @@ func (*suite) TestEntityIssuesBaseEntityQueryConcurrently(c *gc.C) {
 	store := newChanStore()
 	cache := entitycache.New(store)
 	defer cache.Close()
-	cache.AddBaseEntityFields("url", "name")
+	cache.AddBaseEntityFields(map[string]int{"url": 1, "name": 1})
 
 	entity := &mongodoc.Entity{
 		URL:      charm.MustParseURL("~bob/wordpress-1"),
@@ -62,7 +62,7 @@ func (*suite) TestEntityIssuesBaseEntityQueryConcurrently(c *gc.C) {
 	queryDone := make(chan struct{})
 	go func() {
 		defer close(queryDone)
-		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl", "blobname")
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"url": 1, "baseurl": 1, "blobname": 1})
 		c.Check(err, gc.IsNil)
 		c.Check(e, gc.Equals, entity)
 	}()
@@ -95,11 +95,11 @@ func (*suite) TestEntityIssuesBaseEntityQueryConcurrently(c *gc.C) {
 	// to ensure it doesn't.
 	close(store.entityqc)
 	close(store.baseEntityqc)
-	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl", "blobname")
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"url": 1, "baseurl": 1, "blobname": 1})
 	c.Check(err, gc.IsNil)
 	c.Check(e, gc.Equals, entity)
 
-	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), "url", "name")
+	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), map[string]int{"url": 1, "name": 1})
 	c.Check(err, gc.IsNil)
 	c.Check(be, gc.Equals, baseEntity)
 }
@@ -108,7 +108,7 @@ func (*suite) TestFetchWhenFieldsChangeBeforeQueryResult(c *gc.C) {
 	store := newChanStore()
 	cache := entitycache.New(store)
 	defer cache.Close()
-	cache.AddBaseEntityFields("url", "name")
+	cache.AddBaseEntityFields(map[string]int{"url": 1, "name": 1})
 
 	entity := &mongodoc.Entity{
 		URL:      charm.MustParseURL("~bob/wordpress-1"),
@@ -131,7 +131,7 @@ func (*suite) TestFetchWhenFieldsChangeBeforeQueryResult(c *gc.C) {
 	queryDone := make(chan struct{})
 	go func() {
 		defer close(queryDone)
-		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl")
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"url": 1, "baseurl": 1})
 		c.Check(err, gc.IsNil)
 		c.Check(e, gc.Equals, entity)
 	}()
@@ -154,7 +154,7 @@ func (*suite) TestFetchWhenFieldsChangeBeforeQueryResult(c *gc.C) {
 	go func() {
 		defer close(query2Done)
 		// Note the extra "size" field.
-		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl", "size")
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"url": 1, "baseurl": 1, "size": 1})
 		c.Check(err, gc.IsNil)
 		c.Check(e, gc.Equals, entity2)
 	}()
@@ -182,7 +182,7 @@ func (*suite) TestFetchWhenFieldsChangeBeforeQueryResult(c *gc.C) {
 	// to ensure it doesn't.
 	close(store.entityqc)
 	close(store.baseEntityqc)
-	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl")
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"url": 1, "baseurl": 1})
 	c.Check(err, gc.IsNil)
 	c.Check(e, gc.Equals, entity2)
 }
@@ -191,7 +191,7 @@ func (*suite) TestSecondFetchesWaitForFirst(c *gc.C) {
 	store := newChanStore()
 	cache := entitycache.New(store)
 	defer cache.Close()
-	cache.AddBaseEntityFields("url", "name")
+	cache.AddBaseEntityFields(map[string]int{"url": 1, "name": 1})
 
 	entity := &mongodoc.Entity{
 		URL:      charm.MustParseURL("~bob/wordpress-1"),
@@ -215,7 +215,7 @@ func (*suite) TestSecondFetchesWaitForFirst(c *gc.C) {
 	initialRequestGroup.Add(1)
 	go func() {
 		defer initialRequestGroup.Done()
-		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl")
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"url": 1, "baseurl": 1})
 		c.Check(err, gc.IsNil)
 		c.Check(e, gc.Equals, entity)
 	}()
@@ -233,7 +233,7 @@ func (*suite) TestSecondFetchesWaitForFirst(c *gc.C) {
 		initialRequestGroup.Add(1)
 		go func() {
 			defer initialRequestGroup.Done()
-			e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "url", "baseurl")
+			e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"url": 1, "baseurl": 1})
 			c.Check(err, gc.IsNil)
 			c.Check(e, gc.Equals, entity)
 		}()
@@ -255,7 +255,7 @@ func (*suite) TestSecondFetchesWaitForFirst(c *gc.C) {
 	otherRequestDone := make(chan struct{})
 	go func() {
 		defer close(otherRequestDone)
-		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-2"), "url", "baseurl")
+		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-2"), map[string]int{"url": 1, "baseurl": 1})
 		c.Check(err, gc.IsNil)
 		c.Check(e, gc.Equals, entity2)
 	}()
@@ -292,13 +292,13 @@ func (*suite) TestGetEntityNotFound(c *gc.C) {
 	}
 	cache := entitycache.New(store)
 	defer cache.Close()
-	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
 	c.Assert(e, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "not found")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 
 	// Make sure that the not-found result has been cached.
-	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
 	c.Assert(e, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "not found")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
@@ -306,16 +306,17 @@ func (*suite) TestGetEntityNotFound(c *gc.C) {
 	c.Assert(entityFetchCount, gc.Equals, 1)
 
 	// Make sure fetching the base entity works the same way.
-	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
+	c.Assert(be, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "not found")
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
+
+	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
 	c.Assert(be, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "not found")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 
 	c.Assert(baseEntityFetchCount, gc.Equals, 1)
-	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
-	c.Assert(be, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "not found")
-	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 }
 
 func (*suite) TestFetchError(c *gc.C) {
@@ -335,24 +336,24 @@ func (*suite) TestFetchError(c *gc.C) {
 	defer cache.Close()
 
 	// Check that we get the entity fetch error from cache.Entity.
-	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
 	c.Assert(e, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `cannot fetch "cs:~bob/wordpress-1": entity error`)
 
 	// Check that the error is cached.
-	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
 	c.Assert(e, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `cannot fetch "cs:~bob/wordpress-1": entity error`)
 
 	c.Assert(entityFetchCount, gc.Equals, 1)
 
 	// Check that we get the base-entity fetch error from cache.BaseEntity.
-	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
 	c.Assert(be, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `cannot fetch "cs:~bob/wordpress": base entity error`)
 
 	// Check that the error is cached.
-	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
 	c.Assert(be, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `cannot fetch "cs:~bob/wordpress": base entity error`)
 	c.Assert(baseEntityFetchCount, gc.Equals, 1)
@@ -384,14 +385,14 @@ func (*suite) TestStartFetch(c *gc.C) {
 	entityQueryDone := make(chan struct{})
 	go func() {
 		defer close(entityQueryDone)
-		e, err := cache.Entity(url)
+		e, err := cache.Entity(url, nil)
 		c.Check(err, gc.IsNil)
 		c.Check(e, jc.DeepEquals, entity)
 	}()
 	baseEntityQueryDone := make(chan struct{})
 	go func() {
 		defer close(baseEntityQueryDone)
-		e, err := cache.BaseEntity(baseURL)
+		e, err := cache.BaseEntity(baseURL, nil)
 		c.Check(err, gc.IsNil)
 		c.Check(e, jc.DeepEquals, baseEntity)
 	}()
@@ -433,20 +434,20 @@ func (*suite) TestAddEntityFields(c *gc.C) {
 		return baseEntity, nil
 	}
 	cache := entitycache.New(store)
-	cache.AddEntityFields("blobname", "size")
+	cache.AddEntityFields(map[string]int{"blobname": 1, "size": 1})
 	queryDone := make(chan struct{})
 	go func() {
 		defer close(queryDone)
-		e, err := cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), "blobname")
+		e, err := cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), map[string]int{"blobname": 1})
 		c.Check(err, gc.IsNil)
 		expect := *entity
 		selectFields(&expect, "url", "blobname", "size")
 		c.Check(e, jc.DeepEquals, &expect)
 
 		// Adding existing entity fields should have no effect.
-		cache.AddEntityFields("blobname", "size")
+		cache.AddEntityFields(map[string]int{"blobname": 1, "size": 1})
 
-		e, err = cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), "size")
+		e, err = cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), map[string]int{"size": 1})
 		c.Check(err, gc.IsNil)
 		expect = *entity
 		selectFields(&expect, "url", "blobname", "size")
@@ -455,8 +456,8 @@ func (*suite) TestAddEntityFields(c *gc.C) {
 		// Adding a new field should will cause the cache to be invalidated
 		// and a new fetch to take place.
 
-		cache.AddEntityFields("blobhash")
-		e, err = cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"))
+		cache.AddEntityFields(map[string]int{"blobhash": 1})
+		e, err = cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), nil)
 		c.Check(err, gc.IsNil)
 		expect = *entity
 		selectFields(&expect, "url", "blobname", "size", "blobhash")
@@ -517,7 +518,7 @@ func (*suite) TestLookupByDifferentKey(c *gc.C) {
 	}
 	cache := entitycache.New(store)
 	defer cache.Close()
-	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e, gc.Equals, entity)
 
@@ -531,7 +532,7 @@ func (*suite) TestLookupByDifferentKey(c *gc.C) {
 		BaseURL:  charm.MustParseURL("~bob/wordpress"),
 		BlobName: "w2",
 	}
-	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress"))
+	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Logf("got %p; old entity %p; new entity %p", e, oldEntity, entity)
 	c.Assert(e, gc.Equals, oldEntity)
@@ -547,7 +548,7 @@ func (s *suite) TestIterSingle(c *gc.C) {
 	cache := entitycache.New(store)
 	defer cache.Close()
 	fakeIter := newFakeIter()
-	iter := entitycache.CacheIter(cache, fakeIter, "size", "blobsize")
+	iter := entitycache.CacheIter(cache, fakeIter, map[string]int{"size": 1, "blobsize": 1})
 	nextDone := make(chan struct{})
 	go func() {
 		defer close(nextDone)
@@ -589,7 +590,7 @@ func (s *suite) TestIterSingle(c *gc.C) {
 	c.Assert(iter.Entity(), jc.DeepEquals, entity)
 
 	// Check that the entity can now be fetched from the cache.
-	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e, gc.Equals, expectCached)
 
@@ -602,7 +603,7 @@ func (s *suite) TestIterSingle(c *gc.C) {
 	queryDone := make(chan struct{})
 	go func() {
 		defer close(queryDone)
-		e, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+		e, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
 		c.Check(err, gc.IsNil)
 		c.Check(e, gc.Equals, baseEntity)
 	}()
@@ -646,11 +647,11 @@ func (*suite) TestIterWithEntryAlreadyInCache(c *gc.C) {
 	}
 	cache := entitycache.New(store)
 	defer cache.Close()
-	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), "size", "blobsize")
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"size": 1, "blobsize": 1})
 	c.Assert(err, gc.IsNil)
 	c.Assert(e, gc.Equals, store.entities[0])
 
-	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), "size", "blobsize")
+	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), map[string]int{"size": 1, "blobsize": 1})
 	c.Assert(err, gc.IsNil)
 	c.Assert(be, gc.Equals, store.baseEntities[0])
 
@@ -661,7 +662,7 @@ func (*suite) TestIterWithEntryAlreadyInCache(c *gc.C) {
 	}
 
 	fakeIter := newFakeIter()
-	iter := entitycache.CacheIter(cache, fakeIter, "size", "blobsize")
+	iter := entitycache.CacheIter(cache, fakeIter, map[string]int{"size": 1, "blobsize": 1})
 	iterDone := make(chan struct{})
 	go func() {
 		defer close(iterDone)
@@ -691,11 +692,11 @@ func (*suite) TestIterWithEntryAlreadyInCache(c *gc.C) {
 	// The original cached entities should still be there.
 	cache = entitycache.New(store)
 	defer cache.Close()
-	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"))
+	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e, gc.Equals, store.entities[0])
 
-	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"))
+	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(be, gc.Equals, store.baseEntities[0])
 }
@@ -731,7 +732,7 @@ func (*suite) TestIterCloseEarlyWhenBatchLimitExceeded(c *gc.C) {
 	fakeIter := &sliceIter{
 		entities: entities,
 	}
-	iter := entitycache.CacheIter(cache, fakeIter, "blobname")
+	iter := entitycache.CacheIter(cache, fakeIter, map[string]int{"blobname": 1})
 	iter.Close()
 	c.Assert(iter.Next(), gc.Equals, false)
 }
@@ -757,11 +758,11 @@ func (*suite) TestIterCloseEarlyBeforeBatchLimitExceeded(c *gc.C) {
 		}},
 	}
 	cache := entitycache.New(store)
-	cache.AddBaseEntityFields("public")
+	cache.AddBaseEntityFields(map[string]int{"public": 1})
 	// Ask for one of the entities that will be iterated over,
 	// so that the Iter.run loop will send an entity without
 	// starting the base URL fetch.
-	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-2"), "blobname")
+	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-2"), map[string]int{"blobname": 1})
 	c.Assert(err, gc.IsNil)
 	c.Assert(e, jc.DeepEquals, store.entities[0])
 
@@ -776,7 +777,7 @@ func (*suite) TestIterCloseEarlyBeforeBatchLimitExceeded(c *gc.C) {
 	}}
 
 	fakeIter := newFakeIter()
-	iter := entitycache.CacheIter(cache, fakeIter, "blobname")
+	iter := entitycache.CacheIter(cache, fakeIter, map[string]int{"blobname": 1})
 	iterDone := make(chan struct{})
 	go func() {
 		defer close(iterDone)
@@ -810,7 +811,7 @@ func (*suite) TestIterCloseEarlyBeforeBatchLimitExceeded(c *gc.C) {
 
 	// Ensure that we can still retrieve the base entity that
 	// was added (and then removed) by the iterator.
-	be, err := cache.BaseEntity(charm.MustParseURL("~alice/mysql-1"), "public")
+	be, err := cache.BaseEntity(charm.MustParseURL("~alice/mysql-1"), map[string]int{"public": 1})
 	c.Assert(err, gc.IsNil)
 	c.Assert(be, jc.DeepEquals, store.baseEntities[1])
 }
@@ -838,7 +839,7 @@ func (*suite) TestIterEntityBatchLimitExceeded(c *gc.C) {
 	fakeIter := &sliceIter{
 		entities: entities,
 	}
-	iter := entitycache.CacheIter(cache, fakeIter, "blobname")
+	iter := entitycache.CacheIter(cache, fakeIter, map[string]int{"blobname": 1})
 
 	// The iterator should fetch up to entityThreshold entities
 	// from the underlying iterator before sending
@@ -872,10 +873,10 @@ func (*suite) TestIterEntityBatchLimitExceeded(c *gc.C) {
 
 	// Check that all the entities and base entities are in fact cached.
 	for _, want := range entities {
-		got, err := cache.Entity(want.URL)
+		got, err := cache.Entity(want.URL, nil)
 		c.Assert(err, gc.IsNil)
 		c.Assert(got, jc.DeepEquals, want)
-		gotBase, err := cache.BaseEntity(want.URL)
+		gotBase, err := cache.BaseEntity(want.URL, nil)
 		c.Assert(err, gc.IsNil)
 		c.Assert(gotBase, jc.DeepEquals, &mongodoc.BaseEntity{
 			URL: want.BaseURL,
@@ -886,7 +887,7 @@ func (*suite) TestIterEntityBatchLimitExceeded(c *gc.C) {
 func (*suite) TestIterError(c *gc.C) {
 	cache := entitycache.New(&staticStore{})
 	fakeIter := newFakeIter()
-	iter := entitycache.CacheIter(cache, fakeIter)
+	iter := entitycache.CacheIter(cache, fakeIter, nil)
 	// Err returns nil while the iteration is in progress.
 	err := iter.Err()
 	c.Assert(err, gc.IsNil)

--- a/internal/entitycache/export_test.go
+++ b/internal/entitycache/export_test.go
@@ -1,6 +1,6 @@
 package entitycache
 
-func CacheIter(c *Cache, mgoIter mgoIter, fields ...string) *Iter {
+func CacheIter(c *Cache, mgoIter mgoIter, fields map[string]int) *Iter {
 	c.entities.mu.Lock()
 	defer c.entities.mu.Unlock()
 	// Note: this is exactly the same as Cache.Iter except that

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -121,25 +121,6 @@ type Entity struct {
 	Development bool
 }
 
-// CanonicalURLs returns the canonical URLs that can be used
-// to look up the entity. For non-promulgated entities,
-// there will only be one element in the result.
-func (e *Entity) CanonicalURLs() []*charm.URL {
-	// Larger capacity than strictly necessary to allow
-	// a caller to append to the returned slice without allocating.
-	urls := make([]*charm.URL, 1, 3)
-	urls[0] = copyURL(e.URL)
-	if e.PromulgatedURL != nil {
-		urls = append(urls, copyURL(e.PromulgatedURL))
-	}
-	if e.Development {
-		for _, u := range urls {
-			u.Channel = charm.DevelopmentChannel
-		}
-	}
-	return urls
-}
-
 // PreferredURL returns the preferred way to refer to this entity. If
 // the entity has a promulgated URL and usePromulgated is true then the
 // promulgated URL will be used, otherwise the standard URL is used.
@@ -194,22 +175,6 @@ type BaseEntity struct {
 	// the base entity. Thhose data apply to all revisions.
 	// The byte slices hold JSON-encoded data.
 	CommonInfo map[string][]byte `bson:",omitempty" json:",omitempty"`
-}
-
-// CanonicalURLs returns the canonical URLs that can be used
-// to look up the entity. For non-promulgated entities,
-// there will only be one element in the result.
-func (e *BaseEntity) CanonicalURLs() []*charm.URL {
-	// Larger capacity than strictly necessary to allow
-	// a caller to append to the returned slice without allocating.
-	urls := make([]*charm.URL, 1, 3)
-	urls[0] = copyURL(e.URL)
-	if e.Promulgated {
-		u := copyURL(e.URL)
-		u.User = ""
-		urls = append(urls, u)
-	}
-	return urls
 }
 
 // ACL holds lists of users and groups that are

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -76,8 +76,15 @@ func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams) charms
 	return New(pool, config)
 }
 
-// The v4 resolvedURL function also requires SupporedSeries.
-var requiredEntityFields = append(v5.RequiredEntityFields, "supportedseries")
+// The v4 resolvedURL function also requires SupportedSeries.
+var requiredEntityFields = func() map[string]int {
+	fields := make(map[string]int)
+	for f := range v5.RequiredEntityFields {
+		fields[f] = 1
+	}
+	fields["supportedseries"] = 1
+	return fields
+}()
 
 // NewReqHandler fetchs a new instance of ReqHandler
 // from h.Pool and returns it. The ReqHandler must
@@ -94,8 +101,8 @@ func (h *Handler) NewReqHandler() (ReqHandler, error) {
 	rh.Handler = h.Handler
 	rh.Store = store
 	rh.Cache = entitycache.New(store)
-	rh.Cache.AddEntityFields(requiredEntityFields...)
-	rh.Cache.AddBaseEntityFields(v5.RequiredBaseEntityFields...)
+	rh.Cache.AddEntityFields(requiredEntityFields)
+	rh.Cache.AddBaseEntityFields(v5.RequiredBaseEntityFields)
 	return rh, nil
 }
 
@@ -138,7 +145,7 @@ func (h ReqHandler) ResolveURLs(urls []*charm.URL) ([]*router.ResolvedURL, error
 // It's defined as a separate function so it can be more
 // easily unit-tested.
 func resolveURL(cache *entitycache.Cache, url *charm.URL) (*router.ResolvedURL, error) {
-	entity, err := cache.Entity(url)
+	entity, err := cache.Entity(url, nil)
 	if err != nil && errgo.Cause(err) != params.ErrNotFound {
 		return nil, errgo.Mask(err)
 	}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -39,6 +39,7 @@ import (
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting/hashtesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v4"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 )
 
 var testPublicKey = bakery.PublicKey{
@@ -1539,10 +1540,13 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1))
 	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
 
+	cache := entitycache.New(s.store)
+	cache.AddEntityFields(map[string]int{"supportedseries": 1})
+	cache.AddEntityFields(v5.RequiredEntityFields)
 	for i, test := range resolveURLTests {
 		c.Logf("test %d: %s", i, test.url)
 		url := charm.MustParseURL(test.url)
-		rurl, err := v4.ResolveURL(entitycache.New(s.store), url)
+		rurl, err := v4.ResolveURL(cache, url)
 		if test.notFound {
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 			c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for ".*"`)

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -2546,28 +2546,6 @@ func entitySizeChecker(c *gc.C, data interface{}) {
 	c.Assert(response.Size, gc.Not(gc.Equals), int64(0))
 }
 
-func (s *APISuite) addPublicCharm(c *gc.C, charmName string, rurl *router.ResolvedURL) (*router.ResolvedURL, charm.Charm) {
-	ch := storetesting.Charms.CharmDir(charmName)
-	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
-	return rurl, ch
-}
-
-func (s *APISuite) addPublicBundle(c *gc.C, bundleName string, rurl *router.ResolvedURL) (*router.ResolvedURL, charm.Bundle) {
-	bundle := storetesting.Charms.BundleDir(bundleName)
-	err := s.store.AddBundleWithArchive(rurl, bundle)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
-	return rurl, bundle
-}
-
 func (s *APISuite) assertPutNonAdmin(c *gc.C, url string, val interface{}) {
 	s.assertPut0(c, url, val, false)
 }
@@ -3513,7 +3491,7 @@ func (s *APISuite) TestTooManyConcurrentRequests(c *gc.C) {
 		MaxMgoSessions: 1,
 	}
 	db := s.Session.DB("charmstore")
-	srv, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v5.NewAPIHandler})
+	srv, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"v5": v5.NewAPIHandler})
 	c.Assert(err, gc.IsNil)
 	defer srv.Close()
 

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -537,7 +537,7 @@ func (h *ReqHandler) bundleCharms(ids []string) (map[string]charm.Charm, error) 
 			// be returned to the user along with other bundle errors.
 			continue
 		}
-		e, err := h.Store.FindBestEntity(url, nil)
+		e, err := h.Cache.Entity(url, nil)
 		if err != nil {
 			if errgo.Cause(err) == params.ErrNotFound {
 				// Ignore this error too, for the same reasons

--- a/internal/v5/auth.go
+++ b/internal/v5/auth.go
@@ -279,7 +279,7 @@ func areAllowedEntities(entityIds []*router.ResolvedURL, allowedEntities string)
 // AuthorizeEntity checks that the given HTTP request
 // can access the entity with the given id.
 func (h *ReqHandler) AuthorizeEntity(id *router.ResolvedURL, req *http.Request) error {
-	baseEntity, err := h.Store.FindBaseEntity(&id.URL, charmstore.FieldSelector("acls", "developmentacls"))
+	baseEntity, err := h.Cache.BaseEntity(id.UserOwnedURL(), charmstore.FieldSelector("acls", "developmentacls"))
 	if err != nil {
 		if errgo.Cause(err) == params.ErrNotFound {
 			return errgo.WithCausef(nil, params.ErrNotFound, "entity %q not found", id)

--- a/internal/v5/bench_test.go
+++ b/internal/v5/bench_test.go
@@ -1,0 +1,47 @@
+package v5_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	gc "gopkg.in/check.v1"
+)
+
+type BenchmarkSuite struct {
+	commonSuite
+}
+
+var _ = gc.Suite(&BenchmarkSuite{})
+
+func (s *BenchmarkSuite) TestBenchmarkMeta(c *gc.C) {
+	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
+	srv := httptest.NewServer(s.srv)
+	defer srv.Close()
+	url := srv.URL + storeURL("wordpress/meta/archive-size")
+	c.Logf("benchmark start")
+	resp, err := http.Get(url)
+	if err != nil {
+		c.Fatalf("get failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		c.Fatalf("response failed with code %v", resp.Status)
+	}
+}
+
+func (s *BenchmarkSuite) BenchmarkMeta(c *gc.C) {
+	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
+	srv := httptest.NewServer(s.srv)
+	defer srv.Close()
+	url := srv.URL + storeURL("wordpress/meta/archive-size")
+	for i := 0; i < c.N; i++ {
+		resp, err := http.Get(url)
+		if err != nil {
+			c.Fatalf("get failed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			c.Fatalf("response failed with code %v", resp.Status)
+		}
+	}
+}


### PR DESCRIPTION
The cache is actually doing something useful now.
Benchmark shows a reasonable speedup for the
simple case (where the cache is most at risk
of slowing things down).

With the old API:

PASS: bench_test.go:31: BenchmarkSuite.BenchmarkMeta        2000       2391650 ns/op

With the new one:

PASS: bench_test.go:32: BenchmarkSuite.BenchmarkMeta        2000       1424191 ns/op

That's a ~40% improvement.

We've verified that only a single entity and base-entity request is made for a typical
metadata request.

Still to come: endpoints that use iterators, search, etc.
