### PR TITLE
internal/charmstore: fix PromulgatedURL so that it doesn't contain dev channel

### DIFF
--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -463,6 +463,7 @@ func (s *Store) syncSearch() error {
 			return errgo.Notef(err, "cannot index %s", rurl)
 		}
 	}
+	logger.Infof("finished sync search")
 	if err := iter.Close(); err != nil {
 		return err
 	}

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -540,7 +540,7 @@ func (s *Store) AddCharm(c charm.Charm, p AddParams) (err error) {
 	logger.Infof("add charm url %s; prev %d; dev %v", &id, p.URL.PromulgatedRevision, p.URL.Development)
 	entity := &mongodoc.Entity{
 		URL:                     &id,
-		PromulgatedURL:          p.URL.PromulgatedURL(),
+		PromulgatedURL:          p.URL.DocPromulgatedURL(),
 		BlobHash:                p.BlobHash,
 		BlobHash256:             p.BlobHash256,
 		BlobName:                p.BlobName,
@@ -586,9 +586,6 @@ func (s *Store) AddCharm(c charm.Charm, p AddParams) (err error) {
 // if the entity URL does not contain a series. If the entity
 // URL *does* contain a series, e.SupportedSeries will
 // be overwritten.
-//
-// This is exported for the purposes of tests that
-// need to create directly into the database.
 func denormalizeEntity(e *mongodoc.Entity) {
 	e.BaseURL = mongodoc.BaseURL(e.URL)
 	e.Name = e.URL.Name
@@ -1074,7 +1071,7 @@ func (s *Store) AddBundle(b charm.Bundle, p AddParams) error {
 		BundleReadMe:       b.ReadMe(),
 		BundleCharms:       urls,
 		Contents:           p.Contents,
-		PromulgatedURL:     p.URL.PromulgatedURL(),
+		PromulgatedURL:     p.URL.DocPromulgatedURL(),
 		Development:        p.URL.Development,
 	}
 	denormalizeEntity(entity)

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -71,7 +71,7 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool, url *r
 		exists, err := store.ES.HasDocument(s.TestIndex, typeName, id)
 		c.Assert(err, gc.IsNil)
 		c.Assert(exists, gc.Equals, true)
-		if purl := url.PromulgatedURL(); purl != nil {
+		if purl := url.DocPromulgatedURL(); purl != nil {
 			c.Assert(result.PromulgatedURL, jc.DeepEquals, purl)
 		}
 	}
@@ -100,7 +100,7 @@ func (s *StoreSuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool, url *r
 		CharmConfig:             ch.Config(),
 		CharmProvidedInterfaces: []string{"http", "logging", "monitoring"},
 		CharmRequiredInterfaces: []string{"mysql", "varnish"},
-		PromulgatedURL:          url.PromulgatedURL(),
+		PromulgatedURL:          url.DocPromulgatedURL(),
 		SupportedSeries:         ch.Meta().Series,
 		Development:             url.Development,
 	}))
@@ -188,7 +188,7 @@ func (s *StoreSuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bool, 
 		},
 		BundleMachineCount: newInt(2),
 		BundleUnitCount:    newInt(2),
-		PromulgatedURL:     url.PromulgatedURL(),
+		PromulgatedURL:     url.DocPromulgatedURL(),
 		Development:        url.Development,
 	}))
 
