### PR TITLE
wip: new charm store model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+audit.log
+charmload.err
 version/init.go

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -299,13 +299,15 @@ func (s *migrationsSuite) TestMigrateParallelMigration(c *gc.C) {
 		URL:            charm.MustParseURL("~charmers/trusty/django-42"),
 		PromulgatedURL: charm.MustParseURL("trusty/django-3"),
 		Size:           12,
+		Development:    true,
 	}
 	denormalizeEntity(e1)
 	s.insertEntity(c, e1, beforeAllMigrations)
 
 	e2 := &mongodoc.Entity{
-		URL:  charm.MustParseURL("~who/utopic/rails-47"),
-		Size: 13,
+		URL:         charm.MustParseURL("~who/utopic/rails-47"),
+		Size:        13,
+		Development: true,
 	}
 	denormalizeEntity(e2)
 	s.insertEntity(c, e2, beforeAllMigrations)

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -83,7 +83,7 @@ func (s *Store) UpdateSearch(r *router.ResolvedURL) error {
 	if s.ES == nil || s.ES.Database == nil {
 		return nil
 	}
-	if r.Development || r.URL.Series != "" && !series.Series[r.URL.Series].SearchIndex {
+	if r.URL.Series != "" && !series.Series[r.URL.Series].SearchIndex {
 		return nil
 	}
 
@@ -99,6 +99,9 @@ func (s *Store) UpdateSearch(r *router.ResolvedURL) error {
 			return errgo.WithCausef(nil, params.ErrNotFound, "entity not found %s", r)
 		}
 		return errgo.Notef(err, "cannot get %s", r)
+	}
+	if !entity.Stable {
+		return nil
 	}
 	baseEntity, err := s.FindBaseEntity(entity.BaseURL, nil)
 	if err != nil {

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -115,10 +115,14 @@ type Entity struct {
 	// If the entity is not promulgated this should be set to -1.
 	PromulgatedRevision int `bson:"promulgated-revision"`
 
-	// Development holds whether the entity is in development or published.
-	// A development entity can only be referred to using URLs including the
-	// "development" channel.
+	// Development holds whether the entity is or has been in marked as a
+	// development revision. A development entity can only be referred to
+	// using URLs including the "development" channel.
 	Development bool
+
+	// Stable holds whether the entity is or has been in marked as a stable
+	// revision.
+	Stable bool
 }
 
 // PreferredURL returns the preferred way to refer to this entity. If
@@ -159,13 +163,24 @@ type BaseEntity struct {
 	// be ignored when reading a charm.
 	Public bool
 
-	// ACLs holds permission information relevant to the base entity.
-	// The permissions apply to all revisions.
+	// ACLs holds permission information for unpublished entities.
 	ACLs ACL
 
-	// DevelopmentACLs is similar to ACLs but applies to all development
-	// revisions.
+	// StableACLs holds permission information relevant to the base entity.
+	// The permissions apply to all stable revisions.
+	StableACLs ACL
+
+	// DevelopmentACLs is similar to StableACLsACLs but applies to all
+	// development revisions.
 	DevelopmentACLs ACL
+
+	// DevelopmentSeries maps charm or bundle series to the URL of the current
+	// development charm or bundle.
+	DevelopmentSeries map[string]*charm.URL `bson:",omitempty" json:",omitempty"`
+
+	// StableSeries maps charm or bundle series to the URL of the current
+	// stable charm or bundle.
+	StableSeries map[string]*charm.URL `bson:",omitempty" json:",omitempty"`
 
 	// Promulgated specifies whether the charm or bundle should be
 	// promulgated.

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -31,6 +31,9 @@ func NewEntity(url string) EntityBuilder {
 			User:                URL.User,
 			BaseURL:             mongodoc.BaseURL(URL),
 			PromulgatedRevision: -1,
+			SupportedSeries:     []string{URL.Series},
+			Development:         true,
+			Stable:              true,
 		},
 	}
 }
@@ -110,10 +113,21 @@ func (b BaseEntityBuilder) WithPromulgated(promulgated bool) BaseEntityBuilder {
 	return b
 }
 
-// WithACLs sets the non-development ACLs field on the BaseEntity.
+// WithStableSeries sets the stable releases on the BaseEntity.
+func (b BaseEntityBuilder) WithStableSeries(series map[string]string) BaseEntityBuilder {
+	b = b.copy()
+	stableSeries := make(map[string]*charm.URL, len(series))
+	for s, u := range series {
+		stableSeries[s] = charm.MustParseURL(u)
+	}
+	b.baseEntity.StableSeries = stableSeries
+	return b
+}
+
+// WithACLs sets the stable ACLs field on the BaseEntity.
 func (b BaseEntityBuilder) WithACLs(acls mongodoc.ACL) BaseEntityBuilder {
 	b = b.copy()
-	b.baseEntity.ACLs = acls
+	b.baseEntity.StableACLs = acls
 	return b
 }
 

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -150,7 +150,7 @@ func resolveURL(cache *entitycache.Cache, url *charm.URL) (*router.ResolvedURL, 
 	rurl := &router.ResolvedURL{
 		URL:                 *entity.URL,
 		PromulgatedRevision: -1,
-		Development:         url.Channel == charm.DevelopmentChannel,
+		Development:         (url.Channel == charm.DevelopmentChannel) || (entity.Development && !entity.Stable),
 	}
 	if url.User == "" {
 		rurl.PromulgatedRevision = entity.PromulgatedRevision

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -593,9 +593,18 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	// its third party caveat.
 	s.discharge = dischargeForUser("bob")
 
+	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-22", 22))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-24", 24))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/trusty/wordpress-1", 1))
+
+	// Mark the first precise revision as both stable release and the second as
+	// development release.
+	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-22", 22), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), charm.DevelopmentChannel)
+	c.Assert(err, gc.IsNil)
+
 	s.assertGet(c, "wordpress/meta/perm", params.PermResponse{
 		Read:  []string{params.Everyone, "charmers"},
 		Write: []string{"charmers"},
@@ -608,30 +617,31 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.ACLs.Read, gc.DeepEquals, []string{params.Everyone, "charmers"})
 
-	// Change the published read perms to only include a specific user and the
-	// published write perms to include an "admin" user.
-	s.assertPut(c, "precise/wordpress-23/meta/perm/read", []string{"bob"})
-	s.assertPut(c, "precise/wordpress-23/meta/perm/write", []string{"admin"})
+	// Change the unpublished read perms to only include a specific user and
+	// the unpublished write perms to only include an "admin" user.
+	s.assertPut(c, "precise/wordpress-24/meta/perm/read", []string{"bob"})
+	s.assertPut(c, "precise/wordpress-24/meta/perm/write", []string{"admin"})
 
-	// Check that the perms have changed for all revisions and series.
-	for i, u := range []string{"precise/wordpress-23", "precise/wordpress-24", "trusty/wordpress-1"} {
+	// Check that the perms have changed for all unpublished revisions.
+	for i, u := range []string{"precise/wordpress-24", "trusty/wordpress-1"} {
 		c.Logf("id %d: %q", i, u)
-		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-			Handler: s.srv,
-			Do:      bakeryDo(nil),
-			URL:     storeURL(u + "/meta/perm"),
-			ExpectBody: params.PermResponse{
-				Read:  []string{"bob"},
-				Write: []string{"admin"},
-			},
-		})
-		// The development perms did not mutate.
-		s.assertGet(c, "development/"+u+"/meta/perm", params.PermResponse{
-			Read:  []string{params.Everyone, "charmers"},
-			Write: []string{"charmers"},
+		s.assertGet(c, u+"/meta/perm", params.PermResponse{
+			Read:  []string{"bob"},
+			Write: []string{"admin"},
 		})
 	}
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
+
+	// The stable and development perms did not mutate.
+	s.assertGet(c, "precise/wordpress-22/meta/perm", params.PermResponse{
+		Read:  []string{params.Everyone, "charmers"},
+		Write: []string{"charmers"},
+	})
+	s.assertGet(c, "development/precise/wordpress-23/meta/perm", params.PermResponse{
+		Read:  []string{params.Everyone, "charmers"},
+		Write: []string{"charmers"},
+	})
+
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-24"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsFalse)
 	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
@@ -642,14 +652,18 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read:  []string{params.Everyone, "charmers"},
 		Write: []string{"charmers"},
 	})
+	c.Assert(e.StableACLs, jc.DeepEquals, mongodoc.ACL{
+		Read:  []string{params.Everyone, "charmers"},
+		Write: []string{"charmers"},
+	})
 
-	// Try restoring everyone's read permission on the published charm, and
+	// Try adding bob's read permission on the stable charm, and
 	// adding write permissions to bob for the development charm.
 	s.assertPut(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
 	s.assertPut(c, "development/wordpress/meta/perm/write", []string{"bob", "admin"})
 	s.assertGet(c, "wordpress/meta/perm", params.PermResponse{
 		Read:  []string{"bob", params.Everyone},
-		Write: []string{"admin"},
+		Write: []string{"charmers"},
 	})
 	s.assertGet(c, "development/wordpress/meta/perm", params.PermResponse{
 		Read:  []string{params.Everyone, "charmers"},
@@ -661,12 +675,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsTrue)
 	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
-		Read:  []string{"bob", params.Everyone},
+		Read:  []string{"bob"},
 		Write: []string{"admin"},
 	})
 	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{
 		Read:  []string{params.Everyone, "charmers"},
 		Write: []string{"bob", "admin"},
+	})
+	c.Assert(e.StableACLs, jc.DeepEquals, mongodoc.ACL{
+		Read:  []string{"bob", params.Everyone},
+		Write: []string{"charmers"},
 	})
 
 	// Try deleting all development permissions.
