### PR TITLE
internal/v5: use cache for relations-related endpoints

### DIFF
--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1776,9 +1777,13 @@ func (s *ArchiveSuiteWithTerms) TestGetUserHasAgreedToTermsAndConditions(c *gc.C
 	termsDischargeAccessed := false
 	s.dischargeTerms = func(cond, args string) ([]checkers.Caveat, error) {
 		termsDischargeAccessed = true
-		if cond != "has-agreed" || args != "terms-1/1 terms-2/5" {
-			c.Logf("terms %#v", args)
-			return nil, errgo.New("discharge error")
+		if cond != "has-agreed" {
+			return nil, errgo.New("unexpected condition")
+		}
+		terms := strings.Fields(args)
+		sort.Strings(terms)
+		if strings.Join(terms, " ") != "terms-1/1 terms-2/5" {
+			return nil, errgo.New("unexpected terms in condition")
 		}
 		return nil, nil
 	}

--- a/internal/v5/bench_test.go
+++ b/internal/v5/bench_test.go
@@ -4,7 +4,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 )
 
 type BenchmarkSuite struct {
@@ -34,6 +38,7 @@ func (s *BenchmarkSuite) BenchmarkMeta(c *gc.C) {
 	srv := httptest.NewServer(s.srv)
 	defer srv.Close()
 	url := srv.URL + storeURL("wordpress/meta/archive-size")
+	c.ResetTimer()
 	for i := 0; i < c.N; i++ {
 		resp, err := http.Get(url)
 		if err != nil {
@@ -44,4 +49,143 @@ func (s *BenchmarkSuite) BenchmarkMeta(c *gc.C) {
 			c.Fatalf("response failed with code %v", resp.Status)
 		}
 	}
+}
+
+var benchmarkCharmRelatedAddCharms = map[string]charm.Charm{
+	"0 ~charmers/trusty/wordpress-0": &relationTestingCharm{
+		requires: map[string]charm.Relation{
+			"cache": {
+				Name:      "cache",
+				Role:      "requirer",
+				Interface: "memcache",
+			},
+			"nfs": {
+				Name:      "nfs",
+				Role:      "requirer",
+				Interface: "mount",
+			},
+		},
+	},
+	"1 ~charmers/utopic/memcached-1": &relationTestingCharm{
+		provides: map[string]charm.Relation{
+			"cache": {
+				Name:      "cache",
+				Role:      "provider",
+				Interface: "memcache",
+			},
+		},
+	},
+	"2 ~charmers/utopic/memcached-2": &relationTestingCharm{
+		provides: map[string]charm.Relation{
+			"cache": {
+				Name:      "cache",
+				Role:      "provider",
+				Interface: "memcache",
+			},
+		},
+	},
+	"90 ~charmers/utopic/redis-90": &relationTestingCharm{
+		provides: map[string]charm.Relation{
+			"cache": {
+				Name:      "cache",
+				Role:      "provider",
+				Interface: "memcache",
+			},
+		},
+	},
+	"47 ~charmers/trusty/nfs-47": &relationTestingCharm{
+		provides: map[string]charm.Relation{
+			"nfs": {
+				Name:      "nfs",
+				Role:      "provider",
+				Interface: "mount",
+			},
+		},
+	},
+	"42 ~charmers/precise/nfs-42": &relationTestingCharm{
+		provides: map[string]charm.Relation{
+			"nfs": {
+				Name:      "nfs",
+				Role:      "provider",
+				Interface: "mount",
+			},
+		},
+	},
+	"47 ~charmers/precise/nfs-47": &relationTestingCharm{
+		provides: map[string]charm.Relation{
+			"nfs": {
+				Name:      "nfs",
+				Role:      "provider",
+				Interface: "mount",
+			},
+		},
+	},
+}
+
+var benchmarkCharmRelatedExpectBody = params.RelatedResponse{
+	Provides: map[string][]params.MetaAnyResponse{
+		"memcache": {{
+			Id: charm.MustParseURL("utopic/memcached-1"),
+			Meta: map[string]interface{}{
+				"archive-size": params.ArchiveSizeResponse{Size: fakeBlobSize},
+			},
+		}, {
+			Id: charm.MustParseURL("utopic/memcached-2"),
+			Meta: map[string]interface{}{
+				"archive-size": params.ArchiveSizeResponse{Size: fakeBlobSize},
+			},
+		}, {
+			Id: charm.MustParseURL("utopic/redis-90"),
+			Meta: map[string]interface{}{
+				"archive-size": params.ArchiveSizeResponse{Size: fakeBlobSize},
+			},
+		}},
+		"mount": {{
+			Id: charm.MustParseURL("precise/nfs-42"),
+			Meta: map[string]interface{}{
+				"archive-size": params.ArchiveSizeResponse{Size: fakeBlobSize},
+			},
+		}, {
+			Id: charm.MustParseURL("precise/nfs-47"),
+			Meta: map[string]interface{}{
+				"archive-size": params.ArchiveSizeResponse{Size: fakeBlobSize},
+			},
+		}, {
+			Id: charm.MustParseURL("trusty/nfs-47"),
+			Meta: map[string]interface{}{
+				"archive-size": params.ArchiveSizeResponse{Size: fakeBlobSize},
+			},
+		}},
+	},
+}
+
+func (s *BenchmarkSuite) BenchmarkCharmRelated(c *gc.C) {
+	s.addCharms(c, benchmarkCharmRelatedAddCharms)
+	expectBody := benchmarkCharmRelatedExpectBody
+	srv := httptest.NewServer(s.srv)
+	defer srv.Close()
+	url := srv.URL + storeURL("trusty/wordpress-0/meta/charm-related?include=archive-size")
+	c.ResetTimer()
+	for i := 0; i < c.N; i++ {
+		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+			Handler:      s.srv,
+			URL:          url,
+			ExpectStatus: http.StatusOK,
+			ExpectBody:   expectBody,
+		})
+	}
+}
+
+func (s *BenchmarkSuite) TestCharmRelated(c *gc.C) {
+	s.addCharms(c, benchmarkCharmRelatedAddCharms)
+	expectBody := benchmarkCharmRelatedExpectBody
+	srv := httptest.NewServer(s.srv)
+	defer srv.Close()
+	url := srv.URL + storeURL("trusty/wordpress-0/meta/charm-related?include=archive-size")
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		URL:          url,
+		ExpectStatus: http.StatusOK,
+		ExpectBody:   expectBody,
+	})
 }

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -419,34 +419,6 @@ var metaCharmRelatedTests = []struct {
 	},
 }}
 