@@ -280,7 +280,7 @@ var urlFindingTests = []struct {
 }, {
 	inStore: []string{"23 cs:~charmers/precise/wordpress-23", "24 cs:~charmers/precise/wordpress-24", "25 cs:~charmers/development/precise/wordpress-25"},
 	expand:  "development/wordpress",
-	expect:  []string{"25 cs:~charmers/development/precise/wordpress-25", "23 cs:~charmers/precise/wordpress-23", "24 cs:~charmers/precise/wordpress-24"},
+	expect:  []string{"23 cs:~charmers/precise/wordpress-23", "24 cs:~charmers/precise/wordpress-24", "25 cs:~charmers/precise/wordpress-25"},
 }, {
 	inStore: []string{"23 cs:~charmers/precise/wordpress-23", "24 cs:~charmers/trusty/wordpress-24", "25 cs:~charmers/development/precise/wordpress-25"},
 	expand:  "precise/wordpress",
@@ -288,7 +288,7 @@ var urlFindingTests = []struct {
 }, {
 	inStore: []string{"23 cs:~charmers/precise/wordpress-23", "24 cs:~charmers/trusty/wordpress-24", "25 cs:~charmers/development/precise/wordpress-25", "26 cs:~charmers/development/wily/wordpress-26"},
 	expand:  "development/precise/wordpress",
-	expect:  []string{"25 cs:~charmers/development/precise/wordpress-25", "23 cs:~charmers/precise/wordpress-23"},
+	expect:  []string{"23 cs:~charmers/precise/wordpress-23", "25 cs:~charmers/development/precise/wordpress-25"},
 }, {
 	inStore: []string{"23 cs:~charmers/precise/wordpress-23", "24 cs:~charmers/trusty/wordpress-24", "434 cs:~charmers/foo/varnish-434"},
 	expand:  "wordpress",
@@ -514,8 +514,8 @@ func (s *StoreSuite) TestFindEntities(c *gc.C) {
 		for i, url := range expect {
 			c.Assert(gotEntities[i], jc.DeepEquals, &mongodoc.Entity{
 				URL:            &url.URL,
-				PromulgatedURL: url.PromulgatedURL(),
-			})
+				PromulgatedURL: url.DocPromulgatedURL(),
+			}, gc.Commentf("index %d", i))
 		}
 
 		// check FindEntities works when retrieving all fields.
@@ -1871,6 +1871,7 @@ func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
 	}, {
 		URL: charm.MustParseURL("~pluto/wily/multi-series-1"),
 	}}
+	// TODO add development entities above.
 	for _, e := range entities {
 		err := store.DB.Entities().Insert(denormalizedEntity(e))
 		c.Assert(err, gc.IsNil)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -192,6 +192,17 @@ func (id *ResolvedURL) PreferredURL() *charm.URL {
 	return u
 }
 
+// DocPromulgatedURL the promulgated URL that
+// should be stored in the mongodoc.Entity.
+// It does not have the channel set.
+func (id *ResolvedURL) DocPromulgatedURL() *charm.URL {
+	u := id.PromulgatedURL()
+	if u != nil {
+		u.Channel = ""
+	}
+	return u
+}
+
 // PromulgatedURL returns the promulgated URL for id if there
 // is one, or nil otherwise.
 func (id *ResolvedURL) PromulgatedURL() *charm.URL {

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1091,7 +1091,7 @@ func (s *ArchiveSuite) assertUpload(c *gc.C, method string, url *router.Resolved
 	c.Assert(err, gc.IsNil)
 	c.Assert(entity.BlobHash, gc.Equals, hashSum)
 	c.Assert(entity.BlobHash256, gc.Equals, hash256Sum)
-	c.Assert(entity.PromulgatedURL, gc.DeepEquals, expectedPromulgatedId)
+	c.Assert(entity.PromulgatedURL, gc.DeepEquals, url.DocPromulgatedURL())
 	c.Assert(entity.Development, gc.Equals, url.Development)
 	// Test that the expected entry has been created
 	// in the blob store.

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -781,6 +781,7 @@ func (h *ReqHandler) metaRevisionInfo(id *router.ResolvedURL, path string, flags
 	}
 	var response params.RevisionInfoResponse
 	for _, doc := range docs {
+		// TODO use proper promulgated URL.
 		if id.PromulgatedRevision != -1 {
 			response.Revisions = append(response.Revisions, doc.PromulgatedURL)
 		} else {

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -1111,7 +1111,7 @@ func (s *commonArchiveSuite) assertUpload(c *gc.C, method string, url *router.Re
 	c.Assert(err, gc.IsNil)
 	c.Assert(entity.BlobHash, gc.Equals, hashSum)
 	c.Assert(entity.BlobHash256, gc.Equals, hash256Sum)
-	c.Assert(entity.PromulgatedURL, gc.DeepEquals, expectedPromulgatedId)
+	c.Assert(entity.PromulgatedURL, gc.DeepEquals, url.DocPromulgatedURL())
 	c.Assert(entity.Development, gc.Equals, url.Development)
 	// Test that the expected entry has been created
 	// in the blob store.


### PR DESCRIPTION
This fixes a bug where the development channel was appearing even though
the charm was published.