@@ -684,17 +702,18 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	})
 	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
-	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
-	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsTrue)
-	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{})
 	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
-		Read:  []string{"bob", params.Everyone},
+		Read:  []string{"bob"},
 		Write: []string{"admin"},
 	})
+	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{})
+	c.Assert(e.StableACLs, jc.DeepEquals, mongodoc.ACL{
+		Read:  []string{"bob", params.Everyone},
+		Write: []string{"charmers"},
+	})
 
-	// Try deleting all published permissions.
+	// Try deleting all stable permissions.
 	s.assertPut(c, "wordpress/meta/perm/read", []string{})
 	s.assertPut(c, "wordpress/meta/perm/write", []string{})
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -710,10 +729,26 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsFalse)
-	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{})
-	c.Assert(e.ACLs.Read, gc.DeepEquals, []string{})
+	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
+		Read:  []string{"bob"},
+		Write: []string{"admin"},
+	})
+	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{})
+	c.Assert(e.StableACLs, jc.DeepEquals, mongodoc.ACL{})
 
-	// Try setting all published permissions in one request.
+	// Try setting all unpublished permissions in one request.
+	s.assertPut(c, "trusty/wordpress-1/meta/perm", params.PermRequest{
+		Read:  []string{"bob", "who"},
+		Write: []string{"charmers"},
+	})
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
+	c.Assert(err, gc.IsNil)
+	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
+		Read:  []string{"bob", "who"},
+		Write: []string{"charmers"},
+	})
+
+	// Try setting all stable permissions in one request.
 	s.assertPut(c, "wordpress/meta/perm", params.PermRequest{
 		Read:  []string{"bob"},
 		Write: []string{"admin"},
@@ -721,7 +756,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsFalse)
-	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
+	c.Assert(e.StableACLs, jc.DeepEquals, mongodoc.ACL{
 		Read:  []string{"bob"},
 		Write: []string{"admin"},
 	})
@@ -739,15 +774,15 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Write: []string{"who"},
 	})
 
-	// Try only read permissions to published meta/perm endpoint.
+	// Try only read permissions to stable meta/perm endpoint.
 	var readRequest = struct {
 		Read []string
 	}{Read: []string{"joe"}}
 	s.assertPut(c, "wordpress/meta/perm", readRequest)
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
+	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-22"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsFalse)
-	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
+	c.Assert(e.StableACLs, jc.DeepEquals, mongodoc.ACL{
 		Read:  []string{"joe"},
 		Write: []string{},
 	})
@@ -1033,6 +1068,8 @@ func (s *APISuite) TestCommonInfo(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-24", 24))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/trusty/wordpress-1", 1))
+	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-24", 24), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 
 	s.assertPut(c, "wordpress/meta/common-info/key", "something")
 
@@ -1330,7 +1367,10 @@ func (s *APISuite) TestIdsAreResolved(c *gc.C) {
 	// passed to the router. Given how Router is
 	// defined, and the ResolveURL tests, this should
 	// be sufficient to "join the dots".
-	_, wordpress := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	url := newResolvedURL("cs:~charmers/precise/wordpress-23", 23)
+	_, wordpress := s.addPublicCharm(c, "wordpress", url)
+	err := s.store.Publish(url, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 	s.assertGet(c, "wordpress/meta/charm-metadata", wordpress.Meta())
 }
 
@@ -1366,7 +1406,7 @@ var resolveURLTests = []struct {
 	expect: newResolvedURL("cs:~charmers/trusty/wordpress-25", 25),
 }, {
 	url:    "development/wordpress",
-	expect: newResolvedURL("cs:~charmers/development/trusty/wordpress-25", 25),
+	expect: newResolvedURL("cs:~charmers/development/trusty/wordpress-26", 26),
 }, {
 	url:    "precise/wordpress",
 	expect: newResolvedURL("cs:~charmers/precise/wordpress-24", 24),
@@ -1396,7 +1436,7 @@ var resolveURLTests = []struct {
 	expect: newResolvedURL("cs:~charmers/trusty/wordpress-25", -1),
 }, {
 	url:    "~charmers/development/wordpress",
-	expect: newResolvedURL("cs:~charmers/development/trusty/wordpress-25", -1),
+	expect: newResolvedURL("cs:~charmers/development/trusty/wordpress-26", -1),
 }, {
 	url:      "~charmers/wordpress-24",
 	notFound: true,
@@ -1408,13 +1448,16 @@ var resolveURLTests = []struct {
 	expect: newResolvedURL("cs:~bob/trusty/wordpress-1", -1),
 }, {
 	url:    "~bob/development/wordpress",
-	expect: newResolvedURL("cs:~bob/development/trusty/wordpress-1", -1),
+	expect: newResolvedURL("cs:~bob/development/precise/wordpress-2", -1),
 }, {
 	url:    "~bob/precise/wordpress",
 	expect: newResolvedURL("cs:~bob/precise/wordpress-2", -1),
 }, {
 	url:    "~bob/development/precise/wordpress",
 	expect: newResolvedURL("cs:~bob/development/precise/wordpress-2", -1),
+}, {
+	url:      "~bob/private",
+	notFound: true,
 }, {
 	url:    "bigdata",
 	expect: newResolvedURL("cs:~charmers/utopic/bigdata-10", 10),
@@ -1452,17 +1495,17 @@ var resolveURLTests = []struct {
 	url:      "development/trusty/bigdata",
 	notFound: true,
 }, {
-	url:      "~bob/wily/django-47",
-	notFound: true,
+	url:    "~bob/wily/django-47",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", -1),
 }, {
-	url:      "~bob/django",
-	notFound: true,
+	url:    "~bob/django",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", -1),
 }, {
-	url:      "wily/django",
-	notFound: true,
+	url:    "wily/django",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", 27),
 }, {
-	url:      "django",
-	notFound: true,
+	url:    "django",
+	expect: newResolvedURL("cs:~bob/development/wily/django-47", 27),
 }, {
 	url:    "~bob/development/wily/django-47",
 	expect: newResolvedURL("cs:~bob/development/wily/django-47", -1),
@@ -1482,10 +1525,10 @@ var resolveURLTests = []struct {
 	url:    "development/django",
 	expect: newResolvedURL("cs:~bob/development/wily/django-47", 27),
 }, {
-	url:      "~bob/trusty/haproxy-0",
+	url:      "~bob/trusty/haproxy-1",
 	notFound: true,
 }, {
-	url:      "~bob/haproxy",
+	url:      "~bob/haproxy-2",
 	notFound: true,
 }, {
 	url:      "trusty/haproxy",
@@ -1525,27 +1568,54 @@ var resolveURLTests = []struct {
 }}
 
 func (s *APISuite) TestResolveURL(c *gc.C) {
+	// Add the charms and bundles to the database.
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-24", 24))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-24", 24))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-25", 25))
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-26", 26))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-10", 10))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/saucy/bigdata-99", 99))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/bigdata-10", 10))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/trusty/wordpress-1", -1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/wordpress-2", -1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/other-2", -1))
+	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/private-1", -1))
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10))
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/wily/django-47", 27))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1))
 	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
 
+	// Mark charms and bundles as stable/development.
+	err := s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-25", 25), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-26", 26), charm.DevelopmentChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~charmers/precise/wordpress-24", 24), charm.DevelopmentChannel, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~charmers/utopic/bigdata-10", 10), charm.DevelopmentChannel, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~bob/trusty/wordpress-1", -1), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~bob/precise/wordpress-2", -1), charm.DevelopmentChannel, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10), charm.DevelopmentChannel, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~bob/development/wily/django-47", 27), charm.DevelopmentChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1), charm.DevelopmentChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~bob/multi-series-0", -1), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+
 	cache := entitycache.New(s.store)
 	cache.AddEntityFields(map[string]int{"supportedseries": 1})
 	cache.AddEntityFields(v5.RequiredEntityFields)
+
+	// Run the tests.
 	for i, test := range resolveURLTests {
-		c.Logf("test %d: %s", i, test.url)
+		c.Logf("\ntest %d: %s", i, test.url)
 		url := charm.MustParseURL(test.url)
 		rurl, err := v4.ResolveURL(cache, url)
 		if test.notFound {
@@ -1857,6 +1927,8 @@ func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-43", 43))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-9", 9))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-42", 42))
+	err := s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-42", 42), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-0", -1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-1", -1))
@@ -1867,14 +1939,22 @@ func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-4", -1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-5", 4))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-6", 5))
+	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/cinder-6", 5), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(newResolvedURL("cs:~openstack-charmers/trusty/cinder-0", 2), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 
 	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-1", 40))
 	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-2", 41))
+	err = s.store.Publish(newResolvedURL("cs:~charmers/multi-series-2", 41), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-1", 40))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-2", 41))
 	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-3", 42))
 	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-4", 43))
+	err = s.store.Publish(newResolvedURL("cs:~charmers/mixed-3", 42), charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 
 	for i, test := range serveMetaRevisionInfoTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -2719,7 +2799,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).WithPromulgated(true).Build(),
 	},
 	id:           "~charmers/wordpress",
 	body:         storetesting.JSONReader(params.PromulgateRequest{Promulgated: false}),
@@ -2730,7 +2812,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).Build(),
 	},
 	expectUser: "admin",
 }, {
@@ -2739,7 +2823,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),
 	},
 	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).Build(),
 	},
 	id:           "~charmers/wordpress",
 	body:         storetesting.JSONReader(params.PromulgateRequest{Promulgated: true}),