-func (s *RelationsSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
-	for id, ch := range charms {
-		url := mustParseResolvedURL(id)
-		// The blob related info are not used in these tests.
-		// The related charms are retrieved from the entities collection,
-		// without accessing the blob store.
-		err := s.store.AddCharm(ch, charmstore.AddParams{
-			URL:      url,
-			BlobName: "blobName",
-			BlobHash: fakeBlobHash,
-			BlobSize: fakeBlobSize,
-		})
-		c.Assert(err, gc.IsNil, gc.Commentf("id %q", id))
-		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
-		if url.Development {
-			err = s.store.SetPerms(url.UserOwnedURL(), "read", params.Everyone, url.URL.User)
-		}
-	}
-}
-
-func (s *RelationsSuite) setPerms(c *gc.C, readACLs map[string][]string) {
-	for url, acl := range readACLs {
-		err := s.store.SetPerms(charm.MustParseURL(url), "read", acl...)
-		c.Assert(err, gc.IsNil)
-	}
-}
-
 func (s *RelationsSuite) TestMetaCharmRelated(c *gc.C) {
 	for i, test := range metaCharmRelatedTests {
 		c.Logf("test %d: %s", i, test.about)

--- a/internal/v5/search.go
+++ b/internal/v5/search.go
@@ -58,7 +58,7 @@ func (h *ReqHandler) Search(sp charmstore.SearchParams, req *http.Request) (inte
 	}, nil
 }
 
-//addMetada adds the requested meta data with the include list.
+// addMetaData adds the requested meta data with the include list.
 func (h *ReqHandler) addMetaData(results []*mongodoc.Entity, include []string, req *http.Request) []params.EntityResult {
 	entities := make([]params.EntityResult, len(results))
 	run := parallel.NewRun(maxConcurrency)


### PR DESCRIPTION
Also fix an intermittent test failure in TestGetUserHasAgreedToTermsAndConditions.

The new benchmark shows a ~50% speedup from the old code, which will
only get better when the database is remote.

Old code:

PASS: bench_test.go:162: BenchmarkSuite.BenchmarkCharmRelated        500       9137372 ns/op

New code:

PASS: bench_test.go:162: BenchmarkSuite.BenchmarkCharmRelated       1000       4874554 ns/op

Here are the database operations invoked by the old code (running BenchmarkSuite.TestCharmRelated). They all run sequentially:

```
FindBestEntity cs:trusty/wordpress-0
FindBaseEntity cs:~charmers/trusty/wordpress-0
FindEntity cs:trusty/wordpress-0
FindBaseEntity cs:~charmers/utopic/memcached-1
FindEntity cs:utopic/memcached-1
FindBaseEntity cs:~charmers/utopic/memcached-2
FindEntity cs:utopic/memcached-2
FindBaseEntity cs:~charmers/utopic/redis-90
FindEntity cs:utopic/redis-90
FindBaseEntity cs:~charmers/precise/nfs-42
FindEntity cs:precise/nfs-42
FindBaseEntity cs:~charmers/precise/nfs-47
FindEntity cs:precise/nfs-47
FindBaseEntity cs:~charmers/trusty/nfs-47
FindEntity cs:trusty/nfs-47
```

And with the new code. The last three FindBaseEntity operations
run concurrently.

```
FindBestEntity cs:trusty/wordpress-0
FindBaseEntity cs:~charmers/wordpress
FindBaseEntity cs:~charmers/nfs
FindBaseEntity cs:~charmers/memcached
FindBaseEntity cs:~charmers/redis
```
