### PR TITLE
internal/v5: use EntityResult in charm-related response

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -19,7 +19,7 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	a3d228ef5292531219d17d47679b260580fba1a8	2015-11-19T07:39:58Z
-gopkg.in/juju/charmrepo.v2-unstable	git	b17697d8bb60cdac7d8ffd61e1357c9977cc2096	2015-11-30T13:55:09Z
+gopkg.in/juju/charmrepo.v2-unstable	git	7dae7dfe5f90a5728920ac2a2c43e563b1b90d0c	2016-01-11T16:49:48Z
 gopkg.in/juju/jujusvg.v1	git	2c97ff517dee12dc48bb3c2d2b113e5045a75b71	2015-11-19T14:54:17Z
 gopkg.in/macaroon-bakery.v1	git	7b63aca524cc3f7b1ad0171e54cb78b33ce1e747	2015-12-01T10:11:23Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z

--- a/internal/v4/list_test.go
+++ b/internal/v4/list_test.go
@@ -222,7 +222,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 		query: "name=wordpress&type=charm&include=charm-related",
 		meta: map[string]interface{}{
 			"charm-related": params.RelatedResponse{
-				Provides: map[string][]params.MetaAnyResponse{
+				Provides: map[string][]params.EntityResult{
 					"mysql": {
 						{
 							Id: exportTestCharms["mysql"].PreferredURL(),
@@ -241,7 +241,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 		query: "name=wordpress&type=charm&include=charm-related&include=charm-config",
 		meta: map[string]interface{}{
 			"charm-related": params.RelatedResponse{
-				Provides: map[string][]params.MetaAnyResponse{
+				Provides: map[string][]params.EntityResult{
 					"mysql": {
 						{
 							Id: exportTestCharms["mysql"].PreferredURL(),

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -92,8 +92,8 @@ func (h *ReqHandler) getRelatedCharmsResponse(
 	getInterfaces entityRelatedInterfacesGetter,
 	includes []string,
 	req *http.Request,
-) (map[string][]params.MetaAnyResponse, error) {
-	results := make(map[string][]params.MetaAnyResponse, len(ifaces))
+) (map[string][]params.EntityResult, error) {
+	results := make(map[string][]params.EntityResult, len(ifaces))
 	for _, iface := range ifaces {
 		responses, err := h.getRelatedIfaceResponses(iface, entities, getInterfaces, includes, req)
 		if err != nil {
@@ -112,7 +112,7 @@ func (h *ReqHandler) getRelatedIfaceResponses(
 	getInterfaces entityRelatedInterfacesGetter,
 	includes []string,
 	req *http.Request,
-) ([]params.MetaAnyResponse, error) {
+) ([]params.EntityResult, error) {
 	// Build a list of responses including only entities which are related
 	// to the given interface.
 	usesInterface := func(e *mongodoc.Entity) bool {
@@ -131,8 +131,8 @@ func (h *ReqHandler) getRelatedIfaceResponses(
 	return resp, nil
 }
 
-func (h *ReqHandler) getMetadataForEntities(entities []*mongodoc.Entity, includes []string, req *http.Request, includeEntity func(*mongodoc.Entity) bool) ([]params.MetaAnyResponse, error) {
-	response := make([]params.MetaAnyResponse, 0, len(entities))
+func (h *ReqHandler) getMetadataForEntities(entities []*mongodoc.Entity, includes []string, req *http.Request, includeEntity func(*mongodoc.Entity) bool) ([]params.EntityResult, error) {
+	response := make([]params.EntityResult, 0, len(entities))
 	err := expandMultiSeries(entities, func(series string, e *mongodoc.Entity) error {
 		if includeEntity != nil && !includeEntity(e) {
 			return nil
@@ -146,7 +146,7 @@ func (h *ReqHandler) getMetadataForEntities(entities []*mongodoc.Entity, include
 		}
 		id := e.PreferredURL(true)
 		id.Series = series
-		response = append(response, params.MetaAnyResponse{
+		response = append(response, params.EntityResult{
 			Id:   id,
 			Meta: meta,
 		})

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -136,7 +136,7 @@ var metaCharmRelatedTests = []struct {
 	id:     "utopic/wordpress-0",
 	// V4 SPECIFIC
 	expectBody: params.RelatedResponse{
-		Provides: map[string][]params.MetaAnyResponse{
+		Provides: map[string][]params.EntityResult{
 			"memcache": {{
 				Id: charm.MustParseURL("utopic/memcached-42"),
 			}},
@@ -144,7 +144,7 @@ var metaCharmRelatedTests = []struct {
 				Id: charm.MustParseURL("precise/nfs-1"),
 			}},
 		},
-		Requires: map[string][]params.MetaAnyResponse{
+		Requires: map[string][]params.EntityResult{
 			"http": {{
 				Id: charm.MustParseURL("precise/multi-series-1"),
 			}, {
@@ -163,7 +163,7 @@ var metaCharmRelatedTests = []struct {
 	charms: metaCharmRelatedCharms,
 	id:     "trusty/haproxy-47",
 	expectBody: params.RelatedResponse{
-		Provides: map[string][]params.MetaAnyResponse{
+		Provides: map[string][]params.EntityResult{
 			"http": {{
 				Id: charm.MustParseURL("utopic/wordpress-0"),
 			}},
@@ -174,7 +174,7 @@ var metaCharmRelatedTests = []struct {
 	charms: metaCharmRelatedCharms,
 	id:     "utopic/memcached-42",
 	expectBody: params.RelatedResponse{
-		Requires: map[string][]params.MetaAnyResponse{
+		Requires: map[string][]params.EntityResult{
 			"memcache": {{
 				Id: charm.MustParseURL("utopic/wordpress-0"),
 			}},
@@ -254,7 +254,7 @@ var metaCharmRelatedTests = []struct {
 	},
 	id: "trusty/wordpress-0",
 	expectBody: params.RelatedResponse{
-		Provides: map[string][]params.MetaAnyResponse{
+		Provides: map[string][]params.EntityResult{
 			"memcache": {{
 				Id: charm.MustParseURL("utopic/memcached-1"),
 			}, {
@@ -338,7 +338,7 @@ var metaCharmRelatedTests = []struct {
 	},
 	id: "trusty/wordpress-0",
 	expectBody: params.RelatedResponse{
-		Provides: map[string][]params.MetaAnyResponse{
+		Provides: map[string][]params.EntityResult{
 			"memcache": {{
 				Id: charm.MustParseURL("utopic/memcached-1"),
 			}, {
@@ -361,7 +361,7 @@ var metaCharmRelatedTests = []struct {
 	id:          "precise/nfs-1",
 	querystring: "?include=archive-size&include=charm-metadata",
 	expectBody: params.RelatedResponse{
-		Requires: map[string][]params.MetaAnyResponse{
+		Requires: map[string][]params.EntityResult{
 			"mount": {{
 				Id: charm.MustParseURL("utopic/wordpress-0"),
 				Meta: map[string]interface{}{

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -370,7 +370,7 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		query: "name=wordpress&type=charm&include=charm-related",
 		meta: map[string]interface{}{
 			"charm-related": params.RelatedResponse{
-				Provides: map[string][]params.MetaAnyResponse{
+				Provides: map[string][]params.EntityResult{
 					"mysql": {
 						{
 							Id: exportTestCharms["mysql"].PreferredURL(),
@@ -389,7 +389,7 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		query: "name=wordpress&type=charm&include=charm-related&include=charm-config",
 		meta: map[string]interface{}{
 			"charm-related": params.RelatedResponse{
-				Provides: map[string][]params.MetaAnyResponse{
+				Provides: map[string][]params.EntityResult{
 					"mysql": {
 						{
 							Id: exportTestCharms["mysql"].PreferredURL(),

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -479,7 +479,7 @@ var metaEndpoints = []metaEndpoint{{
 }, {
 	name: "terms",
 	get: func(store *charmstore.Store, url *router.ResolvedURL) (interface{}, error) {
-		doc, err := store.FindEntity(url)
+		doc, err := store.FindEntity(url, nil)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -21,10 +21,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/errgo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	charmtesting "gopkg.in/juju/charmrepo.v2-unstable/testing"

--- a/internal/v5/bench_test.go
+++ b/internal/v5/bench_test.go
@@ -123,7 +123,7 @@ var benchmarkCharmRelatedAddCharms = map[string]charm.Charm{
 }
 
 var benchmarkCharmRelatedExpectBody = params.RelatedResponse{
-	Provides: map[string][]params.MetaAnyResponse{
+	Provides: map[string][]params.EntityResult{
 		"memcache": {{
 			Id: charm.MustParseURL("utopic/memcached-1"),
 			Meta: map[string]interface{}{

--- a/internal/v5/list_test.go
+++ b/internal/v5/list_test.go
@@ -222,7 +222,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 		query: "name=wordpress&type=charm&include=charm-related",
 		meta: map[string]interface{}{
 			"charm-related": params.RelatedResponse{
-				Provides: map[string][]params.MetaAnyResponse{
+				Provides: map[string][]params.EntityResult{
 					"mysql": {
 						{
 							Id: exportTestCharms["mysql"].PreferredURL(),
@@ -241,7 +241,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 		query: "name=wordpress&type=charm&include=charm-related&include=charm-config",
 		meta: map[string]interface{}{
 			"charm-related": params.RelatedResponse{
-				Provides: map[string][]params.MetaAnyResponse{
+				Provides: map[string][]params.EntityResult{
 					"mysql": {
 						{
 							Id: exportTestCharms["mysql"].PreferredURL(),

--- a/internal/v5/relations.go
+++ b/internal/v5/relations.go
@@ -103,8 +103,8 @@ func (h *ReqHandler) getRelatedCharmsResponse(
 	getInterfaces entityRelatedInterfacesGetter,
 	includes []string,
 	req *http.Request,
-) (map[string][]params.MetaAnyResponse, error) {
-	results := make(map[string][]params.MetaAnyResponse, len(ifaces))
+) (map[string][]params.EntityResult, error) {
+	results := make(map[string][]params.EntityResult, len(ifaces))
 	for _, iface := range ifaces {
 		responses, err := h.getRelatedIfaceResponses(iface, entities, getInterfaces, includes, req)
 		if err != nil {
@@ -123,7 +123,7 @@ func (h *ReqHandler) getRelatedIfaceResponses(
 	getInterfaces entityRelatedInterfacesGetter,
 	includes []string,
 	req *http.Request,
-) ([]params.MetaAnyResponse, error) {
+) ([]params.EntityResult, error) {
 	// Build a list of responses including only entities which are related
 	// to the given interface.
 	usesInterface := func(e *mongodoc.Entity) bool {
@@ -255,9 +255,9 @@ func (h *ReqHandler) metaBundlesContaining(entity *mongodoc.Entity, id *router.R
 	return resp, nil
 }
 
-func (h *ReqHandler) getMetadataForEntities(entities []*mongodoc.Entity, includes []string, req *http.Request, includeEntity func(*mongodoc.Entity) bool) ([]params.MetaAnyResponse, error) {
+func (h *ReqHandler) getMetadataForEntities(entities []*mongodoc.Entity, includes []string, req *http.Request, includeEntity func(*mongodoc.Entity) bool) ([]params.EntityResult, error) {
 	// TODO(rog) make this concurrent.
-	response := make([]params.MetaAnyResponse, 0, len(entities))
+	response := make([]params.EntityResult, 0, len(entities))
 	for _, e := range entities {
 		if includeEntity != nil && !includeEntity(e) {
 			continue
@@ -269,7 +269,7 @@ func (h *ReqHandler) getMetadataForEntities(entities []*mongodoc.Entity, include
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}
-		response = append(response, params.MetaAnyResponse{
+		response = append(response, params.EntityResult{
 			Id:   e.PreferredURL(true),
 			Meta: meta,
 		})

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -143,7 +143,7 @@ var metaCharmRelatedTests = []struct {
 	charms: metaCharmRelatedCharms,
 	id:     "utopic/wordpress-0",
 	expectBody: params.RelatedResponse{
-		Provides: map[string][]params.MetaAnyResponse{
+		Provides: map[string][]params.EntityResult{
 			"memcache": {{
 				Id: charm.MustParseURL("utopic/memcached-42"),
 			}},
@@ -151,7 +151,7 @@ var metaCharmRelatedTests = []struct {
 				Id: charm.MustParseURL("precise/nfs-1"),
 			}},
 		},
-		Requires: map[string][]params.MetaAnyResponse{
+		Requires: map[string][]params.EntityResult{
 			"http": {{
 				Id: charm.MustParseURL("multi-series-1"),
 			}, {
@@ -166,7 +166,7 @@ var metaCharmRelatedTests = []struct {
 	charms: metaCharmRelatedCharms,
 	id:     "trusty/haproxy-47",
 	expectBody: params.RelatedResponse{
-		Provides: map[string][]params.MetaAnyResponse{
+		Provides: map[string][]params.EntityResult{
 			"http": {{
 				Id: charm.MustParseURL("utopic/wordpress-0"),
 			}},
@@ -177,7 +177,7 @@ var metaCharmRelatedTests = []struct {
 	charms: metaCharmRelatedCharms,
 	id:     "utopic/memcached-42",
 	expectBody: params.RelatedResponse{
-		Requires: map[string][]params.MetaAnyResponse{
+		Requires: map[string][]params.EntityResult{
 			"memcache": {{
 				Id: charm.MustParseURL("utopic/wordpress-0"),
 			}},
@@ -257,7 +257,7 @@ var metaCharmRelatedTests = []struct {
 	},
 	id: "trusty/wordpress-0",
 	expectBody: params.RelatedResponse{
-		Provides: map[string][]params.MetaAnyResponse{
+		Provides: map[string][]params.EntityResult{
 			"memcache": {{
 				Id: charm.MustParseURL("utopic/memcached-1"),
 			}, {
@@ -341,7 +341,7 @@ var metaCharmRelatedTests = []struct {
 	},
 	id: "trusty/wordpress-0",
 	expectBody: params.RelatedResponse{
-		Provides: map[string][]params.MetaAnyResponse{
+		Provides: map[string][]params.EntityResult{
 			"memcache": {{
 				Id: charm.MustParseURL("utopic/memcached-1"),
 			}, {
@@ -364,7 +364,7 @@ var metaCharmRelatedTests = []struct {
 	id:          "precise/nfs-1",
 	querystring: "?include=archive-size&include=charm-metadata",
 	expectBody: params.RelatedResponse{
-		Requires: map[string][]params.MetaAnyResponse{
+		Requires: map[string][]params.EntityResult{
 			"mount": {{
 				Id: charm.MustParseURL("utopic/wordpress-0"),
 				Meta: map[string]interface{}{
@@ -402,12 +402,12 @@ var metaCharmRelatedTests = []struct {
 	},
 	id: "utopic/wordpress-0",
 	expectBody: params.RelatedResponse{
-		Provides: map[string][]params.MetaAnyResponse{
+		Provides: map[string][]params.EntityResult{
 			"mount": {{
 				Id: charm.MustParseURL("precise/nfs-1"),
 			}},
 		},
-		Requires: map[string][]params.MetaAnyResponse{
+		Requires: map[string][]params.EntityResult{
 			"http": {{
 				Id: charm.MustParseURL("multi-series-1"),
 			}, {

--- a/internal/v5/search_test.go
+++ b/internal/v5/search_test.go
@@ -508,7 +508,7 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		query: "name=wordpress&type=charm&include=charm-related",
 		meta: map[string]interface{}{
 			"charm-related": params.RelatedResponse{
-				Provides: map[string][]params.MetaAnyResponse{
+				Provides: map[string][]params.EntityResult{
 					"mysql": {
 						{
 							Id: exportTestCharms["mysql"].PreferredURL(),
@@ -527,7 +527,7 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		query: "name=wordpress&type=charm&include=charm-related&include=charm-config",
 		meta: map[string]interface{}{
 			"charm-related": params.RelatedResponse{
-				Provides: map[string][]params.MetaAnyResponse{
+				Provides: map[string][]params.EntityResult{
 					"mysql": {
 						{
 							Id: exportTestCharms["mysql"].PreferredURL(),


### PR DESCRIPTION
This means we'll be able to use the same functions across all list endpoints
without unnecessary slice copying.