@@ -2752,6 +2838,8 @@ var promulgateTests = []struct {
 	expectBaseEntities: []*mongodoc.BaseEntity{
 		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.ACL{
 			Write: []string{v4.PromulgatorsGroup},
+		}).WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
 		}).WithPromulgated(true).Build(),
 	},
 	expectPromulgate: true,
@@ -2808,7 +2896,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).WithPromulgated(true).Build(),
 	},
 	id:           "~charmers/wordpress",
 	body:         storetesting.JSONReader(params.PromulgateRequest{Promulgated: false}),
@@ -2824,7 +2914,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).WithPromulgated(true).Build(),
 	},
 }, {
 	about: "bad JSON",
@@ -2832,7 +2924,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).WithPromulgated(true).Build(),
 	},
 	id:           "~charmers/wordpress",
 	body:         bytes.NewReader([]byte("tru")),
@@ -2847,7 +2941,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).WithPromulgated(true).Build(),
 	},
 }, {
 	about: "unpromulgate base entity with macaroon",
@@ -2855,7 +2951,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).WithPromulgated(true).Build(),
 	},
 	id:   "~charmers/wordpress",
 	body: storetesting.JSONReader(params.PromulgateRequest{Promulgated: false}),
@@ -2867,7 +2965,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).Build(),
 	},
 	expectUser: v4.PromulgatorsGroup,
 }, {
@@ -2876,7 +2976,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),
 	},
 	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).Build(),
 	},
 	id:   "~charmers/wordpress",
 	body: storetesting.JSONReader(params.PromulgateRequest{Promulgated: true}),
@@ -2890,6 +2992,8 @@ var promulgateTests = []struct {
 	expectBaseEntities: []*mongodoc.BaseEntity{
 		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.ACL{
 			Write: []string{v4.PromulgatorsGroup},
+		}).WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
 		}).WithPromulgated(true).Build(),
 	},
 	expectPromulgate: true,
@@ -2900,7 +3004,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),
 	},
 	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).Build(),
 	},
 	id:   "~charmers/wordpress",
 	body: storetesting.JSONReader(params.PromulgateRequest{Promulgated: true}),
@@ -2917,6 +3023,8 @@ var promulgateTests = []struct {
 	expectBaseEntities: []*mongodoc.BaseEntity{
 		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.ACL{
 			Write: []string{v4.PromulgatorsGroup},
+		}).WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
 		}).WithPromulgated(true).Build(),
 	},
 	expectPromulgate: true,
@@ -2927,7 +3035,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).WithPromulgated(true).Build(),
 	},
 	useHTTPDo:    true,
 	id:           "~charmers/wordpress",
@@ -2938,7 +3048,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithPromulgated(true).Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).WithPromulgated(true).Build(),
 	},
 }, {
 	about: "promulgate base entity with unauthorized user macaroon",
@@ -2946,7 +3058,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),
 	},
 	baseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).Build(),
 	},
 	id:   "~charmers/wordpress",
 	body: storetesting.JSONReader(params.PromulgateRequest{Promulgated: true}),
@@ -2965,7 +3079,9 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").Build(),
+		storetesting.NewBaseEntity("~charmers/wordpress").WithStableSeries(map[string]string{
+			"trusty": "~charmers/trusty/wordpress-0",
+		}).Build(),
 	},
 }}
 
@@ -3043,303 +3159,433 @@ func (s *APISuite) TestEndpointRequiringBaseEntityWithPromulgatedId(c *gc.C) {
 	})
 }
 
+type dbEntity struct {
+	url      *router.ResolvedURL
+	channels []charm.Channel
+}
+
 var publishTests = []struct {
 	about      string
-	db         []*router.ResolvedURL
+	db         []dbEntity
 	id         string
-	publish    bool
-	expectDB   []*router.ResolvedURL
+	channels   []charm.Channel
+	expectDB   map[string]string
 	expectBody params.PublishResponse
 }{{
-	about: "publish: one development charm present, fully qualified id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", -1),
-	},
-	id:      "~who/wily/django-42",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", -1),
+	about: "publish stable: one unpublished charm present, fully qualified id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", -1), nil,
+	}},
+	id:       "~who/wily/django-42",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"~who/wily/django-42": "~who/wily/django-42",
+		"~who/wily/django":    "~who/wily/django-42",
 	},
 	expectBody: params.PublishResponse{
 		Id: charm.MustParseURL("~who/wily/django-42"),
 	},
 }, {
-	about: "publish: one development charm present, fully qualified id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 47),
+	about: "publish stable: one development charm present, fully qualified id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", -1), []charm.Channel{charm.DevelopmentChannel},
+	}},
+	id:       "~who/wily/django-42",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"~who/wily/django":             "~who/wily/django-42",
+		"~who/development/wily/django": "~who/wily/django-42",
 	},
-	id:      "wily/django-47",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", 47),
+	expectBody: params.PublishResponse{
+		Id: charm.MustParseURL("~who/wily/django-42"),
+	},
+}, {
+	about: "publish stable: one unpublished charm present, fully qualified id, promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", 47), nil,
+	}},
+	id:       "wily/django-47",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"django":           "~who/wily/django-42",
+		"wily/django":      "~who/wily/django-42",
+		"wily/django-47":   "~who/wily/django-42",
+		"~who/wily/django": "~who/wily/django-42",
 	},
 	expectBody: params.PublishResponse{
 		Id:            charm.MustParseURL("~who/wily/django-42"),
 		PromulgatedId: charm.MustParseURL("wily/django-47"),
 	},
 }, {
-	about: "publish: one development charm present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", -1),
-	},
-	id:      "~who/wily/django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-42"),
-	},
-}, {
-	about: "publish: one development charm present, partial id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 47),
-	},
-	id:      "django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", 47),
+	about: "publish stable: one development charm present, fully qualified id, promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", 47), []charm.Channel{charm.DevelopmentChannel},
+	}},
+	id:       "wily/django-47",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"django":                       "~who/wily/django-42",
+		"wily/django":                  "~who/wily/django-42",
+		"wily/django-47":               "~who/wily/django-42",
+		"~who/wily/django":             "~who/wily/django-42",
+		"development/django":           "~who/wily/django-42",
+		"development/wily/django":      "~who/wily/django-42",
+		"development/wily/django-47":   "~who/wily/django-42",
+		"~who/development/wily/django": "~who/wily/django-42",
 	},
 	expectBody: params.PublishResponse{
 		Id:            charm.MustParseURL("~who/wily/django-42"),
 		PromulgatedId: charm.MustParseURL("wily/django-47"),
 	},
 }, {
-	about: "publish: one published charm present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-1", -1),
-	},
-	id:      "~who/django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-1", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-1"),
-	},
-}, {
-	about: "publish: one published charm present, fully qualified id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-2", 0),
-	},
-	id:      "wily/django-0",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-2", 0),
+	about: "publish stable: one stable charm present, fully qualified id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", -1), []charm.Channel{charmstore.StableChannel},
+	}},
+	id:       "~who/wily/django-42",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"~who/wily/django": "~who/wily/django-42",
 	},
 	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/wily/django-2"),
-		PromulgatedId: charm.MustParseURL("wily/django-0"),
+		Id: charm.MustParseURL("~who/wily/django-42"),
 	},
 }, {
-	about: "publish: multiple development charms present, fully qualified id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
-		newResolvedURL("~who/development/trusty/django-1", -1),
-	},
-	id:      "~who/wily/django-1",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
-		newResolvedURL("~who/development/trusty/django-1", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-1"),
-	},
-}, {
-	about: "publish: multiple development charms present, fully qualified id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 10),
-		newResolvedURL("~who/development/wily/django-43", 11),
-		newResolvedURL("~who/development/wily/django-44", 12),
-		newResolvedURL("~who/development/wily/rails-100", 10),
-	},
-	id:      "wily/django-10",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", 10),
-		newResolvedURL("~who/development/wily/django-43", 11),
-		newResolvedURL("~who/development/wily/django-44", 12),
-		newResolvedURL("~who/development/wily/rails-100", 10),
+	about: "publish stable: one stable charm present, fully qualified id, promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", 47), []charm.Channel{charmstore.StableChannel},
+	}},
+	id:       "wily/django-47",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"django":           "~who/wily/django-42",
+		"wily/django":      "~who/wily/django-42",
+		"wily/django-47":   "~who/wily/django-42",
+		"~who/wily/django": "~who/wily/django-42",
 	},
 	expectBody: params.PublishResponse{
 		Id:            charm.MustParseURL("~who/wily/django-42"),
-		PromulgatedId: charm.MustParseURL("wily/django-10"),
+		PromulgatedId: charm.MustParseURL("wily/django-47"),
 	},
 }, {
-	about: "publish: multiple development charms present, fully qualified id, promulgated, last one published",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 10),
-		newResolvedURL("~who/development/wily/django-43", 11),
-		newResolvedURL("~who/development/wily/django-44", 12),
-		newResolvedURL("~who/development/wily/rails-100", 10),
+	about: "publish stable: multiple development charms present, partial id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", -1), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-43", -1), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-44", -1), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-45", -1), nil,
+	}},
+	id:       "~who/wily/django",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"~who/wily/django":             "~who/wily/django-44",
+		"~who/development/wily/django": "~who/wily/django-44",
 	},
