### PR TITLE
internal/v5: fix panic on public write perms

### DIFF
--- a/internal/v5/stats.go
+++ b/internal/v5/stats.go
@@ -115,7 +115,7 @@ func (h *ReqHandler) serveStatsCounter(_ http.Header, r *http.Request) (interfac
 // PUT stats/update
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#put-statsupdate
 func (h *ReqHandler) serveStatsUpdate(w http.ResponseWriter, r *http.Request) error {
-	if _, err := h.authorize(r, []string {"statsupdate@cs"}, true, nil); err != nil {
+	if _, err := h.authorize(r, []string{"statsupdate@cs"}, true, nil); err != nil {
 		return err
 	}
 	if r.Method != "PUT" {

--- a/internal/v5/stats_test.go
+++ b/internal/v5/stats_test.go
@@ -324,14 +324,14 @@ func (s *StatsSuite) TestServerStatsUpdatePartOfStatsUpdateGroup(c *gc.C) {
 
 	s.discharge = dischargeForUser("statsupdate")
 	s.idM.groups = map[string][]string{
-		"statsupdate": []string {"statsupdate@cs"},
+		"statsupdate": []string{"statsupdate@cs"},
 	}
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler:  s.srv,
-		URL:      storeURL("stats/update"),
-		Do:       bakeryDo(nil),
-		Method:   "PUT",
+		Handler: s.srv,
+		URL:     storeURL("stats/update"),
+		Do:      bakeryDo(nil),
+		Method:  "PUT",
 		JSONBody: params.StatsUpdateRequest{
 			Entries: []params.StatsUpdateEntry{{
 				Timestamp:      time.Now(),


### PR DESCRIPTION
When write perms on an entity allowed "everyone", the auth
check did not bother checking any authorization, as none
was required. Unfortunately this meant that the code would
panic later when it tried to add an audit log entry but found
no username. We fix the issue by always requiring authorization
for non-read operations.
