### PR TITLE
internal/v5: set cookie name

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -16,12 +16,12 @@ github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:1
 github.com/julienschmidt/httprouter	git	109e267447e95ad1bb48b758e40dd7453eb7b039	2015-09-05T17:25:33Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
-gopkg.in/check.v1	git	b3d3430320d4260e5fea99841af984b3badcea63	2015-06-26T10:50:28Z
+gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	a3d228ef5292531219d17d47679b260580fba1a8	2015-11-19T07:39:58Z
 gopkg.in/juju/charmrepo.v2-unstable	git	7dae7dfe5f90a5728920ac2a2c43e563b1b90d0c	2016-01-11T16:49:48Z
 gopkg.in/juju/jujusvg.v1	git	a0c526a74b02b392b76cd02402d7438db1fc757a	2015-12-04T20:24:49Z
-gopkg.in/macaroon-bakery.v1	git	7b63aca524cc3f7b1ad0171e54cb78b33ce1e747	2015-12-01T10:11:23Z
+gopkg.in/macaroon-bakery.v1	git	a165ebf9a2ce170e430ee2360dab11c70c22062c	2016-01-19T15:40:20Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -133,7 +133,7 @@ func init() {
 }
 
 func (s *migrationsSuite) newServer(c *gc.C) error {
-	apiHandler := func(p *Pool, config ServerParams) HTTPCloseHandler {
+	apiHandler := func(p *Pool, config ServerParams, _ string) HTTPCloseHandler {
 		return nopCloseHandler{http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})}
 	}
 	srv, err := NewServer(s.db.Database, nil, serverParams, map[string]NewAPIHandlerFunc{

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -20,8 +20,9 @@ import (
 )
 
 // NewAPIHandlerFunc is a function that returns a new API handler that uses
-// the given Store.
-type NewAPIHandlerFunc func(*Pool, ServerParams) HTTPCloseHandler
+// the given Store. The absPath parameter holds the root path of the
+// API handler.
+type NewAPIHandlerFunc func(pool *Pool, p ServerParams, absPath string) HTTPCloseHandler
 
 // HTTPCloseHandler represents a HTTP handler that
 // must be closed after use.
@@ -135,8 +136,9 @@ func NewServer(db *mgo.Database, si *SearchIndex, config ServerParams, versions 
 	// Version independent API.
 	handle(srv.mux, "/debug", newServiceDebugHandler(pool, config, srv.mux))
 	for vers, newAPI := range versions {
-		h := newAPI(pool, config)
-		handle(srv.mux, "/"+vers, h)
+		root := "/" + vers
+		h := newAPI(pool, config, root)
+		handle(srv.mux, root, h)
 		srv.handlers = append(srv.handlers, h)
 	}
 

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -38,7 +38,7 @@ type versionResponse struct {
 func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	db := s.Session.DB("foo")
 	serveVersion := func(vers string) NewAPIHandlerFunc {
-		return func(p *Pool, config ServerParams) HTTPCloseHandler {
+		return func(p *Pool, config ServerParams, _ string) HTTPCloseHandler {
 			return nopCloseHandler{
 				router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 					return versionResponse{
@@ -91,7 +91,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 }
 
 func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
-	serveConfig := func(p *Pool, config ServerParams) HTTPCloseHandler {
+	serveConfig := func(p *Pool, config ServerParams, _ string) HTTPCloseHandler {
 		return nopCloseHandler{
 			router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 				return config, nil
@@ -111,7 +111,7 @@ func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
 }
 
 func (s *ServerSuite) TestNewServerWithElasticSearch(c *gc.C) {
-	serveConfig := func(p *Pool, config ServerParams) HTTPCloseHandler {
+	serveConfig := func(p *Pool, config ServerParams, _ string) HTTPCloseHandler {
 		return nopCloseHandler{
 			router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 				return config, nil

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -102,9 +102,9 @@ var reqHandlerPool = mempool.Pool{
 	},
 }
 
-func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams) charmstore.HTTPCloseHandler {
+func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string) charmstore.HTTPCloseHandler {
 	return &Handler{
-		v4: v4.New(pool, config),
+		v4: v4.New(pool, config, rootPath),
 	}
 }
 

--- a/internal/router/util.go
+++ b/internal/router/util.go
@@ -170,12 +170,12 @@ func (mux *ServeMux) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h.ServeHTTP(w, req)
 }
 
-// RelativeURLPath returns a relative URL path that is lexically equivalent to
-// targpath when interpreted by url.URL.ResolveReference.
-// On succes, the returned path will always be relative to basePath, even if basePath
-// and targPath share no elements. An error is returned if targPath can't
-// be made relative to basePath (for example when either basePath
-// or targetPath are non-absolute).
+// RelativeURLPath returns a relative URL path that is lexically
+// equivalent to targpath when interpreted by url.URL.ResolveReference.
+// On success, the returned path will always be non-empty and relative
+// to basePath, even if basePath and targPath share no elements.
+//
+// An error is returned if basePath or targPath are not absolute paths.
 func RelativeURLPath(basePath, targPath string) (string, error) {
 	if !strings.HasPrefix(basePath, "/") {
 		return "", errgo.Newf("non-absolute base URL")
@@ -208,7 +208,15 @@ func RelativeURLPath(basePath, targPath string) (string, error) {
 	}
 	result = append(result, targOnly...)
 	result = append(result, lastElem)
-	return strings.Join(result, "/"), nil
+	final := strings.Join(result, "/")
+	if final == "" {
+		// If the final result is empty, the last element must
+		// have been empty, so the target was slash terminated
+		// and there were no previous elements, so "."
+		// is appropriate.
+		final = "."
+	}
+	return final, nil
 }
 
 // TODO(mhilton) This is not an ideal place for UnmarshalJSONResponse,

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -50,19 +50,13 @@ type ReqHandler struct {
 	*v5.ReqHandler
 }
 
-func New(pool *charmstore.Pool, config charmstore.ServerParams) Handler {
+func New(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string) Handler {
 	return Handler{
-		Handler: v5.New(pool, config),
+		Handler: v5.New(pool, config, rootPath),
 	}
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	// When requests in this handler use router.RelativeURL, we want
-	// the "absolute path" there to be interpreted relative to the
-	// root of this handler, not the absolute root of the web server,
-	// which may be abitrarily many levels up.
-	req.RequestURI = req.URL.Path
-
 	rh, err := h.NewReqHandler()
 	if err != nil {
 		router.WriteError(w, err)
@@ -72,8 +66,8 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	rh.ServeHTTP(w, req)
 }
 
-func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams) charmstore.HTTPCloseHandler {
-	return New(pool, config)
+func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string) charmstore.HTTPCloseHandler {
+	return New(pool, config, rootPath)
 }
 
 // The v4 resolvedURL function also requires SupportedSeries.

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -157,6 +157,9 @@ func (j *cookieJar) SetCookies(url *url.URL, cookies []*http.Cookie) {
 		if cookie.Path != "" {
 			url1.Path = cookie.Path
 		}
+		if cookie.Name != "macaroon-authn" {
+			panic("unexpected cookie name: " + cookie.Name)
+		}
 	}
 	j.cookieURLs = append(j.cookieURLs, url1.String())
 	j.CookieJar.SetCookies(url, cookies)

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -189,7 +189,7 @@ func (s *commonSuite) startServer(c *gc.C) {
 // used to invoke private methods. The caller
 // is responsible for calling Put on the returned handler.
 func (s *commonSuite) handler(c *gc.C) v4.ReqHandler {
-	h := v4.New(s.store.Pool(), s.srvParams)
+	h := v4.New(s.store.Pool(), s.srvParams, "")
 	defer h.Close()
 	rh, err := h.NewReqHandler()
 	c.Assert(err, gc.IsNil)

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -157,6 +157,9 @@ func (j *cookieJar) SetCookies(url *url.URL, cookies []*http.Cookie) {
 		if cookie.Path != "" {
 			url1.Path = cookie.Path
 		}
+		if cookie.Name != "macaroon-authn" {
+			panic("unexpected cookie name: " + cookie.Name)
+		}
 	}
 	j.cookieURLs = append(j.cookieURLs, url1.String())
 	j.CookieJar.SetCookies(url, cookies)

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -267,7 +267,7 @@ func (s *commonSuite) setPerms(c *gc.C, readACLs map[string][]string) {
 // used to invoke private methods. The caller
 // is responsible for calling Put on the returned handler.
 func (s *commonSuite) handler(c *gc.C) *v5.ReqHandler {
-	h := v5.New(s.store.Pool(), s.srvParams)
+	h := v5.New(s.store.Pool(), s.srvParams, "")
 	defer h.Close()
 	rh, err := h.NewReqHandler()
 	c.Assert(err, gc.IsNil)

--- a/internal/v5/content.go
+++ b/internal/v5/content.go
@@ -39,7 +39,7 @@ func (h *ReqHandler) serveDiagram(id *router.ResolvedURL, w http.ResponseWriter,
 	canvas, err := jujusvg.NewFromBundle(entity.BundleData, func(id *charm.URL) string {
 		// TODO change jujusvg so that the iconURL function can
 		// return an error.
-		absPath := "/" + id.Path() + "/icon.svg"
+		absPath := h.Handler.rootPath + "/" + id.Path() + "/icon.svg"
 		p, err := router.RelativeURLPath(req.RequestURI, absPath)
 		if err != nil {
 			urlErr = errgo.Notef(err, "cannot make relative URL from %q and %q", req.RequestURI, absPath)


### PR DESCRIPTION
This required us to set the cookie on the charmstore root,
not just / (which would make it available to all services),
so we needed to fix RelativeURL somewhat and also this
led to a mild conflict with the way RelativeURL was used in
serveDiagram, where we want a URL relative to the
version-specific path, not to the root of the charm store.
We fix that by passing the version root path to the handler,
so it can use it to create the appropriate relative path.