-	id:      "wily/django-12",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 10),
-		newResolvedURL("~who/development/wily/django-43", 11),
-		newResolvedURL("~who/wily/django-44", 12),
-		newResolvedURL("~who/development/wily/rails-100", 10),
+	expectBody: params.PublishResponse{
+		Id: charm.MustParseURL("~who/wily/django-44"),
+	},
+}, {
+	about: "publish stable: multiple development charms present, fully qualified id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", -1), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-43", -1), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-44", -1), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-45", -1), nil,
+	}},
+	id:       "~who/wily/django-43",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"~who/wily/django":             "~who/wily/django-43",
+		"~who/development/wily/django": "~who/wily/django-44",
+	},
+	expectBody: params.PublishResponse{
+		Id: charm.MustParseURL("~who/wily/django-43"),
+	},
+}, {
+	about: "publish stable: multiple development charms present, fully qualified id, promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", 0), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-43", 1), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-44", 2), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-45", 3), nil,
+	}},
+	id:       "wily/django-3",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"django":                       "~who/wily/django-45",
+		"development/django":           "~who/wily/django-44",
+		"wily/django":                  "~who/wily/django-45",
+		"wily/django-3":                "~who/wily/django-45",
+		"development/wily/django":      "~who/wily/django-44",
+		"~who/wily/django":             "~who/wily/django-45",
+		"~who/development/wily/django": "~who/wily/django-44",
+	},
+	expectBody: params.PublishResponse{
+		Id:            charm.MustParseURL("~who/wily/django-45"),
+		PromulgatedId: charm.MustParseURL("wily/django-3"),
+	},
+}, {
+	about: "publish stable: multiple development charms present, partial id, promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", 0), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-43", 1), nil,
+	}, {
+		newResolvedURL("~who/wily/django-44", 2), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-45", 3), nil,
+	}},
+	id:       "django",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"django":                       "~who/wily/django-44",
+		"development/django":           "~who/wily/django-44",
+		"wily/django":                  "~who/wily/django-44",
+		"wily/django-2":                "~who/wily/django-44",
+		"development/wily/django":      "~who/wily/django-44",
+		"~who/wily/django":             "~who/wily/django-44",
+		"~who/development/wily/django": "~who/wily/django-44",
 	},
 	expectBody: params.PublishResponse{
 		Id:            charm.MustParseURL("~who/wily/django-44"),
-		PromulgatedId: charm.MustParseURL("wily/django-12"),
+		PromulgatedId: charm.MustParseURL("wily/django-2"),
 	},
 }, {
-	about: "publish: multiple development charms present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/trusty/django-42", -1),
-		newResolvedURL("~who/development/trusty/django-47", -1),
-	},
-	id:      "~who/wily/django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/wily/django-1", -1),
-		newResolvedURL("~who/development/trusty/django-42", -1),
-		newResolvedURL("~who/development/trusty/django-47", -1),
+	about: "publish stable: multiple stable charms present, fully qualified id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-43", -1), []charm.Channel{charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-44", -1), []charm.Channel{charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-45", -1), nil,
+	}, {
+		newResolvedURL("~who/wily/django-46", -1), nil,
+	}},
+	id:       "~who/wily/django-45",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"~who/wily/django": "~who/wily/django-45",
 	},
 	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-1"),
+		Id: charm.MustParseURL("~who/wily/django-45"),
 	},
 }, {
-	about: "publish: multiple development charms present, partial id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", 0),
-		newResolvedURL("~who/development/wily/django-1", 1),
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/development/trusty/django-47", 11),
-	},
-	id:      "django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", 0),
-		newResolvedURL("~who/development/wily/django-1", 1),
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
+	about: "publish stable: multiple stable and development charms present, fully qualified id, promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", 0), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-43", 1), []charm.Channel{charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-44", 2), []charm.Channel{charm.DevelopmentChannel, charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-45", 3), nil,
+	}, {
+		newResolvedURL("~who/wily/django-46", 4), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-47", 5), nil,
+	}},
+	id:       "wily/django-1",
+	channels: []charm.Channel{charmstore.StableChannel},
+	expectDB: map[string]string{
+		"django":                       "~who/wily/django-43",
+		"development/django":           "~who/wily/django-46",
+		"wily/django":                  "~who/wily/django-43",
+		"wily/django-1":                "~who/wily/django-43",
+		"development/wily/django":      "~who/wily/django-46",
+		"~who/wily/django":             "~who/wily/django-43",
+		"~who/development/wily/django": "~who/wily/django-46",
 	},
 	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/trusty/django-47"),
-		PromulgatedId: charm.MustParseURL("trusty/django-11"),
+		Id:            charm.MustParseURL("~who/wily/django-43"),
+		PromulgatedId: charm.MustParseURL("wily/django-1"),
 	},
 }, {
-	about: "publish: multiple published charms present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
-	},
-	id:      "~who/wily/django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/wily/django-2", -1),
+	about: "publish development: one unpublished charm present, fully qualified id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", -1), nil,
+	}},
+	id:       "~who/wily/django-42",
+	channels: []charm.Channel{charm.DevelopmentChannel},
+	expectDB: map[string]string{
+		"~who/wily/django-42":             "~who/wily/django-42",
+		"~who/wily/django":                "~who/wily/django-42",
+		"~who/development/wily/django-42": "~who/wily/django-42",
+		"~who/development/wily/django":    "~who/wily/django-42",
 	},
 	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-2"),
+		Id: charm.MustParseURL("~who/wily/django-42"),
 	},
 }, {
-	about: "publish: multiple published charms present, partial id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
-		newResolvedURL("~who/trusty/django-48", 12),
-		newResolvedURL("~who/development/trusty/django-49", 13),
-	},
-	id:      "django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
-		newResolvedURL("~who/trusty/django-48", 12),
-		newResolvedURL("~who/trusty/django-49", 13),
+	about: "publish development: one unpublished charm present, fully qualified id, promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", 47), nil,
+	}},
+	id:       "wily/django-47",
+	channels: []charm.Channel{charm.DevelopmentChannel},
+	expectDB: map[string]string{
+		"django":                       "~who/wily/django-42",
+		"wily/django":                  "~who/wily/django-42",
+		"wily/django-47":               "~who/wily/django-42",
+		"~who/wily/django":             "~who/wily/django-42",
+		"development/django":           "~who/wily/django-42",
+		"development/wily/django":      "~who/wily/django-42",
+		"development/wily/django-47":   "~who/wily/django-42",
+		"~who/development/wily/django": "~who/wily/django-42",
 	},
 	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/trusty/django-49"),
-		PromulgatedId: charm.MustParseURL("trusty/django-13"),
+		Id:            charm.MustParseURL("~who/wily/django-42"),
+		PromulgatedId: charm.MustParseURL("wily/django-47"),
 	},
 }, {
-	about: "unpublish: one published charm present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-1", -1),
-	},
-	id: "~who/django",
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-1", -1),
+	about: "publish development: one stable charm present, fully qualified id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", -1), []charm.Channel{charmstore.StableChannel},
+	}},
+	id:       "~who/wily/django-42",
+	channels: []charm.Channel{charm.DevelopmentChannel},
+	expectDB: map[string]string{
+		"~who/wily/django":             "~who/wily/django-42",
+		"~who/development/wily/django": "~who/wily/django-42",
 	},
 	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/development/wily/django-1"),
+		Id: charm.MustParseURL("~who/wily/django-42"),
 	},
 }, {
-	about: "unpublish: one published charm present, fully qualified id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-2", 0),
-	},
-	id: "wily/django-0",
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-2", 0),
+	about: "publish development: one stable charm present, fully qualified id, promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", 47), []charm.Channel{charmstore.StableChannel},
+	}},
+	id:       "wily/django-47",
+	channels: []charm.Channel{charm.DevelopmentChannel},
+	expectDB: map[string]string{
+		"django":                       "~who/wily/django-42",
+		"wily/django":                  "~who/wily/django-42",
+		"wily/django-47":               "~who/wily/django-42",
+		"~who/wily/django":             "~who/wily/django-42",
+		"development/django":           "~who/wily/django-42",
+		"development/wily/django":      "~who/wily/django-42",
+		"development/wily/django-47":   "~who/wily/django-42",
+		"~who/development/wily/django": "~who/wily/django-42",
 	},
 	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/development/wily/django-2"),
-		PromulgatedId: charm.MustParseURL("development/wily/django-0"),
+		Id:            charm.MustParseURL("~who/wily/django-42"),
+		PromulgatedId: charm.MustParseURL("wily/django-47"),
 	},
 }, {
-	about: "unpublish: multiple published charms present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
-	},
-	id: "~who/wily/django",
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
+	about: "publish development: multiple stable charms present, fully qualified id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-43", -1), []charm.Channel{charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-44", -1), []charm.Channel{charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-45", -1), nil,
+	}, {
+		newResolvedURL("~who/wily/django-46", -1), nil,
+	}},
+	id:       "~who/wily/django-46",
+	channels: []charm.Channel{charm.DevelopmentChannel},
+	expectDB: map[string]string{
+		"~who/wily/django":             "~who/wily/django-44",
+		"~who/development/wily/django": "~who/wily/django-46",
 	},
 	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/development/wily/django-0"),
