### PR TITLE
use entitycache for list endpoints

### DIFF
--- a/internal/entitycache/export_test.go
+++ b/internal/entitycache/export_test.go
@@ -1,20 +1,5 @@
 package entitycache
 
-type TestIter interface {
-	SetFields(fields map[string]int)
-	mgoIter
-}
-
-func CacheIter(c *Cache, iter TestIter, fields map[string]int) *Iter {
-	c.entities.mu.Lock()
-	defer c.entities.mu.Unlock()
-	// Note: this is exactly the same as Cache.Iter except that
-	// it doesn't actually call the Query methods.
-	c.entities.addFields(fields)
-	iter.SetFields(c.entities.fields)
-	return c.iter(iter)
-}
-
 var (
 	RequiredEntityFields     = requiredEntityFields
 	RequiredBaseEntityFields = requiredBaseEntityFields

--- a/internal/v5/bench_test.go
+++ b/internal/v5/bench_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
-
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 )
 

--- a/internal/v5/list_test.go
+++ b/internal/v5/list_test.go
@@ -44,7 +44,6 @@ var exportListTestBundles = map[string]*router.ResolvedURL{
 }
 
 func (s *ListSuite) SetUpSuite(c *gc.C) {
-	s.enableES = true
 	s.enableIdentity = true
 	s.commonSuite.SetUpSuite(c)
 }
@@ -61,10 +60,6 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 			},
 		}}},
 	)
-	c.Assert(err, gc.IsNil)
-	err = s.store.UpdateSearch(newResolvedURL("~charmers/trusty/riak-0", 0))
-	c.Assert(err, gc.IsNil)
-	err = s.esSuite.ES.RefreshIndex(s.esSuite.TestIndex)
 	c.Assert(err, gc.IsNil)
 }
 


### PR DESCRIPTION
We make the entitycache package API slightly more general
so that it can deal with the output of the list pipe.