+		Id: charm.MustParseURL("~who/wily/django-46"),
 	},
 }, {
-	about: "unpublish: multiple published charms present, partial id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
-		newResolvedURL("~who/trusty/django-48", 12),
-		newResolvedURL("~who/development/trusty/django-49", 13),
-	},
-	id: "django",
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
-		newResolvedURL("~who/development/trusty/django-48", 12),
-		newResolvedURL("~who/development/trusty/django-49", 13),
+	about: "publish development: multiple stable and development charms present, fully qualified id, promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", 0), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-43", 1), []charm.Channel{charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-44", 2), []charm.Channel{charm.DevelopmentChannel, charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-45", 3), nil,
+	}, {
+		newResolvedURL("~who/wily/django-46", 4), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-47", 5), nil,
+	}},
+	id:       "wily/django-3",
+	channels: []charm.Channel{charm.DevelopmentChannel},
+	expectDB: map[string]string{
+		"django":                       "~who/wily/django-44",
+		"development/django":           "~who/wily/django-45",
+		"wily/django":                  "~who/wily/django-44",
+		"wily/django-2":                "~who/wily/django-44",
+		"development/wily/django":      "~who/wily/django-45",
+		"~who/wily/django":             "~who/wily/django-44",
+		"~who/development/wily/django": "~who/wily/django-45",
 	},
 	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/development/trusty/django-48"),
-		PromulgatedId: charm.MustParseURL("development/trusty/django-12"),
+		Id:            charm.MustParseURL("~who/wily/django-45"),
+		PromulgatedId: charm.MustParseURL("wily/django-3"),
+	},
+}, {
+	about: "publish both: multiple stable and development charms present, fully qualified id, not promulgated",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", -1), []charm.Channel{charm.DevelopmentChannel, charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-43", -1), []charm.Channel{charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-44", -1), []charm.Channel{charm.DevelopmentChannel, charmstore.StableChannel},
+	}, {
+		newResolvedURL("~who/wily/django-45", -1), nil,
+	}, {
+		newResolvedURL("~who/wily/django-46", -1), []charm.Channel{charm.DevelopmentChannel},
+	}, {
+		newResolvedURL("~who/wily/django-47", -1), nil,
+	}},
+	id:       "~who/wily/django-47",
+	channels: []charm.Channel{charm.DevelopmentChannel, charmstore.StableChannel},
+	expectDB: map[string]string{
+		"~who/wily/django":             "~who/wily/django-47",
+		"~who/development/wily/django": "~who/wily/django-47",
+	},
+	expectBody: params.PublishResponse{
+		Id: charm.MustParseURL("~who/wily/django-47"),
+	},
+}, {
+	about: "publish stable and invalid channel",
+	db: []dbEntity{{
+		newResolvedURL("~who/wily/django-42", -1), nil,
+	}},
+	id:       "~who/wily/django-42",
+	channels: []charm.Channel{charmstore.StableChannel, charm.Channel("ignored")},
+	expectDB: map[string]string{
+		"~who/wily/django-42": "~who/wily/django-42",
+		"~who/wily/django":    "~who/wily/django-42",
+	},
+	expectBody: params.PublishResponse{
+		Id: charm.MustParseURL("~who/wily/django-42"),
 	},
 }}
 
 func (s *APISuite) TestPublish(c *gc.C) {
 	for i, test := range publishTests {
-		c.Logf("test %d: %s", i, test.about)
+		c.Logf("\ntest %d: %s", i, test.about)
 
 		// Add the initial entities to the database.
-		for _, rurl := range test.db {
-			s.addPublicCharm(c, "wordpress", rurl)
+		for _, e := range test.db {
+			s.addPublicCharm(c, "wordpress", e.url)
+			if len(e.channels) != 0 {
+				err := s.store.Publish(e.url, e.channels...)
+				c.Assert(err, gc.IsNil)
+			}
 		}
 
 		// Build the proper request body.
-		body := mustMarshalJSON(params.PublishRequest{
-			Published: test.publish,
+		body := mustMarshalJSON(v5.PublishRequest{
+			Channels: test.channels,
 		})
 
 		// Check that the request/response process works as expected.
@@ -3356,10 +3602,11 @@ func (s *APISuite) TestPublish(c *gc.C) {
 		})
 
 		// Check that the database now includes the expected entities.
-		for _, rurl := range test.expectDB {
-			e, err := s.store.FindEntity(rurl, nil)
+		for id, expectId := range test.expectDB {
+			c.Logf("\nquery: %s, expected: %s", id, expectId)
+			e, err := s.store.FindBestEntity(charm.MustParseURL(id), charmstore.FieldSelector("_id"))
 			c.Assert(err, gc.IsNil)
-			c.Assert(charmstore.EntityResolvedURL(e), jc.DeepEquals, rurl)
+			c.Assert(e.URL, jc.DeepEquals, charm.MustParseURL(expectId))
 		}
 
 		// Remove all entities from the database.
@@ -3397,13 +3644,13 @@ var publishErrorsTests = []struct {
 		Message: "POST not allowed",
 	},
 }, {
-	about:        "invalid channel",
+	about:        "channel specified",
 	method:       "PUT",
 	id:           "~who/development/wily/django-42",
-	expectStatus: http.StatusForbidden,
+	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
-		Code:    params.ErrForbidden,
-		Message: `can only set publish on published URL, "cs:~who/development/wily/django-42" provided`,
+		Code:    params.ErrBadRequest,
+		Message: "channel specified, but should not be specified",
 	},
 }, {
 	about:        "unexpected content type",
@@ -3413,7 +3660,7 @@ var publishErrorsTests = []struct {
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: `cannot unmarshal publish request body: cannot unmarshal into field: unexpected content type text/invalid; want application/json; content: "{\"Published\":true}"`,
+		Message: `cannot unmarshal publish request body: cannot unmarshal into field: unexpected content type text/invalid; want application/json; content: "{\"Channels\":[\"development\"]}"`,
 	},
 }, {
 	about:        "invalid body",
@@ -3432,23 +3679,21 @@ var publishErrorsTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: `no matching charm or bundle for "cs:~who/development/wily/django-42"`,
+		Message: `no matching charm or bundle for "cs:~who/wily/django-42"`,
 	},
 }, {
-	about:  "entity to be unpublished not found",
-	method: "PUT",
-	id:     "~who/wily/django-42",
-	body: mustMarshalJSON(params.PublishRequest{
-		Published: false,
-	}),
-	expectStatus: http.StatusNotFound,
+	about:        "no channels provided",
+	method:       "PUT",
+	id:           "~who/trusty/wordpress-0",
+	body:         mustMarshalJSON(v5.PublishRequest{}),
+	expectStatus: http.StatusInternalServerError,
 	expectBody: params.Error{
-		Code:    params.ErrNotFound,
-		Message: `no matching charm or bundle for "cs:~who/wily/django-42"`,
+		Message: `cannot publish charm or bundle: cannot update "cs:~who/trusty/wordpress-0": no channels provided`,
 	},
 }}
 
 func (s *APISuite) TestPublishErrors(c *gc.C) {
+	s.addPublicCharm(c, "wordpress", newResolvedURL("~who/trusty/wordpress-0", -1))
 	for i, test := range publishErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
 		contentType := test.contentType
@@ -3457,8 +3702,8 @@ func (s *APISuite) TestPublishErrors(c *gc.C) {
 		}
 		body := test.body
 		if body == "" {
-			body = mustMarshalJSON(params.PublishRequest{
-				Published: true,
+			body = mustMarshalJSON(v5.PublishRequest{
+				Channels: []charm.Channel{charm.DevelopmentChannel},
 			})
 		}
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -78,24 +78,25 @@ func (s *ArchiveSuite) TestGet(c *gc.C) {
 	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/precise/wordpress-0")
 	assertCacheControl(c, rec.Header(), true)
 
-	// The development version of the entity can also be retrieved.
-	err = s.store.SetPerms(id.URL.WithChannel(charm.DevelopmentChannel), "read", params.Everyone, id.URL.User)
-	c.Assert(err, gc.IsNil)
-	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     storeURL("~charmers/development/precise/wordpress-0/archive"),
+	// The development version of the entity cannot be retrieved.
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		URL:          storeURL("~charmers/development/precise/wordpress-0/archive"),
+		ExpectStatus: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Code:    params.ErrNotFound,
+			Message: `no matching charm or bundle for "cs:~charmers/development/precise/wordpress-0"`,
+		},
 	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
-	c.Assert(rec.Header().Get(params.ContentHashHeader), gc.Equals, hashOfBytes(archiveBytes))
-	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/development/precise/wordpress-0")
 }
 
 func (s *ArchiveSuite) TestGetDevelopment(c *gc.C) {
-	id := newResolvedURL("cs:~charmers/development/trusty/wordpress-0", -1)
+	id := newResolvedURL("cs:~charmers/trusty/wordpress-0", -1)
 	wordpress := s.assertUploadCharm(c, "POST", id, "wordpress")
-	url := id.PreferredURL()
-	err := s.store.SetPerms(url, "read", params.Everyone, id.URL.User)
+	url := id.UserOwnedURL()
+	err := s.store.Publish(id, charm.DevelopmentChannel)
+	c.Assert(err, gc.IsNil)
+	err = s.store.SetPerms(url.WithChannel(charm.DevelopmentChannel), "read", params.Everyone, id.URL.User)
 	c.Assert(err, gc.IsNil)
 
 	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
@@ -109,26 +110,13 @@ func (s *ArchiveSuite) TestGetDevelopment(c *gc.C) {
 	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
 	c.Assert(rec.Header().Get(params.ContentHashHeader), gc.Equals, hashOfBytes(archiveBytes))
 	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/development/trusty/wordpress-0")
-
-	// It is not possible to use the published URL to retrieve the archive,
-	err = s.store.SetPerms(url.WithChannel(""), "read", params.Everyone, id.URL.User)
-	c.Assert(err, gc.IsNil)
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler:      s.srv,
-		URL:          storeURL("~charmers/trusty/wordpress-0/archive"),
-		ExpectStatus: http.StatusNotFound,
-		ExpectBody: params.Error{
-			Code:    params.ErrNotFound,
-			Message: `no matching charm or bundle for "cs:~charmers/trusty/wordpress-0"`,
-		},
-	})
 }
 
 func (s *ArchiveSuite) TestGetWithPartialId(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/utopic/wordpress-42", -1)
-	err := s.store.AddCharmWithArchive(
-		id,
-		storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"))
+	err := s.store.AddCharmWithArchive(id, storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"))
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(id, charmstore.StableChannel)
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 	c.Assert(err, gc.IsNil)
@@ -143,9 +131,9 @@ func (s *ArchiveSuite) TestGetWithPartialId(c *gc.C) {
 
 func (s *ArchiveSuite) TestGetPromulgatedWithPartialId(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/utopic/wordpress-42", 42)
-	err := s.store.AddCharmWithArchive(
-		id,
-		storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"))
+	err := s.store.AddCharmWithArchive(id, storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"))
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(id, charmstore.StableChannel)
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 	c.Assert(err, gc.IsNil)
@@ -392,13 +380,23 @@ func (s *ArchiveSuite) TestPostCharm(c *gc.C) {
 	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress")
 
 	// Subsequent charm uploads should increment the revision by 1.
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-1", -1), "mysql")
+	url := newResolvedURL("~charmers/precise/wordpress-1", -1)
+	s.assertUploadCharm(c, "POST", url, "mysql")
 
-	// Subsequent development charm uploads should increment the revision by 1.
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/precise/wordpress-2", -1), "wordpress")
+	// Set this last revision as stable.
+	err := s.store.Publish(url, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 
-	// Retrieving the published version returns the last non-development charm.
-	err := s.store.SetPerms(charm.MustParseURL("~charmers/wordpress"), "read", params.Everyone)
+	// Subsequent charm uploads should increment the revision by 1.
+	url = newResolvedURL("~charmers/precise/wordpress-2", -1)
+	s.assertUploadCharm(c, "POST", url, "wordpress")
+
+	// Set this last revision as development.
+	err = s.store.Publish(url, charm.DevelopmentChannel)
+	c.Assert(err, gc.IsNil)
+
+	// Retrieving the stable version returns the last stable charm.
+	err = s.store.SetPerms(charm.MustParseURL("~charmers/wordpress"), "read", params.Everyone)
 	c.Assert(err, gc.IsNil)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -406,22 +404,33 @@ func (s *ArchiveSuite) TestPostCharm(c *gc.C) {
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/precise/wordpress-1")
+
+	// Retrieving the development version returns the last development charm.
+	err = s.store.SetPerms(charm.MustParseURL("~charmers/development/wordpress"), "read", params.Everyone)
+	c.Assert(err, gc.IsNil)
+	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL("~charmers/development/wordpress/archive"),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/development/precise/wordpress-2")
 }
 
 func (s *ArchiveSuite) TestPostCurrentVersion(c *gc.C) {
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/precise/wordpress-0", -1), "wordpress")
+	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress")
 
 	// Subsequent charm uploads should not increment the revision by 1.
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/precise/wordpress-0", -1), "wordpress")
+	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress")
 }
 
 func (s *ArchiveSuite) TestPostDevelopmentPromulgated(c *gc.C) {
-	s.assertUploadCharm(c, "PUT", newResolvedURL("~charmers/development/trusty/wordpress-0", 0), "wordpress")
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/trusty/wordpress-1", 1), "mysql")
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/trusty/wordpress-1", 1), "mysql")
+	s.assertUploadCharm(c, "PUT", newResolvedURL("~charmers/trusty/wordpress-0", 0), "wordpress")
+	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/trusty/wordpress-1", 1), "mysql")
+	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/trusty/wordpress-1", 1), "mysql")
+	err := s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), charm.DevelopmentChannel)
 
 	// The promulgated charm can be accessed via its development URL.
-	err := s.store.SetPerms(charm.MustParseURL("~charmers/development/wordpress"), "read", params.Everyone)
+	err = s.store.SetPerms(charm.MustParseURL("~charmers/development/wordpress"), "read", params.Everyone)
 	c.Assert(err, gc.IsNil)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -429,85 +438,6 @@ func (s *ArchiveSuite) TestPostDevelopmentPromulgated(c *gc.C) {
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:development/trusty/wordpress-1")
-
-	// The promulgated charm cannot be retrieved using the published URL.
-	err = s.store.SetPerms(charm.MustParseURL("~charmers/wordpress"), "read", params.Everyone)
-	c.Assert(err, gc.IsNil)
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler:      s.srv,
-		URL:          storeURL("wordpress/archive"),
-		ExpectStatus: http.StatusNotFound,
-		ExpectBody: params.Error{
-			Code:    params.ErrNotFound,
-			Message: `no matching charm or bundle for "cs:wordpress"`,
-		},
-	})
-}
-
-var uploadAndPublishTests = []struct {
-	about             string
-	existing          string
-	upload            string
-	expectId          string
-	expectDevelopment bool
-}{{
-	about:             "upload same development entity",
-	existing:          "~who/development/django-0",
-	upload:            "~who/development/django",
-	expectId:          "~who/development/django-0",
-	expectDevelopment: true,
-}, {
-	about:    "upload same published entity",
-	existing: "~who/django-0",
-	upload:   "~who/django",
-	expectId: "~who/django-0",
-}, {
-	about:    "existing development, upload published",
-	existing: "~who/development/django-0",
-	upload:   "~who/django",
-	expectId: "~who/django-0",
-}, {
-	about:    "existing published, upload development",
-	existing: "~who/django-0",
-	upload:   "~who/development/django",
-	expectId: "~who/development/django-0",
-}}
-
-func (s *ArchiveSuite) TestUploadAndPublish(c *gc.C) {
-	for i, test := range uploadAndPublishTests {
-		c.Logf("%d. %s", i, test.about)
-
-		// Upload the pre-existing entity.
-		rurl := newResolvedURL(test.existing, -1)
-		s.assertUploadCharm(c, "POST", rurl, "multi-series")
-
-		// Upload the same charm again, using the upload URL.
-		body, hash, size := archiveInfo(c, "multi-series")
-		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-			Handler:       s.srv,
-			URL:           storeURL(test.upload + "/archive?hash=" + hash),
-			Method:        "POST",
-			ContentLength: size,
-			Header:        http.Header{"Content-Type": {"application/zip"}},
-			Body:          body,
-			Username:      testUsername,
-			Password:      testPassword,
-			ExpectBody: params.ArchiveUploadResponse{
-				Id: charm.MustParseURL(test.expectId),
-			},
-		})
-
-		// Check the development flag of the entity.
-		entity, err := s.store.FindEntity(rurl, charmstore.FieldSelector("development"))
-		c.Assert(err, gc.IsNil)
-		c.Assert(entity.Development, gc.Equals, test.expectDevelopment)
-
-		// Remove all entities from the store.
-		_, err = s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
-		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
-	}
 }
 
 func (s *ArchiveSuite) TestPostMultiSeriesCharm(c *gc.C) {
@@ -517,7 +447,7 @@ func (s *ArchiveSuite) TestPostMultiSeriesCharm(c *gc.C) {
 
 func (s *ArchiveSuite) TestPostMultiSeriesDevelopmentCharm(c *gc.C) {
 	// A charm that did not exist before should get revision 0.
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/juju-gui-0", -1), "multi-series")
+	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/juju-gui-0", -1), "multi-series")
 }
 
 var charmPostErrorTests = []struct {
@@ -695,17 +625,22 @@ func (s *ArchiveSuite) TestPutCharm(c *gc.C) {
 
 func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 	// Upload the required charms.
-	err := s.store.AddCharmWithArchive(
-		newResolvedURL("cs:~charmers/utopic/mysql-42", 42),
-		storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
+	url := newResolvedURL("cs:~charmers/utopic/mysql-42", 42)
+	err := s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
 	c.Assert(err, gc.IsNil)
-	err = s.store.AddCharmWithArchive(
-		newResolvedURL("cs:~charmers/utopic/wordpress-47", 47),
-		storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"))
+	err = s.store.Publish(url, charmstore.StableChannel)
 	c.Assert(err, gc.IsNil)
-	err = s.store.AddCharmWithArchive(
-		newResolvedURL("cs:~charmers/utopic/logging-1", 1),
-		storetesting.Charms.CharmArchive(c.MkDir(), "logging"))
+
+	url = newResolvedURL("cs:~charmers/utopic/wordpress-47", 47)
+	err = s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"))
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(url, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
+
+	url = newResolvedURL("cs:~charmers/utopic/logging-1", 1)
+	err = s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "logging"))
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(url, charmstore.StableChannel)
 	c.Assert(err, gc.IsNil)
 
 	// A bundle that did not exist before should get revision 0.
@@ -1558,6 +1493,8 @@ func (s *ArchiveSearchSuite) TestGetSearchUpdate(c *gc.C) {
 
 		// Add a charm to the database (including the archive).
 		err := s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
+		c.Assert(err, gc.IsNil)
+		err = s.store.Publish(url, charmstore.StableChannel)
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -39,7 +39,7 @@ var serveDiagramErrorsTests = []struct {
 	},
 }, {
 	about:        "diagram for a charm",
-	url:          "~charmers/wordpress/diagram.svg",
+	url:          "~charmers/trusty/wordpress-42/diagram.svg",
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
@@ -99,7 +99,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
-		URL:     storeURL("bundle/wordpressbundle/diagram.svg"),
+		URL:     storeURL("bundle/wordpressbundle-42/diagram.svg"),
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %q", rec.Body.Bytes()))
 	c.Assert(rec.Header().Get("Content-Type"), gc.Equals, "image/svg+xml")
@@ -120,7 +120,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	// the relative links should change accordingly.
 	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
-		URL:     storeURL("wordpressbundle/diagram.svg"),
+		URL:     storeURL("wordpressbundle-42/diagram.svg"),
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %q", rec.Body.Bytes()))
 
@@ -167,7 +167,7 @@ func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
-		URL:     storeURL("bundle/wordpressbundle/diagram.svg"),
+		URL:     storeURL("bundle/wordpressbundle-42/diagram.svg"),
 	})
 	// Check that the request succeeds and has the expected content type.
 	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %q", rec.Body.Bytes()))
@@ -255,6 +255,8 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 
 	url := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
 	err := s.store.AddCharmWithArchive(url, wordpress)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(url, charmstore.StableChannel)
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 	c.Assert(err, gc.IsNil)

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -128,6 +128,8 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 	rurl := newResolvedURL("~charmers/precise/wordpress-23", 23)
 	err := s.store.AddCharmWithArchive(rurl, ch)
 	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(rurl, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
 	c.Assert(err, gc.IsNil)
 

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
+	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 )
@@ -326,6 +327,10 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "read", test.readPerm...)
 		c.Assert(err, gc.IsNil)
 
+		// Publish the the entity.
+		err = s.store.Publish(rurl, charm.DevelopmentChannel, charmstore.StableChannel)
+		c.Assert(err, gc.IsNil)
+
 		// Define an helper function used to send requests and check responses.
 		makeRequest := func(path string, expectStatus int, expectBody interface{}) {
 			rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -342,13 +347,13 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 			}
 		}
 
-		// Perform meta and id requests.
-		makeRequest("~charmers/wordpress/meta/archive-size", test.expectStatus, test.expectBody)
-		makeRequest("~charmers/wordpress/expand-id", test.expectStatus, test.expectBody)
-
-		// Perform meta and id requests to the development channel.
+		// Perform meta and id requests on the development version.
 		makeRequest("~charmers/development/wordpress/meta/archive-size", test.expectStatus, test.expectBody)
 		makeRequest("~charmers/development/wordpress/expand-id", test.expectStatus, test.expectBody)
+
+		// Perform meta and id requests on the stable version.
+		makeRequest("~charmers/wordpress/meta/archive-size", test.expectStatus, test.expectBody)
+		makeRequest("~charmers/wordpress/expand-id", test.expectStatus, test.expectBody)
 
 		// Remove permissions for the published charm.
 		err = s.store.SetPerms(&rurl.URL, "read")
@@ -366,8 +371,10 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		// Check that now accessing the development charm is also denied.
 		makeRequest("~charmers/development/wordpress/meta/archive-size", http.StatusUnauthorized, nil)
 
-		// Remove all entities from the store.
+		// Remove all entities and base entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
+		c.Assert(err, gc.IsNil)
+		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
 		c.Assert(err, gc.IsNil)
 	}
 }
@@ -474,6 +481,10 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 		err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "write", test.writePerm...)
 		c.Assert(err, gc.IsNil)
 
+		// Publish both stable and development versions of the charm.
+		err = s.store.Publish(rurl, charm.DevelopmentChannel, charmstore.StableChannel)
+		c.Assert(err, gc.IsNil)
+
 		makeRequest := func(path string, expectStatus int, expectBody interface{}) {
 			client := httpbakery.NewHTTPClient()
 			rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -513,8 +524,10 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 		// Check that now modifying the development charm is also denied.
 		makeRequest("~charmers/development/wordpress/meta/extra-info/key", http.StatusUnauthorized, nil)
 
-		// Remove all entities from the store.
+		// Remove all entities and base entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
+		c.Assert(err, gc.IsNil)
+		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
 		c.Assert(err, gc.IsNil)
 	}
 }
@@ -551,19 +564,10 @@ var uploadEntityAuthorizationTests = []struct {
 	username: "who",
 	id:       "~who/utopic/django",
 }, {
-	about:    "user owned development entity",
-	username: "who",
-	id:       "~who/development/utopic/django",
-}, {
 	about:    "group owned entity",
 	username: "dalek",
 	groups:   []string{"group1", "group2"},
 	id:       "~group1/utopic/django",
-}, {
-	about:    "group owned development entity",
-	username: "dalek",
-	groups:   []string{"group1", "group2"},
-	id:       "~group1/development/utopic/django",
 }, {
 	about:    "specific group",
 	username: "dalek",
@@ -576,27 +580,10 @@ var uploadEntityAuthorizationTests = []struct {
 	id:          "~charmers/utopic/django",
 	promulgated: true,
 }, {
-	about:       "promulgated entity in development",
-	username:    "sisko",
-	groups:      []string{"group1", "charmers"},
-	id:          "~charmers/development/utopic/django",
-	promulgated: true,
-}, {
 	about:        "unauthorized: promulgated entity",
 	username:     "sisko",
 	groups:       []string{"group1", "group2"},
 	id:           "~charmers/utopic/django",
-	promulgated:  true,
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "sisko"`,
-	},
-}, {
-	about:        "unauthorized: promulgated entity in development",
-	username:     "sisko",
-	groups:       []string{"group1", "group2"},
-	id:           "~charmers/development/utopic/django",
 	promulgated:  true,
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -612,25 +599,8 @@ var uploadEntityAuthorizationTests = []struct {
 		Message: "unauthorized: no username declared",
 	},
 }, {
-	about:        "unauthorized: anonymous user, development entity",
-	id:           "~who/development/utopic/django",
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: "unauthorized: no username declared",
-	},
-}, {
 	about:        "unauthorized: anonymous user and promulgated entity",
 	id:           "~charmers/utopic/django",
-	promulgated:  true,
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: "unauthorized: no username declared",
-	},
-}, {
-	about:        "unauthorized: anonymous user and promulgated entity in development",
-	id:           "~charmers/development/utopic/django",
 	promulgated:  true,
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -647,15 +617,6 @@ var uploadEntityAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:        "unauthorized: user does not match for a development entity",
-	username:     "kirk",
-	id:           "~picard/development/utopic/django",
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
-	},
-}, {
 	about:        "unauthorized: group does not match",
 	username:     "kirk",
 	groups:       []string{"group1", "group2", "group3"},
@@ -666,31 +627,10 @@ var uploadEntityAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:        "unauthorized: group does not match for a development entity",
-	username:     "kirk",
-	groups:       []string{"group1", "group2", "group3"},
-	id:           "~group0/development/utopic/django",
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
-	},
-}, {
 	about:        "unauthorized: specific group and promulgated entity",
 	username:     "janeway",
 	groups:       []string{"group1"},
 	id:           "~charmers/utopic/django",
-	promulgated:  true,
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "janeway"`,
-	},
-}, {
-	about:        "unauthorized: specific group and promulgated entity in development",
-	username:     "janeway",
-	groups:       []string{"group1"},
-	id:           "~charmers/development/utopic/django",
 	promulgated:  true,
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -842,9 +782,11 @@ func (s *authSuite) TestIsEntityCaveat(c *gc.C) {
 		newResolvedURL("~charmers/utopic/wordpress-41", 9),
 		storetesting.Charms.CharmDir("wordpress"))
 	c.Assert(err, gc.IsNil)
-	err = s.store.AddCharmWithArchive(
-		newResolvedURL("~charmers/utopic/wordpress-42", 10),
-		storetesting.Charms.CharmDir("wordpress"))
+	url := newResolvedURL("~charmers/utopic/wordpress-42", 10)
+	err = s.store.AddCharmWithArchive(url, storetesting.Charms.CharmDir("wordpress"))
+	c.Assert(err, gc.IsNil)
+	// Publish the testing charm as stable.
+	err = s.store.Publish(url, charmstore.StableChannel)
 	c.Assert(err, gc.IsNil)
 	// Change the ACLs for the testing charm.
 	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "read", "bob")
@@ -943,7 +885,7 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 	// First check that we require authorization to access the charm.
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
-		URL:     storeURL("~charmers/utopic/wordpress/meta/id-name"),
+		URL:     storeURL("~charmers/utopic/wordpress-41/meta/id-name"),
 		Method:  "GET",
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusProxyAuthRequired)
@@ -959,7 +901,7 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,
-		URL:     storeURL("~charmers/utopic/wordpress/meta/id-name"),
+		URL:     storeURL("~charmers/utopic/wordpress-41/meta/id-name"),
 		ExpectBody: params.IdNameResponse{
 			Name: "wordpress",
 		},

--- a/internal/v5/bench_test.go
+++ b/internal/v5/bench_test.go
@@ -17,7 +17,10 @@ type BenchmarkSuite struct {
 var _ = gc.Suite(&BenchmarkSuite{})
 
 func (s *BenchmarkSuite) TestBenchmarkMeta(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
+	u := newResolvedURL("~charmers/precise/wordpress-23", 23)
+	s.addPublicCharm(c, "wordpress", u)
+	err := s.store.Publish(u, charm.DevelopmentChannel)
+	c.Assert(err, gc.IsNil)
 	srv := httptest.NewServer(s.srv)
 	defer srv.Close()
 	url := srv.URL + storeURL("wordpress/meta/archive-size")

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -236,6 +236,7 @@ func (s *commonSuite) addPublicBundle(c *gc.C, bundleName string, rurl *router.R
 func (s *commonSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
 	for id, ch := range charms {
 		url := mustParseResolvedURL(id)
+		c.Logf("adding charm %q to db", url)
 		// The blob related info are not used in these tests.
 		// The related charms are retrieved from the entities collection,
 		// without accessing the blob store.
@@ -246,6 +247,13 @@ func (s *commonSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
 			BlobSize: fakeBlobSize,
 		})
 		c.Assert(err, gc.IsNil, gc.Commentf("id %q", id))
+		channel := charmstore.StableChannel
+		if url.Development {
+			channel = charm.DevelopmentChannel
+		}
+		url.Development = false
+		err = s.store.Publish(url, channel)
+		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)
 		if url.Development {

--- a/internal/v5/content_test.go
+++ b/internal/v5/content_test.go
@@ -40,7 +40,7 @@ var serveDiagramErrorsTests = []struct {
 	},
 }, {
 	about:        "diagram for a charm",
-	url:          "~charmers/wordpress/diagram.svg",
+	url:          "~charmers/trusty/wordpress-42/diagram.svg",
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
@@ -100,7 +100,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
-		URL:     storeURL("bundle/wordpressbundle/diagram.svg"),
+		URL:     storeURL("bundle/wordpressbundle-42/diagram.svg"),
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %q", rec.Body.Bytes()))
 	c.Assert(rec.Header().Get("Content-Type"), gc.Equals, "image/svg+xml")
@@ -121,7 +121,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	// the relative links should change accordingly.
 	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
-		URL:     storeURL("wordpressbundle/diagram.svg"),
+		URL:     storeURL("wordpressbundle-42/diagram.svg"),
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %q", rec.Body.Bytes()))
 
@@ -168,7 +168,7 @@ func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
-		URL:     storeURL("bundle/wordpressbundle/diagram.svg"),
+		URL:     storeURL("bundle/wordpressbundle-42/diagram.svg"),
 	})
 	// Check that the request succeeds and has the expected content type.
 	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %q", rec.Body.Bytes()))
@@ -256,6 +256,8 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 
 	url := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
 	err := s.store.AddCharmWithArchive(url, wordpress)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(url, charmstore.StableChannel)
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 	c.Assert(err, gc.IsNil)

--- a/internal/v5/list_test.go
+++ b/internal/v5/list_test.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/macaroon.v1"
 	"gopkg.in/mgo.v2/bson"
 
+	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
@@ -55,7 +56,7 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 	err := s.store.DB.BaseEntities().UpdateId(
 		charm.MustParseURL("cs:~charmers/riak"),
 		bson.D{{"$set", map[string]mongodoc.ACL{
-			"acls": {
+			"stableacls": {
 				Read: []string{"charmers", "test-user"},
 			},
 		}}},
@@ -64,21 +65,23 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ListSuite) addCharmsToStore(c *gc.C) {
-	for name, id := range exportListTestCharms {
-		err := s.store.AddCharmWithArchive(id, getCharm(name))
+	publishAndUpdate := func(id *router.ResolvedURL) {
+		err := s.store.Publish(id, charmstore.StableChannel)
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 		c.Assert(err, gc.IsNil)
 		err = s.store.UpdateSearch(id)
 		c.Assert(err, gc.IsNil)
 	}
+	for name, id := range exportListTestCharms {
+		err := s.store.AddCharmWithArchive(id, getCharm(name))
+		c.Assert(err, gc.IsNil)
+		publishAndUpdate(id)
+	}
 	for name, id := range exportListTestBundles {
 		err := s.store.AddBundleWithArchive(id, getListBundle(name))
 		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.UpdateSearch(id)
-		c.Assert(err, gc.IsNil)
+		publishAndUpdate(id)
 	}
 }
 
@@ -253,7 +256,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 		},
 	}}
 	for i, test := range tests {
-		c.Logf("test %d. %s", i, test.about)
+		c.Logf("\ntest %d. %s", i, test.about)
 		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 			Handler: s.srv,
 			URL:     storeURL("list?" + test.query),
@@ -409,7 +412,10 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/precise/wordpress-24", 24)
 	err := s.store.AddCharmWithArchive(id, getCharm("wordpress"))
 	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(id, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
+	c.Assert(err, gc.IsNil)
 
 	testresults := []*router.ResolvedURL{
 		exportTestBundles["wordpress-simple"],
@@ -425,7 +431,7 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 	var sr params.ListResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &sr)
 	c.Assert(err, gc.IsNil)
-	c.Assert(sr.Results, gc.HasLen, 4, gc.Commentf("expected %#v", testresults))
+	c.Assert(sr.Results, gc.HasLen, len(testresults), gc.Commentf("expected %#v", testresults))
 	c.Logf("results: %s", rec.Body.Bytes())
 	for i := range testresults {
 		c.Assert(sr.Results[i].Id.String(), gc.Equals, testresults[i].PreferredURL().String(), gc.Commentf("element %d"))
@@ -443,7 +449,7 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 	})
 	err = json.Unmarshal(rec.Body.Bytes(), &sr)
 	c.Assert(err, gc.IsNil)
-	c.Assert(sr.Results, gc.HasLen, 4, gc.Commentf("expected %#v", testresults))
+	c.Assert(sr.Results, gc.HasLen, len(testresults), gc.Commentf("expected %#v", testresults))
 	c.Logf("results: %s", rec.Body.Bytes())
 	for i := range testresults {
 		c.Assert(sr.Results[i].Id.String(), gc.Equals, testresults[i].PreferredURL().String(), gc.Commentf("element %d"))

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -20,6 +20,7 @@ import (
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 )
 
@@ -421,7 +422,7 @@ var metaCharmRelatedTests = []struct {
 
 func (s *RelationsSuite) TestMetaCharmRelated(c *gc.C) {
 	for i, test := range metaCharmRelatedTests {
-		c.Logf("test %d: %s", i, test.about)
+		c.Logf("\ntest %d: %s", i, test.about)
 		s.addCharms(c, test.charms)
 		s.setPerms(c, test.readACLs)
 		storeURL := storeURL(test.id + "/meta/charm-related" + test.querystring)
@@ -792,6 +793,8 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
 		c.Assert(err, gc.IsNil)
+		err = s.store.Publish(rurl, charmstore.StableChannel)
+		c.Assert(err, gc.IsNil)
 
 		// Perform the request and ensure the response is what we expect.
 		storeURL := storeURL(test.id + "/meta/bundles-containing" + test.querystring)
@@ -802,8 +805,10 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 			ExpectBody:   sameMetaAnyResponses(test.expectBody),
 		})
 
-		// Clean up the charm entity in the store.
+		// Clean up the charm entity and base entity in the store.
 		err = s.store.DB.Entities().Remove(bson.D{{"_id", &rurl.URL}})
+		c.Assert(err, gc.IsNil)
+		err = s.store.DB.BaseEntities().Remove(bson.D{{"_id", mongodoc.BaseURL(&rurl.URL)}})
 		c.Assert(err, gc.IsNil)
 	}
 }

--- a/internal/v5/search_test.go
+++ b/internal/v5/search_test.go
@@ -69,21 +69,23 @@ func (s *SearchSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *SearchSuite) addCharmsToStore(c *gc.C) {
-	for name, id := range exportTestCharms {
-		err := s.store.AddCharmWithArchive(id, getCharm(name))
+	publishAndUpdate := func(id *router.ResolvedURL) {
+		err := s.store.Publish(id, charmstore.StableChannel)
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 		c.Assert(err, gc.IsNil)
 		err = s.store.UpdateSearch(id)
 		c.Assert(err, gc.IsNil)
 	}
+	for name, id := range exportTestCharms {
+		err := s.store.AddCharmWithArchive(id, getCharm(name))
+		c.Assert(err, gc.IsNil)
+		publishAndUpdate(id)
+	}
 	for name, id := range exportTestBundles {
 		err := s.store.AddBundleWithArchive(id, getBundle(name))
 		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.UpdateSearch(id)
-		c.Assert(err, gc.IsNil)
+		publishAndUpdate(id)
 	}
 }
 
@@ -721,6 +723,8 @@ func (s *SearchSuite) TestDownloadsBoost(c *gc.C) {
 		url := newResolvedURL("cs:~downloads-test/trusty/x-1", -1)
 		url.URL.Name = n
 		err := s.store.AddCharmWithArchive(url, getCharm(n))
+		c.Assert(err, gc.IsNil)
+		err = s.store.Publish(url, charmstore.StableChannel)
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)

--- a/internal/v5/stats_test.go
+++ b/internal/v5/stats_test.go
@@ -133,6 +133,8 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 	rurl := newResolvedURL("~charmers/precise/wordpress-23", 23)
 	err := s.store.AddCharmWithArchive(rurl, ch)
 	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(rurl, charmstore.StableChannel)
+	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
 	c.Assert(err, gc.IsNil)
 


### PR DESCRIPTION
This branch proposes an implementation a the slightly changed
uploading and publishing model for the charm store, as
discussed in Cape Town.

In the new model we separate entities in two groups:
- unpublished entities;
- entities with at least one channel assigned.
  For the time being we support two channels: stable and development.
  When you first upload an entity, it is unpublished, and it can be
  referenced only by a restricted set of users (defined in BaseEntity.ACLs)
  using the specific revision. The publish endpoint can then be used to
  assign one or more channels to the entity, and contextually set the 
  corresponding entity as the current one for that channel, meaning
  it's the one being referenced when the revision is not specified.
  The whole model is better described in the model change google doc.

It's a long diff and I apologize, but lots of lines are related
to v5/v4 test changes, some are code removal, etc.
And yet there are many things that are missing and that are 
required here:, notably:
- modify expand-id (both v5 nd v4);
- fix expand-id tests;
- add tests for the included migrations;
- move publish request to charm package;
- extend publish and meta/perm responses;
- update documentation to reflect new endpoint semantics;
- add meta/channels API endpoint (doable in another branch).
