### PR TITLE
internal/charmstore: move upload logic from API level

### DIFF
--- a/internal/charmstore/addentity.go
+++ b/internal/charmstore/addentity.go
@@ -1,0 +1,653 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charmstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/series"
+)
+
+// addParams holds parameters held in common between the
+// Store.addCharm and Store.addBundle methods.
+type addParams struct {
+	// URL holds the id to be associated with the stored entity.
+	// If URL.PromulgatedRevision is not -1, the entity will
+	// be promulgated.
+	URL *router.ResolvedURL
+
+	// BlobName holds the name of the entity's archive blob.
+	BlobName string
+
+	// BlobHash holds the hash of the entity's archive blob.
+	BlobHash string
+
+	// BlobHash256 holds the sha256 hash of the entity's archive blob.
+	BlobHash256 string
+
+	// BlobHash holds the size of the entity's archive blob.
+	BlobSize int64
+}
+
+// putArchive reads the charm or bundle archive from the given reader and
+// puts into the blob store. The archiveSize and hash must holds the length
+// of the blob content and its SHA384 hash respectively.
+func (s *Store) putArchive(blob io.Reader, blobSize int64, hash string) (blobName, blobHash256 string, err error) {
+	name := bson.NewObjectId().Hex()
+
+	// Calculate the SHA256 hash while uploading the blob in the blob store.
+	hash256 := sha256.New()
+	blob = io.TeeReader(blob, hash256)
+
+	// Upload the actual blob, and make sure that it is removed
+	// if we fail later.
+	err = s.BlobStore.PutUnchallenged(blob, name, blobSize, hash)
+	if err != nil {
+		return "", "", errgo.Notef(err, "cannot put archive blob")
+	}
+	return name, fmt.Sprintf("%x", hash256.Sum(nil)), nil
+}
+
+// AddCharmWithArchive adds the given charm, which must
+// be either a *charm.CharmDir or implement ArchiverTo,
+// to the charmstore under the given URL.
+//
+// This method is provided for testing purposes only.
+func (s *Store) AddCharmWithArchive(url *router.ResolvedURL, ch charm.Charm) error {
+	return s.addEntityWithArchive(url, ch)
+}
+
+// AddBundleWithArchive adds the given bundle, which must
+// be either a *charm.BundleDir or implement ArchiverTo,
+// to the charmstore under the given URL.
+//
+// This method is provided for testing purposes only.
+func (s *Store) AddBundleWithArchive(url *router.ResolvedURL, b charm.Bundle) error {
+	return s.addEntityWithArchive(url, b)
+}
+
+// addEntityWithArchive provides the implementation for
+// both AddCharmWithArchive and AddBundleWithArchive.
+func (s *Store) addEntityWithArchive(url *router.ResolvedURL, archive interface{}) error {
+	blob, err := getArchive(archive)
+	if err != nil {
+		return errgo.Notef(err, "cannot get archive")
+	}
+	defer blob.Close()
+	hash := blobstore.NewHash()
+	size, err := io.Copy(hash, blob)
+	if err != nil {
+		return errgo.Notef(err, "cannot copy archive")
+	}
+	if _, err := blob.Seek(0, 0); err != nil {
+		return errgo.Notef(err, "cannot seek to start of archive")
+	}
+	if err := s.UploadEntity(url, blob, fmt.Sprintf("%x", hash.Sum(nil)), size); err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+	return nil
+}
+
+// UploadEntity reads the given blob, which should have the given hash
+// and size, and uploads it to the charm store. The following error
+// causes may be returned:
+//	params.ErrDuplicateUpload if the URL duplicates an existing entity.
+//	params.ErrEntityIdNotAllowed if the id may not be created.
+//	params.ErrInvalidEntity if the provided blob is invalid.
+func (s *Store) UploadEntity(url *router.ResolvedURL, blob io.Reader, blobHash string, size int64) error {
+	logger.Infof("uploading entity with blob hash %v", blobHash)
+	blobName, blobHash256, err := s.putArchive(blob, size, blobHash)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	r, _, err := s.BlobStore.Open(blobName)
+	if err != nil {
+		return errgo.Notef(err, "cannot open newly created blob")
+	}
+	defer r.Close()
+	if err := s.addEntityFromReader(url, r, blobName, blobHash, blobHash256, size); err != nil {
+		if err1 := s.BlobStore.Remove(blobName); err1 != nil {
+			logger.Errorf("cannot remove blob %s after error: %v", blobName, err1)
+		}
+		return errgo.Mask(err,
+			errgo.Is(params.ErrDuplicateUpload),
+			errgo.Is(params.ErrEntityIdNotAllowed),
+			errgo.Is(params.ErrInvalidEntity),
+		)
+	}
+	return nil
+}
+
+// addEntityFromReader adds the entity represented by the contents
+// of the given reader, associating it with the given id.
+func (s *Store) addEntityFromReader(id *router.ResolvedURL, r io.ReadSeeker, blobName, hash, hash256 string, blobSize int64) error {
+	p := addParams{
+		URL:         id,
+		BlobName:    blobName,
+		BlobHash:    hash,
+		BlobHash256: hash256,
+		BlobSize:    blobSize,
+	}
+	if id.URL.Series == "bundle" {
+		b, err := s.newBundle(id, r, blobSize)
+		if err != nil {
+			return errgo.Mask(err, errgo.Is(params.ErrInvalidEntity), errgo.Is(params.ErrDuplicateUpload), errgo.Is(params.ErrEntityIdNotAllowed))
+		}
+		if err := s.addBundle(b, p); err != nil {
+			return errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload), errgo.Is(params.ErrEntityIdNotAllowed))
+		}
+		return nil
+	}
+	ch, err := s.newCharm(id, r, blobSize)
+	if err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrInvalidEntity), errgo.Is(params.ErrDuplicateUpload), errgo.Is(params.ErrEntityIdNotAllowed))
+	}
+	if err := s.addCharm(ch, p); err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload), errgo.Is(params.ErrEntityIdNotAllowed))
+	}
+	return nil
+}
+
+// newCharm returns a new charm implementation from the archive blob
+// read from r, that should have the given size and will
+// be named with the given id.
+//
+// The charm is checked for validity before returning.
+func (s *Store) newCharm(id *router.ResolvedURL, r io.ReadSeeker, blobSize int64) (charm.Charm, error) {
+	readerAt := ReaderAtSeeker(r)
+	ch, err := charm.ReadCharmArchiveFromReader(readerAt, blobSize)
+	if err != nil {
+		return nil, zipReadError(err, "cannot read charm archive")
+	}
+	if err := checkCharmIsValid(ch); err != nil {
+		return nil, errgo.Mask(err, errgo.Is(params.ErrInvalidEntity))
+	}
+	if err := checkIdAllowed(id, ch); err != nil {
+		return nil, errgo.Mask(err, errgo.Is(params.ErrEntityIdNotAllowed))
+	}
+	return ch, nil
+}
+
+func checkCharmIsValid(ch charm.Charm) error {
+	m := ch.Meta()
+	for _, rels := range []map[string]charm.Relation{m.Provides, m.Requires, m.Peers} {
+		if err := checkRelationsAreValid(rels); err != nil {
+			return errgo.Mask(err, errgo.Is(params.ErrInvalidEntity))
+		}
+	}
+	if err := checkConsistentSeries(m.Series); err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrInvalidEntity))
+	}
+	return nil
+}
+
+func checkRelationsAreValid(rels map[string]charm.Relation) error {
+	for _, rel := range rels {
+		if rel.Name == "relation-name" {
+			return errgo.WithCausef(nil, params.ErrInvalidEntity, "relation %s has almost certainly not been changed from the template", rel.Name)
+		}
+		if rel.Interface == "interface-name" {
+			return errgo.WithCausef(nil, params.ErrInvalidEntity, "interface %s in relation %s has almost certainly not been changed from the template", rel.Interface, rel.Name)
+		}
+	}
+	return nil
+}
+
+// checkConsistentSeries ensures that all of the series listed in the
+// charm metadata come from the same distribution. If an error is
+// returned it will have a cause of params.ErrInvalidEntity.
+func checkConsistentSeries(metadataSeries []string) error {
+	var dist series.Distribution
+	for _, s := range metadataSeries {
+		d := series.Series[s].Distribution
+		if d == "" {
+			return errgo.WithCausef(nil, params.ErrInvalidEntity, "unrecognised series %q in metadata", s)
+		}
+		if dist == "" {
+			dist = d
+		} else if dist != d {
+			return errgo.WithCausef(nil, params.ErrInvalidEntity, "cannot mix series from %s and %s in single charm", dist, d)
+		}
+	}
+	return nil
+}
+
+// checkIdAllowed ensures that the given id may be used for the provided
+// charm. If an error is returned it will have a cause of
+// params.ErrEntityIdNotAllowed.
+func checkIdAllowed(id *router.ResolvedURL, ch charm.Charm) error {
+	m := ch.Meta()
+	if id.URL.Series == "" && len(m.Series) == 0 {
+		return errgo.WithCausef(nil, params.ErrEntityIdNotAllowed, "series not specified in url or charm metadata")
+	} else if id.URL.Series == "" || len(m.Series) == 0 {
+		return nil
+	}
+	// if we get here we have series in both the id and metadata, ensure they agree.
+	for _, s := range m.Series {
+		if s == id.URL.Series {
+			return nil
+		}
+	}
+	return errgo.WithCausef(nil, params.ErrEntityIdNotAllowed, "%q series not listed in charm metadata", id.URL.Series)
+}
+
+// addCharm adds a charm to the entities collection with the given parameters.
+// If p.URL cannot be used as a name for the charm then the returned
+// error will have the cause params.ErrEntityIdNotAllowed. If the charm
+// duplicates an existing charm then the returned error will have the
+// cause params.ErrDuplicateUpload.
+func (s *Store) addCharm(c charm.Charm, p addParams) (err error) {
+	// Strictly speaking this test is redundant, because a ResolvedURL should
+	// always be canonical, but check just in case anyway, as this is
+	// final gateway before a potentially invalid url might be stored
+	// in the database.
+	id := p.URL.URL
+	if id.Series == "bundle" || id.User == "" || id.Revision == -1 {
+		return errgo.Newf("charm added with invalid id %v", &id)
+	}
+	logger.Infof("add charm url %s; prev %d; dev %v", &id, p.URL.PromulgatedRevision, p.URL.Development)
+	entity := &mongodoc.Entity{
+		URL:                     &id,
+		PromulgatedURL:          p.URL.DocPromulgatedURL(),
+		BlobHash:                p.BlobHash,
+		BlobHash256:             p.BlobHash256,
+		BlobName:                p.BlobName,
+		Size:                    p.BlobSize,
+		UploadTime:              time.Now(),
+		CharmMeta:               c.Meta(),
+		CharmConfig:             c.Config(),
+		CharmActions:            c.Actions(),
+		CharmProvidedInterfaces: interfacesForRelations(c.Meta().Provides),
+		CharmRequiredInterfaces: interfacesForRelations(c.Meta().Requires),
+		SupportedSeries:         c.Meta().Series,
+		Development:             p.URL.Development,
+	}
+	denormalizeEntity(entity)
+
+	// Check that we're not going to create a charm that duplicates
+	// the name of a bundle. This is racy, but it's the best we can
+	// do. Also check that there isn't an existing multi-series charm
+	// that would be replaced by this one.
+	entities, err := s.FindEntities(entity.BaseURL, nil)
+	if err != nil {
+		return errgo.Notef(err, "cannot check for existing entities")
+	}
+	for _, entity := range entities {
+		if entity.URL.Series == "bundle" {
+			return errgo.WithCausef(err, params.ErrEntityIdNotAllowed, "charm name duplicates bundle name %v", entity.URL)
+		}
+		if id.Series != "" && entity.URL.Series == "" {
+			return errgo.WithCausef(err, params.ErrEntityIdNotAllowed, "charm name duplicates multi-series charm name %v", entity.URL)
+		}
+	}
+	if err := s.addEntity(entity); err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload))
+	}
+	return nil
+}
+
+// addBundle adds a bundle to the entities collection with the given
+// parameters. If p.URL cannot be used as a name for the bundle then the
+// returned error will have the cause params.ErrEntityIdNotAllowed. If
+// the bundle duplicates an existing bundle then the returned error will
+// have the cause params.ErrDuplicateUpload.
+func (s *Store) addBundle(b charm.Bundle, p addParams) error {
+	// Strictly speaking this test is redundant, because a ResolvedURL should
+	// always be canonical, but check just in case anyway, as this is
+	// final gateway before a potentially invalid url might be stored
+	// in the database.
+	if p.URL.URL.Series != "bundle" || p.URL.URL.User == "" || p.URL.URL.Revision == -1 || p.URL.URL.Series == "" {
+		return errgo.Newf("bundle added with invalid id %v", p.URL)
+	}
+	bundleData := b.Data()
+	urls, err := bundleCharms(bundleData)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	entity := &mongodoc.Entity{
+		URL:                &p.URL.URL,
+		BlobHash:           p.BlobHash,
+		BlobHash256:        p.BlobHash256,
+		BlobName:           p.BlobName,
+		Size:               p.BlobSize,
+		UploadTime:         time.Now(),
+		BundleData:         bundleData,
+		BundleUnitCount:    newInt(bundleUnitCount(bundleData)),
+		BundleMachineCount: newInt(bundleMachineCount(bundleData)),
+		BundleReadMe:       b.ReadMe(),
+		BundleCharms:       urls,
+		PromulgatedURL:     p.URL.DocPromulgatedURL(),
+		Development:        p.URL.Development,
+	}
+	denormalizeEntity(entity)
+
+	// Check that we're not going to create a bundle that duplicates
+	// the name of a charm. This is racy, but it's the best we can do.
+	entities, err := s.FindEntities(entity.BaseURL, nil)
+	if err != nil {
+		return errgo.Notef(err, "cannot check for existing entities")
+	}
+	for _, entity := range entities {
+		if entity.URL.Series != "bundle" {
+			return errgo.WithCausef(err, params.ErrEntityIdNotAllowed, "bundle name duplicates charm name %s", entity.URL)
+		}
+	}
+	if err := s.addEntity(entity); err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload))
+	}
+	return nil
+}
+
+// addEntity actually adds the entity (and its base entity if required) to
+// the database. It assumes that the blob associated with the
+// entity has already been validated and stored.
+func (s *Store) addEntity(entity *mongodoc.Entity) (err error) {
+	// Add the base entity to the database.
+	perms := []string{entity.User}
+	acls := mongodoc.ACL{
+		Read:  perms,
+		Write: perms,
+	}
+	baseEntity := &mongodoc.BaseEntity{
+		URL:             entity.BaseURL,
+		User:            entity.User,
+		Name:            entity.Name,
+		Public:          false,
+		ACLs:            acls,
+		DevelopmentACLs: acls,
+		Promulgated:     entity.PromulgatedURL != nil,
+	}
+	err = s.DB.BaseEntities().Insert(baseEntity)
+	if err != nil && !mgo.IsDup(err) {
+		return errgo.Notef(err, "cannot insert base entity")
+	}
+
+	// Add the entity to the database.
+	err = s.DB.Entities().Insert(entity)
+	if mgo.IsDup(err) {
+		return params.ErrDuplicateUpload
+	}
+	if err != nil {
+		return errgo.Notef(err, "cannot insert entity")
+	}
+	// Ensure that if anything fails after this, that we delete
+	// the entity, otherwise we will be left in an internally
+	// inconsistent state.
+	defer func() {
+		if err != nil {
+			if err := s.DB.Entities().RemoveId(entity.URL); err != nil {
+				logger.Errorf("cannot remove entity after elastic search failure: %v", err)
+			}
+		}
+	}()
+	// Add entity to ElasticSearch.
+	if err := s.UpdateSearch(EntityResolvedURL(entity)); err != nil {
+		return errgo.Notef(err, "cannot index %s to ElasticSearch", entity.URL)
+	}
+	return nil
+}
+
+// denormalizeEntity sets all denormalized fields in e
+// from their associated canonical fields.
+//
+// It is the responsibility of the caller to set e.SupportedSeries
+// if the entity URL does not contain a series. If the entity
+// URL *does* contain a series, e.SupportedSeries will
+// be overwritten.
+func denormalizeEntity(e *mongodoc.Entity) {
+	e.BaseURL = mongodoc.BaseURL(e.URL)
+	e.Name = e.URL.Name
+	e.User = e.URL.User
+	e.Revision = e.URL.Revision
+	e.Series = e.URL.Series
+	if e.URL.Series != "" {
+		if e.URL.Series == "bundle" {
+			e.SupportedSeries = nil
+		} else {
+			e.SupportedSeries = []string{e.URL.Series}
+		}
+	}
+	if e.PromulgatedURL == nil {
+		e.PromulgatedRevision = -1
+	} else {
+		e.PromulgatedRevision = e.PromulgatedURL.Revision
+	}
+}
+
+// newBundle returns a new bundle implementation from the archive blob
+// read from r, that should have the given size and will
+// be named with the given id.
+//
+// The bundle is checked for validity before returning.
+func (s *Store) newBundle(id *router.ResolvedURL, r io.ReadSeeker, blobSize int64) (charm.Bundle, error) {
+	readerAt := ReaderAtSeeker(r)
+	b, err := charm.ReadBundleArchiveFromReader(readerAt, blobSize)
+	if err != nil {
+		return nil, zipReadError(err, "cannot read bundle archive")
+	}
+	bundleData := b.Data()
+	charms, err := s.bundleCharms(bundleData.RequiredCharms())
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot retrieve bundle charms")
+	}
+	if err := bundleData.VerifyWithCharms(verifyConstraints, verifyStorage, charms); err != nil {
+		// TODO frankban: use multiError (defined in internal/router).
+		return nil, errgo.NoteMask(verificationError(err), "bundle verification failed", errgo.Is(params.ErrInvalidEntity))
+	}
+	return b, nil
+}
+
+func (s *Store) bundleCharms(ids []string) (map[string]charm.Charm, error) {
+	numIds := len(ids)
+	urls := make([]*charm.URL, 0, numIds)
+	idKeys := make([]string, 0, numIds)
+	// TODO resolve ids concurrently.
+	for _, id := range ids {
+		url, err := charm.ParseURL(id)
+		if err != nil {
+			// Ignore this error. This will be caught in the bundle
+			// verification process (see bundleData.VerifyWithCharms) and will
+			// be returned to the user along with other bundle errors.
+			continue
+		}
+		e, err := s.FindBestEntity(url, map[string]int{})
+		if err != nil {
+			if errgo.Cause(err) == params.ErrNotFound {
+				// Ignore this error too, for the same reasons
+				// described above.
+				continue
+			}
+			return nil, err
+		}
+		urls = append(urls, e.URL)
+		idKeys = append(idKeys, id)
+	}
+	var entities []mongodoc.Entity
+	if err := s.DB.Entities().
+		Find(bson.D{{"_id", bson.D{{"$in", urls}}}}).
+		All(&entities); err != nil {
+		return nil, err
+	}
+
+	entityCharms := make(map[charm.URL]charm.Charm, len(entities))
+	for i, entity := range entities {
+		entityCharms[*entity.URL] = &entityCharm{entities[i]}
+	}
+	charms := make(map[string]charm.Charm, len(urls))
+	for i, url := range urls {
+		if ch, ok := entityCharms[*url]; ok {
+			charms[idKeys[i]] = ch
+		}
+	}
+	return charms, nil
+}
+
+// bundleCharms returns all the charm URLs used by a bundle,
+// without duplicates.
+// XXX is this still used?
+func bundleCharms(data *charm.BundleData) ([]*charm.URL, error) {
+	// Use a map to de-duplicate the URL list: a bundle can include services
+	// deployed by the same charm.
+	urlMap := make(map[string]*charm.URL)
+	for _, service := range data.Services {
+		url, err := charm.ParseURL(service.Charm)
+		if err != nil {
+			return nil, errgo.Mask(err)
+		}
+		urlMap[url.String()] = url
+		// Also add the corresponding base URL.
+		base := mongodoc.BaseURL(url)
+		urlMap[base.String()] = base
+	}
+	urls := make([]*charm.URL, 0, len(urlMap))
+	for _, url := range urlMap {
+		urls = append(urls, url)
+	}
+	return urls, nil
+}
+
+func newInt(x int) *int {
+	return &x
+}
+
+// bundleUnitCount returns the number of units created by the bundle.
+func bundleUnitCount(b *charm.BundleData) int {
+	count := 0
+	for _, service := range b.Services {
+		count += service.NumUnits
+	}
+	return count
+}
+
+// bundleMachineCount returns the number of machines
+// that will be created or used by the bundle.
+func bundleMachineCount(b *charm.BundleData) int {
+	count := len(b.Machines)
+	for _, service := range b.Services {
+		// The default placement is "new".
+		placement := &charm.UnitPlacement{
+			Machine: "new",
+		}
+		// Check for "new" placements, which means a new machine
+		// must be added.
+		for _, location := range service.To {
+			var err error
+			placement, err = charm.ParsePlacement(location)
+			if err != nil {
+				// Ignore invalid placements - a bundle should always
+				// be verified before adding to the charm store so this
+				// should never happen in practice.
+				continue
+			}
+			if placement.Machine == "new" {
+				count++
+			}
+		}
+		// If there are less elements in To than NumUnits, the last placement
+		// element is replicated. For this reason, if the last element is
+		// "new", we need to add more machines.
+		if placement != nil && placement.Machine == "new" {
+			count += service.NumUnits - len(service.To)
+		}
+	}
+	return count
+}
+
+func interfacesForRelations(rels map[string]charm.Relation) []string {
+	// Eliminate duplicates by storing interface names into a map.
+	interfaces := make(map[string]bool)
+	for _, rel := range rels {
+		interfaces[rel.Interface] = true
+	}
+	result := make([]string, 0, len(interfaces))
+	for iface := range interfaces {
+		result = append(result, iface)
+	}
+	return result
+}
+
+// zipReadError creates an appropriate error for errors in reading an
+// uploaded archive. If the archive could not be read because the data
+// uploaded is invalid then an error with a cause of
+// params.ErrInvalidEntity will be returned. The given message will be
+// added as context.
+func zipReadError(err error, msg string) error {
+	switch errgo.Cause(err) {
+	case zip.ErrFormat, zip.ErrAlgorithm, zip.ErrChecksum:
+		return errgo.WithCausef(err, params.ErrInvalidEntity, msg)
+
+	}
+	return errgo.Notef(err, msg)
+}
+
+func verifyConstraints(s string) error {
+	// TODO(rog) provide some actual constraints checking here.
+	return nil
+}
+
+func verifyStorage(s string) error {
+	// TODO(frankban) provide some actual storage checking here.
+	return nil
+}
+
+// verificationError returns an error whose string representation is a list of
+// all the verification error messages stored in err, in JSON format.
+// Note that err must be a *charm.VerificationError.
+func verificationError(err error) error {
+	verr, ok := err.(*charm.VerificationError)
+	if !ok {
+		return err
+	}
+	messages := make([]string, len(verr.Errors))
+	for i, err := range verr.Errors {
+		messages[i] = err.Error()
+	}
+	sort.Strings(messages)
+	encodedMessages, err := json.Marshal(messages)
+	if err != nil {
+		// This should never happen.
+		return err
+	}
+	return errgo.WithCausef(nil, params.ErrInvalidEntity, string(encodedMessages))
+}
+
+// entityCharm implements charm.Charm.
+type entityCharm struct {
+	mongodoc.Entity
+}
+
+func (e *entityCharm) Meta() *charm.Meta {
+	return e.CharmMeta
+}
+
+func (e *entityCharm) Metrics() *charm.Metrics {
+	return nil
+}
+
+func (e *entityCharm) Config() *charm.Config {
+	return e.CharmConfig
+}
+
+func (e *entityCharm) Actions() *charm.Actions {
+	return e.CharmActions
+}
+
+func (e *entityCharm) Revision() int {
+	return e.URL.Revision
+}

--- a/internal/charmstore/archive.go
+++ b/internal/charmstore/archive.go
@@ -14,7 +14,10 @@ import (
 	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
 )
 
-type archiverTo interface {
+// ArchiverTo can be used to archive a charm or bundle's
+// contents to a writer. It is implemented by *charm.CharmArchive
+// and *charm.BundleArchive.
+type ArchiverTo interface {
 	ArchiveTo(io.Writer) error
 }
 
@@ -23,7 +26,7 @@ type archiverTo interface {
 func getArchive(c interface{}) (blobstore.ReadSeekCloser, error) {
 	var path string
 	switch c := c.(type) {
-	case archiverTo:
+	case ArchiverTo:
 		// For example: charm.CharmDir or charm.BundleDir.
 		var buffer bytes.Buffer
 		if err := c.ArchiveTo(&buffer); err != nil {

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -237,8 +237,9 @@ func (s *StoreSearchSuite) addCharmsToStore(c *gc.C) {
 		for i, s := range cats {
 			tags[i] = s + "TAG"
 		}
-		charmArchive.Meta().Tags = tags
-		err := s.store.AddCharmWithArchive(EntityResolvedURL(ent), charmArchive)
+		meta := charmArchive.Meta()
+		meta.Tags = tags
+		err := s.store.AddCharmWithArchive(EntityResolvedURL(ent), storetesting.NewCharm(meta))
 		c.Assert(err, gc.IsNil)
 		for i := 0; i < charmDownloadCounts[name]; i++ {
 			err := s.store.IncrementDownloadCounts(EntityResolvedURL(ent))
@@ -254,8 +255,9 @@ func (s *StoreSearchSuite) addCharmsToStore(c *gc.C) {
 	}
 	for name, ent := range exportTestBundles {
 		bundleArchive := storetesting.Charms.BundleDir(name)
-		bundleArchive.Data().Tags = strings.Split(name, "-")
-		err := s.store.AddBundleWithArchive(EntityResolvedURL(ent), bundleArchive)
+		data := bundleArchive.Data()
+		data.Tags = strings.Split(name, "-")
+		err := s.store.AddBundleWithArchive(EntityResolvedURL(ent), storetesting.NewBundle(data))
 		c.Assert(err, gc.IsNil)
 		for i := 0; i < charmDownloadCounts[name]; i++ {
 			err := s.store.IncrementDownloadCounts(EntityResolvedURL(ent))

--- a/internal/charmstore/stats_test.go
+++ b/internal/charmstore/stats_test.go
@@ -93,7 +93,7 @@ func (s *StatsSuite) TestSumCounters(c *gc.C) {
 	docs1, err := counters.Count()
 	c.Assert(err, gc.IsNil)
 	if docs1 != 3 && docs1 != 4 {
-		fmt.Errorf("Expected 3 or 4 docs in counters collection, got %d", docs1)
+		c.Errorf("Expected 3 or 4 docs in counters collection, got %d", docs1)
 	}
 
 	// Hack times so that the next operation adds another document.

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -267,6 +267,26 @@ var metaEndpoints = []metaEndpoint{{
 		if url.URL.Series == "bundle" {
 			return nil, nil
 		}
+		switch url.URL.String() {
+		case "cs:~charmers/precise/wordpress-23", "cs:~bob/utopic/wordpress-2":
+			return &params.RelatedResponse{
+				Provides: map[string][]params.EntityResult{
+					"mysql": {{
+						Id: charm.MustParseURL("cs:precise/mysql-5"),
+					}},
+				},
+			}, nil
+		case "cs:~charmers/precise/mysql-5":
+			return &params.RelatedResponse{
+				Requires: map[string][]params.EntityResult{
+					"mysql": {{
+						Id: charm.MustParseURL("cs:~bob/utopic/wordpress-2"),
+					}, {
+						Id: charm.MustParseURL("cs:precise/wordpress-23"),
+					}},
+				},
+			}, nil
+		}
 		return &params.RelatedResponse{}, nil
 	},
 	checkURL: newResolvedURL("~charmers/precise/wordpress-23", 23),
@@ -529,6 +549,8 @@ func (s *APISuite) TestAllMetaEndpointsTested(c *gc.C) {
 var testEntities = []*router.ResolvedURL{
 	// A stock charm.
 	newResolvedURL("cs:~charmers/precise/wordpress-23", 23),
+	// Another stock charm, to satisfy the bundle's requirements.
+	newResolvedURL("cs:~charmers/precise/mysql-5", 5),
 	// A stock bundle.
 	newResolvedURL("cs:~charmers/bundle/wordpress-simple-42", 42),
 	// A charm with some actions.
@@ -542,7 +564,7 @@ var testEntities = []*router.ResolvedURL{
 func (s *APISuite) addTestEntities(c *gc.C) []*router.ResolvedURL {
 	for _, e := range testEntities {
 		if e.URL.Series == "bundle" {
-			s.addPublicBundle(c, e.URL.Name, e)
+			s.addPublicBundle(c, e.URL.Name, e, true)
 		} else {
 			s.addPublicCharm(c, e.URL.Name, e)
 		}
@@ -1221,15 +1243,7 @@ func (s *APISuite) TestMetaCharmTags(c *gc.C) {
 		meta := wordpress.Meta()
 		meta.Tags, meta.Categories = test.tags, test.categories
 		url.URL.Revision = i
-		err := s.store.AddCharm(&testMetaCharm{
-			meta:  meta,
-			Charm: wordpress,
-		}, charmstore.AddParams{
-			URL:      url,
-			BlobName: "no-such-name",
-			BlobHash: fakeBlobHash,
-			BlobSize: fakeBlobSize,
-		})
+		err := s.store.AddCharmWithArchive(url, storetesting.NewCharm(meta))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)
@@ -1251,15 +1265,7 @@ func (s *APISuite) TestPromulgatedMetaCharmTags(c *gc.C) {
 		meta.Tags, meta.Categories = test.tags, test.categories
 		url.URL.Revision = i
 		url.PromulgatedRevision = i
-		err := s.store.AddCharm(&testMetaCharm{
-			meta:  meta,
-			Charm: wordpress,
-		}, charmstore.AddParams{
-			URL:      url,
-			BlobName: "no-such-name",
-			BlobHash: fakeBlobHash,
-			BlobSize: fakeBlobSize,
-		})
+		err := s.store.AddCharmWithArchive(url, storetesting.NewCharm(meta))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)
@@ -1274,15 +1280,11 @@ func (s *APISuite) TestPromulgatedMetaCharmTags(c *gc.C) {
 
 func (s *APISuite) TestBundleTags(c *gc.C) {
 	b := storetesting.Charms.BundleDir("wordpress-simple")
-	url := newResolvedURL("~charmers/bundle/wordpress-2", -1)
+	s.addRequiredCharms(c, b)
+	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", -1)
 	data := b.Data()
 	data.Tags = []string{"foo", "bar"}
-	err := s.store.AddBundle(&testingBundle{data}, charmstore.AddParams{
-		URL:      url,
-		BlobName: "no-such-name",
-		BlobHash: fakeBlobHash,
-		BlobSize: fakeBlobSize,
-	})
+	err := s.store.AddBundleWithArchive(url, storetesting.NewBundle(data))
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 	c.Assert(err, gc.IsNil)
@@ -1296,15 +1298,11 @@ func (s *APISuite) TestBundleTags(c *gc.C) {
 
 func (s *APISuite) TestPromulgatedBundleTags(c *gc.C) {
 	b := storetesting.Charms.BundleDir("wordpress-simple")
-	url := newResolvedURL("~charmers/bundle/wordpress-2", 2)
+	s.addRequiredCharms(c, b)
+	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", 2)
 	data := b.Data()
 	data.Tags = []string{"foo", "bar"}
-	err := s.store.AddBundle(&testingBundle{data}, charmstore.AddParams{
-		URL:      url,
-		BlobName: "no-such-name",
-		BlobHash: fakeBlobHash,
-		BlobSize: fakeBlobSize,
-	})
+	err := s.store.AddBundleWithArchive(url, storetesting.NewBundle(data))
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 	c.Assert(err, gc.IsNil)
@@ -1535,8 +1533,8 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/trusty/wordpress-1", -1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/wordpress-2", -1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/other-2", -1))
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10))
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10))
+	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10), true)
+	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10), true)
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/wily/django-47", 27))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1))
 	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
@@ -1689,8 +1687,8 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/builder-5", -1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/precise/builder-6", -1))
 
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/mongo-0", 0))
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-0", 0))
+	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/mongo-0", 0), true)
+	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-0", 0), true)
 
 	for i, test := range serveExpandIdTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -2144,7 +2142,7 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 
 			// Add the required entities to the database.
 			if url.URL.Series == "bundle" {
-				s.addPublicBundle(c, "wordpress-simple", url)
+				s.addPublicBundle(c, "wordpress-simple", url, true)
 			} else {
 				s.addPublicCharm(c, "wordpress", url)
 			}
@@ -2538,28 +2536,6 @@ func zipGetter(get func(*zip.Reader) interface{}) metaEndpointExpectedValueGette
 func entitySizeChecker(c *gc.C, data interface{}) {
 	response := data.(*params.ArchiveSizeResponse)
 	c.Assert(response.Size, gc.Not(gc.Equals), int64(0))
-}
-
-func (s *APISuite) addPublicCharm(c *gc.C, charmName string, rurl *router.ResolvedURL) (*router.ResolvedURL, charm.Charm) {
-	ch := storetesting.Charms.CharmDir(charmName)
-	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
-	return rurl, ch
-}
-
-func (s *APISuite) addPublicBundle(c *gc.C, bundleName string, rurl *router.ResolvedURL) (*router.ResolvedURL, charm.Bundle) {
-	bundle := storetesting.Charms.BundleDir(bundleName)
-	err := s.store.AddBundleWithArchive(rurl, bundle)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
-	return rurl, bundle
 }
 
 func (s *APISuite) assertPutNonAdmin(c *gc.C, url string, val interface{}) {

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1339,14 +1339,16 @@ func (s *ArchiveSuite) TestDeleteError(c *gc.C) {
 	// Add a charm to the database (not including the archive).
 	id := "~charmers/utopic/mysql-42"
 	url := newResolvedURL(id, -1)
-	err := s.store.AddCharm(storetesting.Charms.CharmArchive(c.MkDir(), "mysql"),
-		charmstore.AddParams{
-			URL:      url,
-			BlobName: "no-such-name",
-			BlobHash: fakeBlobHash,
-			BlobSize: fakeBlobSize,
-		})
+	err := s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
 	c.Assert(err, gc.IsNil)
+
+	err = s.store.DB.Entities().UpdateId(&url.URL, bson.M{
+		"$set": bson.M{
+			"blobname": "no-such-name",
+		},
+	})
+	c.Assert(err, gc.IsNil)
+	// TODO update entity to change BlobName to "no-such-name"
 
 	// Try to delete the charm using the API.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{

--- a/internal/v4/list_test.go
+++ b/internal/v4/list_test.go
@@ -70,7 +70,7 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 
 func (s *ListSuite) addCharmsToStore(c *gc.C) {
 	for name, id := range exportListTestCharms {
-		err := s.store.AddCharmWithArchive(id, getCharm(name))
+		err := s.store.AddCharmWithArchive(id, getListCharm(name))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 		c.Assert(err, gc.IsNil)
@@ -87,16 +87,18 @@ func (s *ListSuite) addCharmsToStore(c *gc.C) {
 	}
 }
 
-func getListCharm(name string) *charm.CharmDir {
+func getListCharm(name string) *storetesting.Charm {
 	ca := storetesting.Charms.CharmDir(name)
-	ca.Meta().Categories = append(strings.Split(name, "-"), "bar")
-	return ca
+	meta := ca.Meta()
+	meta.Categories = append(strings.Split(name, "-"), "bar")
+	return storetesting.NewCharm(meta)
 }
 
-func getListBundle(name string) *charm.BundleDir {
+func getListBundle(name string) *storetesting.Bundle {
 	ba := storetesting.Charms.BundleDir(name)
-	ba.Data().Tags = append(strings.Split(name, "-"), "baz")
-	return ba
+	data := ba.Data()
+	data.Tags = append(strings.Split(name, "-"), "baz")
+	return storetesting.NewBundle(data)
 }
 
 func (s *ListSuite) TestSuccessfulList(c *gc.C) {
@@ -185,7 +187,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 		about: "archive-size",
 		query: "name=mysql&include=archive-size",
 		meta: map[string]interface{}{
-			"archive-size": params.ArchiveSizeResponse{438},
+			"archive-size": params.ArchiveSizeResponse{getListCharm("mysql").Size()},
 		},
 	}, {
 		about: "bundle-metadata",
@@ -413,7 +415,7 @@ func (s *ListSuite) TestSortUnsupportedListField(c *gc.C) {
 
 func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/precise/wordpress-24", 24)
-	err := s.store.AddCharmWithArchive(id, getCharm("wordpress"))
+	err := s.store.AddCharmWithArchive(id, getListCharm("wordpress"))
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -14,13 +14,14 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2/bson"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
-	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 )
 
 // Define fake blob attributes to be used in tests.
@@ -40,83 +41,32 @@ var _ = gc.Suite(&RelationsSuite{})
 // metaCharmRelatedCharms defines a bunch of charms to be used in
 // the relation tests.
 var metaCharmRelatedCharms = map[string]charm.Charm{
-	"0 ~charmers/utopic/wordpress-0": &relationTestingCharm{
-		provides: map[string]charm.Relation{
-			"website": {
-				Name:      "website",
-				Role:      "provider",
-				Interface: "http",
-			},
-		},
-		requires: map[string]charm.Relation{
-			"cache": {
-				Name:      "cache",
-				Role:      "requirer",
-				Interface: "memcache",
-			},
-			"nfs": {
-				Name:      "nfs",
-				Role:      "requirer",
-				Interface: "mount",
-			},
-		},
-	},
-	"42 ~charmers/utopic/memcached-42": &relationTestingCharm{
-		provides: map[string]charm.Relation{
-			"cache": {
-				Name:      "cache",
-				Role:      "provider",
-				Interface: "memcache",
-			},
-		},
-	},
-	"1 ~charmers/precise/nfs-1": &relationTestingCharm{
-		provides: map[string]charm.Relation{
-			"nfs": {
-				Name:      "nfs",
-				Role:      "provider",
-				Interface: "mount",
-			},
-		},
-	},
-	"47 ~charmers/trusty/haproxy-47": &relationTestingCharm{
-		requires: map[string]charm.Relation{
-			"reverseproxy": {
-				Name:      "reverseproxy",
-				Role:      "requirer",
-				Interface: "http",
-			},
-		},
-	},
-	"48 ~charmers/precise/haproxy-48": &relationTestingCharm{
-		requires: map[string]charm.Relation{
-			"reverseproxy": {
-				Name:      "reverseproxy",
-				Role:      "requirer",
-				Interface: "http",
-			},
-		},
-	},
+	"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(relationMeta(
+		"provides website http",
+		"requires cache memcache",
+		"requires nfs mount",
+	)),
+	"42 ~charmers/utopic/memcached-42": storetesting.NewCharm(relationMeta(
+		"provides cache memcache",
+	)),
+	"1 ~charmers/precise/nfs-1": storetesting.NewCharm(relationMeta(
+		"provides nfs mount",
+	)),
+	"47 ~charmers/trusty/haproxy-47": storetesting.NewCharm(relationMeta(
+		"requires reverseproxy http",
+	)),
+	"48 ~charmers/precise/haproxy-48": storetesting.NewCharm(relationMeta(
+		"requires reverseproxy http",
+	)),
 	// development charms should not be included in any results.
-	"49 ~charmers/development/precise/haproxy-49": &relationTestingCharm{
-		provides: map[string]charm.Relation{
-			"reverseproxy": {
-				Name:      "reverseproxy",
-				Role:      "requirer",
-				Interface: "http",
-			},
-		},
-	},
-	"1 ~charmers/multi-series-20": &relationTestingCharm{
-		supportedSeries: []string{"precise", "trusty", "utopic"},
-		requires: map[string]charm.Relation{
-			"reverseproxy": {
-				Name:      "reverseproxy",
-				Role:      "requirer",
-				Interface: "http",
-			},
-		},
-	},
+	"49 ~charmers/development/precise/haproxy-49": storetesting.NewCharm(relationMeta(
+		"requires reverseproxy http",
+	)),
+	"1 ~charmers/multi-series-20": storetesting.NewCharm(
+		metaWithSupportedSeries(relationMeta(
+			"requires reverseproxy http",
+		), "precise", "trusty", "utopic",
+		)),
 }
 
 var metaCharmRelatedTests = []struct {
@@ -183,74 +133,34 @@ var metaCharmRelatedTests = []struct {
 }, {
 	about: "no relations found",
 	charms: map[string]charm.Charm{
-		"0 ~charmers/utopic/wordpress-0": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"website": {
-					Name:      "website",
-					Role:      "provider",
-					Interface: "http",
-				},
-			},
-			requires: map[string]charm.Relation{
-				"cache": {
-					Name:      "cache",
-					Role:      "requirer",
-					Interface: "memcache",
-				},
-				"nfs": {
-					Name:      "nfs",
-					Role:      "requirer",
-					Interface: "mount",
-				},
-			},
-		},
+		"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(relationMeta(
+			"provides website http",
+			"requires cache memcache",
+			"requires nfs mount",
+		)),
 	},
 	id: "utopic/wordpress-0",
 }, {
 	about: "no relations defined",
 	charms: map[string]charm.Charm{
-		"42 ~charmers/utopic/django-42": &relationTestingCharm{},
+		"42 ~charmers/utopic/django-42": storetesting.NewCharm(nil),
 	},
 	id: "utopic/django-42",
 }, {
 	about: "multiple revisions of the same related charm",
 	charms: map[string]charm.Charm{
-		"0 ~charmers/trusty/wordpress-0": &relationTestingCharm{
-			requires: map[string]charm.Relation{
-				"cache": {
-					Name:      "cache",
-					Role:      "requirer",
-					Interface: "memcache",
-				},
-			},
-		},
-		"1 ~charmers/utopic/memcached-1": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"cache": {
-					Name:      "cache",
-					Role:      "provider",
-					Interface: "memcache",
-				},
-			},
-		},
-		"2 ~charmers/utopic/memcached-2": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"cache": {
-					Name:      "cache",
-					Role:      "provider",
-					Interface: "memcache",
-				},
-			},
-		},
-		"3 ~charmers/utopic/memcached-3": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"cache": {
-					Name:      "cache",
-					Role:      "provider",
-					Interface: "memcache",
-				},
-			},
-		},
+		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(relationMeta(
+			"requires cache memcache",
+		)),
+		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(relationMeta(
+			"provides cache memcache",
+		)),
+		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(relationMeta(
+			"provides cache memcache",
+		)),
+		"3 ~charmers/utopic/memcached-3": storetesting.NewCharm(relationMeta(
+			"provides cache memcache",
+		)),
 	},
 	id: "trusty/wordpress-0",
 	expectBody: params.RelatedResponse{
@@ -267,74 +177,28 @@ var metaCharmRelatedTests = []struct {
 }, {
 	about: "reference ordering",
 	charms: map[string]charm.Charm{
-		"0 ~charmers/trusty/wordpress-0": &relationTestingCharm{
-			requires: map[string]charm.Relation{
-				"cache": {
-					Name:      "cache",
-					Role:      "requirer",
-					Interface: "memcache",
-				},
-				"nfs": {
-					Name:      "nfs",
-					Role:      "requirer",
-					Interface: "mount",
-				},
-			},
-		},
-		"1 ~charmers/utopic/memcached-1": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"cache": {
-					Name:      "cache",
-					Role:      "provider",
-					Interface: "memcache",
-				},
-			},
-		},
-		"2 ~charmers/utopic/memcached-2": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"cache": {
-					Name:      "cache",
-					Role:      "provider",
-					Interface: "memcache",
-				},
-			},
-		},
-		"90 ~charmers/utopic/redis-90": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"cache": {
-					Name:      "cache",
-					Role:      "provider",
-					Interface: "memcache",
-				},
-			},
-		},
-		"47 ~charmers/trusty/nfs-47": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"nfs": {
-					Name:      "nfs",
-					Role:      "provider",
-					Interface: "mount",
-				},
-			},
-		},
-		"42 ~charmers/precise/nfs-42": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"nfs": {
-					Name:      "nfs",
-					Role:      "provider",
-					Interface: "mount",
-				},
-			},
-		},
-		"47 ~charmers/precise/nfs-47": &relationTestingCharm{
-			provides: map[string]charm.Relation{
-				"nfs": {
-					Name:      "nfs",
-					Role:      "provider",
-					Interface: "mount",
-				},
-			},
-		},
+		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(relationMeta(
+			"requires cache memcache",
+			"requires nfs mount",
+		)),
+		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(relationMeta(
+			"provides cache memcache",
+		)),
+		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(relationMeta(
+			"provides cache memcache",
+		)),
+		"90 ~charmers/utopic/redis-90": storetesting.NewCharm(relationMeta(
+			"provides cache memcache",
+		)),
+		"47 ~charmers/trusty/nfs-47": storetesting.NewCharm(relationMeta(
+			"provides nfs mount",
+		)),
+		"42 ~charmers/precise/nfs-42": storetesting.NewCharm(relationMeta(
+			"provides nfs mount",
+		)),
+		"47 ~charmers/precise/nfs-47": storetesting.NewCharm(relationMeta(
+			"provides nfs mount",
+		)),
 	},
 	id: "trusty/wordpress-0",
 	expectBody: params.RelatedResponse{
@@ -359,19 +223,20 @@ var metaCharmRelatedTests = []struct {
 	about:       "includes",
 	charms:      metaCharmRelatedCharms,
 	id:          "precise/nfs-1",
-	querystring: "?include=archive-size&include=charm-metadata",
+	querystring: "?include=id-name&include=charm-metadata",
 	expectBody: params.RelatedResponse{
 		Requires: map[string][]params.EntityResult{
 			"mount": {{
 				Id: charm.MustParseURL("utopic/wordpress-0"),
 				Meta: map[string]interface{}{
-					"archive-size": params.ArchiveSizeResponse{Size: fakeBlobSize},
+					"id-name": params.IdNameResponse{"wordpress"},
 					"charm-metadata": &charm.Meta{
 						Provides: map[string]charm.Relation{
 							"website": {
 								Name:      "website",
 								Role:      "provider",
 								Interface: "http",
+								Scope:     charm.ScopeGlobal,
 							},
 						},
 						Requires: map[string]charm.Relation{
@@ -379,11 +244,13 @@ var metaCharmRelatedTests = []struct {
 								Name:      "cache",
 								Role:      "requirer",
 								Interface: "memcache",
+								Scope:     charm.ScopeGlobal,
 							},
 							"nfs": {
 								Name:      "nfs",
 								Role:      "requirer",
 								Interface: "mount",
+								Scope:     charm.ScopeGlobal,
 							},
 						},
 					},
@@ -392,24 +259,6 @@ var metaCharmRelatedTests = []struct {
 		},
 	},
 }}
-
-func (s *RelationsSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
-	for id, ch := range charms {
-		url := mustParseResolvedURL(id)
-		// The blob related info are not used in these tests.
-		// The related charms are retrieved from the entities collection,
-		// without accessing the blob store.
-		err := s.store.AddCharm(ch, charmstore.AddParams{
-			URL:      url,
-			BlobName: "blobName",
-			BlobHash: fakeBlobHash,
-			BlobSize: fakeBlobSize,
-		})
-		c.Assert(err, gc.IsNil, gc.Commentf("id %q", id))
-		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
-	}
-}
 
 func (s *RelationsSuite) TestMetaCharmRelated(c *gc.C) {
 	for i, test := range metaCharmRelatedTests {
@@ -441,43 +290,50 @@ func (s *RelationsSuite) TestMetaCharmRelatedIncludeError(c *gc.C) {
 	})
 }
 
-// relationTestingCharm implements charm.Charm, and it is used for testing
-// charm relations.
-type relationTestingCharm struct {
-	supportedSeries []string
-	provides        map[string]charm.Relation
-	requires        map[string]charm.Relation
+func metaWithSupportedSeries(m *charm.Meta, series ...string) *charm.Meta {
+	m.Series = series
+	return m
 }
 
-func (ch *relationTestingCharm) Meta() *charm.Meta {
-	// The only metadata we are interested in is the relation data.
+func relationMeta(relations ...string) *charm.Meta {
+	provides := make(map[string]charm.Relation)
+	requires := make(map[string]charm.Relation)
+	for _, rel := range relations {
+		r, err := parseRelation(rel)
+		if err != nil {
+			panic(fmt.Errorf("bad relation %q", err))
+		}
+		if r.Role == charm.RoleProvider {
+			provides[r.Name] = r
+		} else {
+			requires[r.Name] = r
+		}
+	}
 	return &charm.Meta{
-		Series:   ch.supportedSeries,
-		Provides: ch.provides,
-		Requires: ch.requires,
+		Provides: provides,
+		Requires: requires,
 	}
 }
 
-func (ch *relationTestingCharm) Config() *charm.Config {
-	// For the purposes of this implementation, the charm configuration is not
-	// relevant.
-	return nil
-}
-
-func (e *relationTestingCharm) Metrics() *charm.Metrics {
-	return nil
-}
-
-func (ch *relationTestingCharm) Actions() *charm.Actions {
-	// For the purposes of this implementation, the charm actions are not
-	// relevant.
-	return nil
-}
-
-func (ch *relationTestingCharm) Revision() int {
-	// For the purposes of this implementation, the charm revision is not
-	// relevant.
-	return 0
+func parseRelation(s string) (charm.Relation, error) {
+	fields := strings.Fields(s)
+	if len(fields) != 3 {
+		return charm.Relation{}, errgo.Newf("wrong field count")
+	}
+	r := charm.Relation{
+		Scope:     charm.ScopeGlobal,
+		Name:      fields[1],
+		Interface: fields[2],
+	}
+	switch fields[0] {
+	case "provides":
+		r.Role = charm.RoleProvider
+	case "requires":
+		r.Role = charm.RoleRequirer
+	default:
+		return charm.Relation{}, errgo.Newf("unknown role")
+	}
+	return r, nil
 }
 
 // metaBundlesContainingBundles defines a bunch of bundles to be used in
@@ -495,13 +351,12 @@ var metaBundlesContainingBundles = map[string]charm.Bundle{
 		"cs:utopic/wordpress-42",
 		"cs:utopic/wordpress-47",
 		"cs:trusty/mysql-0",
-		"cs:trusty/mysql-1",
 		"cs:trusty/memcached-2",
 	}),
 	"42 ~charmers/bundle/django-generic-42": relationTestingBundle([]string{
 		"django",
 		"django",
-		"mysql-1",
+		"utopic/mysql-1",
 		"trusty/memcached",
 	}),
 	"0 ~charmers/bundle/useless-0": relationTestingBundle([]string{
@@ -528,6 +383,9 @@ var metaBundlesContainingTests = []struct {
 	about string
 	// The id of the charm for which related bundles are returned.
 	id string
+	// The id of the target charm (only necessary if it hasn't
+	// been added as a result of addRequiredCharms)
+	addCharm *router.ResolvedURL
 	// The querystring to append to the resulting charmstore URL.
 	querystring string
 	// The expected status code of the response.
@@ -554,27 +412,30 @@ var metaBundlesContainingTests = []struct {
 	}},
 }, {
 	about:        "specific charm not present in any bundle",
-	id:           "trusty/django-42",
+	id:           "trusty/django-0",
 	expectStatus: http.StatusOK,
 	expectBody:   []*params.MetaAnyResponse{},
 }, {
 	about:        "specific charm with includes",
-	id:           "trusty/mysql-1",
-	querystring:  "?include=archive-size&include=bundle-metadata",
+	id:           "trusty/mysql-0",
+	querystring:  "?include=id-name&include=bundle-metadata",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: charm.MustParseURL("bundle/wordpress-complex-1"),
 		Meta: map[string]interface{}{
-			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
+			"id-name":         params.IdNameResponse{"wordpress-complex"},
 			"bundle-metadata": metaBundlesContainingBundles["1 ~charmers/bundle/wordpress-complex-1"].Data(),
 		},
 	}},
 }, {
-	about:        "partial charm id",
-	id:           "mysql", // The test will add cs:utopic/mysql-0.
+	about: "partial charm id",
+	// The addRequiredCharms will have added trusty/mysql-0
+	// which is the latest LTS charm, so that's what this id will
+	// resolve to.
+	id:           "mysql",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
-		Id: charm.MustParseURL("bundle/wordpress-simple-0"),
+		Id: charm.MustParseURL("bundle/wordpress-complex-1"),
 	}},
 }, {
 	about:        "any series set to true",
@@ -610,6 +471,7 @@ var metaBundlesContainingTests = []struct {
 }, {
 	about:        "any revision set to true",
 	id:           "trusty/memcached-99",
+	addCharm:     mustParseResolvedURL("99 ~charmers/trusty/memcached-99"),
 	querystring:  "?any-revision=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
@@ -620,6 +482,7 @@ var metaBundlesContainingTests = []struct {
 }, {
 	about:        "invalid any revision",
 	id:           "trusty/memcached-99",
+	addCharm:     mustParseResolvedURL("99 ~charmers/trusty/memcached-99"),
 	querystring:  "?any-revision=why-not",
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
@@ -652,6 +515,7 @@ var metaBundlesContainingTests = []struct {
 }, {
 	about:        "invalid all-results",
 	id:           "trusty/memcached-99",
+	addCharm:     mustParseResolvedURL("99 ~charmers/trusty/memcached-99"),
 	querystring:  "?all-results=yes!",
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
@@ -661,6 +525,7 @@ var metaBundlesContainingTests = []struct {
 }, {
 	about:        "any series and revision, all results",
 	id:           "saucy/mysql-99",
+	addCharm:     mustParseResolvedURL("99 ~charmers/saucy/mysql-99"),
 	querystring:  "?any-series=1&any-revision=1&all-results=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
@@ -677,6 +542,7 @@ var metaBundlesContainingTests = []struct {
 }, {
 	about:        "any series, any revision",
 	id:           "saucy/mysql-99",
+	addCharm:     mustParseResolvedURL("99 ~charmers/saucy/mysql-99"),
 	querystring:  "?any-series=1&any-revision=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
@@ -691,6 +557,7 @@ var metaBundlesContainingTests = []struct {
 }, {
 	about:        "any series and revision, last results",
 	id:           "saucy/mediawiki",
+	addCharm:     mustParseResolvedURL("99 ~charmers/saucy/mediawiki-99"),
 	querystring:  "?any-series=1&any-revision=1",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
@@ -703,24 +570,25 @@ var metaBundlesContainingTests = []struct {
 }, {
 	about:        "any series and revision with includes",
 	id:           "saucy/wordpress-99",
-	querystring:  "?any-series=1&any-revision=1&include=archive-size&include=bundle-metadata",
+	addCharm:     mustParseResolvedURL("99 ~charmers/saucy/wordpress-99"),
+	querystring:  "?any-series=1&any-revision=1&include=id-name&include=bundle-metadata",
 	expectStatus: http.StatusOK,
 	expectBody: []*params.MetaAnyResponse{{
 		Id: charm.MustParseURL("bundle/useless-0"),
 		Meta: map[string]interface{}{
-			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
+			"id-name":         params.IdNameResponse{"useless"},
 			"bundle-metadata": metaBundlesContainingBundles["0 ~charmers/bundle/useless-0"].Data(),
 		},
 	}, {
 		Id: charm.MustParseURL("bundle/wordpress-complex-1"),
 		Meta: map[string]interface{}{
-			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
+			"id-name":         params.IdNameResponse{"wordpress-complex"},
 			"bundle-metadata": metaBundlesContainingBundles["1 ~charmers/bundle/wordpress-complex-1"].Data(),
 		},
 	}, {
 		Id: charm.MustParseURL("bundle/wordpress-simple-1"),
 		Meta: map[string]interface{}{
-			"archive-size":    params.ArchiveSizeResponse{Size: fakeBlobSize},
+			"id-name":         params.IdNameResponse{"wordpress-simple"},
 			"bundle-metadata": metaBundlesContainingBundles["1 ~charmers/bundle/wordpress-simple-1"].Data(),
 		},
 	}},
@@ -738,50 +606,17 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 	// Add the bundles used for testing to the database.
 	for id, b := range metaBundlesContainingBundles {
 		url := mustParseResolvedURL(id)
-		// The blob related info are not used in these tests.
-		// The charm-bundle relations are retrieved from the entities
-		// collection, without accessing the blob store.
-		err := s.store.AddBundle(b, charmstore.AddParams{
-			URL:      url,
-			BlobName: "blobName",
-			BlobHash: fakeBlobHash,
-			BlobSize: fakeBlobSize,
-		})
+		s.addRequiredCharms(c, b)
+		err := s.store.AddBundleWithArchive(url, b)
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)
 	}
-
 	for i, test := range metaBundlesContainingTests {
 		c.Logf("test %d: %s", i, test.about)
-
-		// Expand the URL if required before adding the charm to the database,
-		// so that at least one matching charm can be resolved.
-		rurl := &router.ResolvedURL{
-			URL:                 *charm.MustParseURL(test.id),
-			PromulgatedRevision: -1,
+		if test.addCharm != nil {
+			s.addPublicCharm(c, "wordpress", test.addCharm)
 		}
-		if rurl.URL.Series == "" {
-			rurl.URL.Series = "utopic"
-		}
-		if rurl.URL.Revision == -1 {
-			rurl.URL.Revision = 0
-		}
-		if rurl.URL.User == "" {
-			rurl.URL.User = "charmers"
-			rurl.PromulgatedRevision = rurl.URL.Revision
-		}
-		// Add the charm we need bundle info on to the database.
-		err := s.store.AddCharm(&relationTestingCharm{}, charmstore.AddParams{
-			URL:      rurl,
-			BlobName: "blobName",
-			BlobHash: fakeBlobHash,
-			BlobSize: fakeBlobSize,
-		})
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
-		c.Assert(err, gc.IsNil)
-
 		// Perform the request and ensure the response is what we expect.
 		storeURL := storeURL(test.id + "/meta/bundles-containing" + test.querystring)
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -790,10 +625,10 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 			ExpectStatus: test.expectStatus,
 			ExpectBody:   sameMetaAnyResponses(test.expectBody),
 		})
-
-		// Clean up the charm entity in the store.
-		err = s.store.DB.Entities().Remove(bson.D{{"_id", &rurl.URL}})
-		c.Assert(err, gc.IsNil)
+		if test.addCharm != nil {
+			err := s.store.DB.Entities().Remove(bson.D{{"_id", &test.addCharm.URL}})
+			c.Assert(err, gc.IsNil)
+		}
 	}
 }
 
@@ -801,15 +636,8 @@ func (s *RelationsSuite) TestMetaBundlesContainingBundleACL(c *gc.C) {
 	// Add the bundles used for testing to the database.
 	for id, b := range metaBundlesContainingBundles {
 		url := mustParseResolvedURL(id)
-		// The blob related info are not used in these tests.
-		// The charm-bundle relations are retrieved from the entities
-		// collection, without accessing the blob store.
-		err := s.store.AddBundle(b, charmstore.AddParams{
-			URL:      url,
-			BlobName: "blobName",
-			BlobHash: fakeBlobHash,
-			BlobSize: fakeBlobSize,
-		})
+		s.addRequiredCharms(c, b)
+		err := s.store.AddBundleWithArchive(url, storetesting.NewBundle(b.Data()))
 		c.Assert(err, gc.IsNil)
 		if url.URL.Name == "useless" {
 			// The useless bundle is not available for "everyone".
@@ -820,17 +648,6 @@ func (s *RelationsSuite) TestMetaBundlesContainingBundleACL(c *gc.C) {
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)
 	}
-	rurl := mustParseResolvedURL("42 ~charmers/utopic/wordpress-42")
-	// Add the charm we need bundle info on to the database.
-	err := s.store.AddCharm(&relationTestingCharm{}, charmstore.AddParams{
-		URL:      rurl,
-		BlobName: "blobName",
-		BlobHash: fakeBlobHash,
-		BlobSize: fakeBlobSize,
-	})
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
 
 	// Perform the request and ensure that the useless bundle isn't listed.
 	storeURL := storeURL("utopic/wordpress-42/meta/bundles-containing")
@@ -878,27 +695,11 @@ func relationTestingBundle(urls []string) charm.Bundle {
 		}
 		services[fmt.Sprintf("service-%d", i)] = service
 	}
-	return &testingBundle{
-		data: &charm.BundleData{
+	return storetesting.NewBundle(
+		&charm.BundleData{
 			Services: services,
-		},
-	}
-}
+		})
 
-// testingBundle is a bundle implementation that
-// returns bundle metadata held in the data field.
-type testingBundle struct {
-	data *charm.BundleData
-}
-
-func (b *testingBundle) Data() *charm.BundleData {
-	return b.data
-}
-
-func (b *testingBundle) ReadMe() string {
-	// For the purposes of this implementation, the charm readme is not
-	// relevant.
-	return ""
 }
 
 type metaAnyResponseById []*params.MetaAnyResponse
@@ -927,6 +728,9 @@ func mustParseResolvedURL(urlStr string) *router.ResolvedURL {
 	case 1:
 	}
 	url := charm.MustParseURL(s[len(s)-1])
+	if url.User == "" {
+		panic(fmt.Sprintf("resolved URL %q does not contain user", urlStr))
+	}
 	return &router.ResolvedURL{
 		URL:                 *url.WithChannel(""),
 		PromulgatedRevision: promRev,

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -72,7 +72,7 @@ func (s *SearchSuite) SetUpTest(c *gc.C) {
 
 func (s *SearchSuite) addCharmsToStore(c *gc.C) {
 	for name, id := range exportTestCharms {
-		err := s.store.AddCharmWithArchive(id, getCharm(name))
+		err := s.store.AddCharmWithArchive(id, getSearchCharm(name))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 		c.Assert(err, gc.IsNil)
@@ -80,7 +80,7 @@ func (s *SearchSuite) addCharmsToStore(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 	}
 	for name, id := range exportTestBundles {
-		err := s.store.AddBundleWithArchive(id, getBundle(name))
+		err := s.store.AddBundleWithArchive(id, getSearchBundle(name))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 		c.Assert(err, gc.IsNil)
@@ -89,16 +89,18 @@ func (s *SearchSuite) addCharmsToStore(c *gc.C) {
 	}
 }
 
-func getCharm(name string) *charm.CharmDir {
+func getSearchCharm(name string) *storetesting.Charm {
 	ca := storetesting.Charms.CharmDir(name)
-	ca.Meta().Categories = append(strings.Split(name, "-"), "bar")
-	return ca
+	meta := ca.Meta()
+	meta.Categories = append(strings.Split(name, "-"), "bar")
+	return storetesting.NewCharm(meta)
 }
 
-func getBundle(name string) *charm.BundleDir {
+func getSearchBundle(name string) *storetesting.Bundle {
 	ba := storetesting.Charms.BundleDir(name)
-	ba.Data().Tags = append(strings.Split(name, "-"), "baz")
-	return ba
+	data := ba.Data()
+	data.Tags = append(strings.Split(name, "-"), "baz")
+	return storetesting.NewBundle(data)
 }
 
 func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
@@ -333,13 +335,13 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		about: "archive-size",
 		query: "name=mysql&include=archive-size",
 		meta: map[string]interface{}{
-			"archive-size": params.ArchiveSizeResponse{438},
+			"archive-size": params.ArchiveSizeResponse{getSearchCharm("mysql").Size()},
 		},
 	}, {
 		about: "bundle-metadata",
 		query: "name=wordpress-simple&type=bundle&include=bundle-metadata",
 		meta: map[string]interface{}{
-			"bundle-metadata": getBundle("wordpress-simple").Data(),
+			"bundle-metadata": getSearchBundle("wordpress-simple").Data(),
 		},
 	}, {
 		about: "bundle-machine-count",
@@ -357,13 +359,13 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		about: "charm-actions",
 		query: "name=wordpress&type=charm&include=charm-actions",
 		meta: map[string]interface{}{
-			"charm-actions": getCharm("wordpress").Actions(),
+			"charm-actions": getSearchCharm("wordpress").Actions(),
 		},
 	}, {
 		about: "charm-config",
 		query: "name=wordpress&type=charm&include=charm-config",
 		meta: map[string]interface{}{
-			"charm-config": getCharm("wordpress").Config(),
+			"charm-config": getSearchCharm("wordpress").Config(),
 		},
 	}, {
 		about: "charm-related",
@@ -402,7 +404,7 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 					},
 				},
 			},
-			"charm-config": getCharm("wordpress").Config(),
+			"charm-config": getSearchCharm("wordpress").Config(),
 		},
 	}}
 	for i, test := range tests {
@@ -619,7 +621,7 @@ func (s *SearchSuite) TestDownloadsBoost(c *gc.C) {
 	for n, cnt := range charmDownloads {
 		url := newResolvedURL("cs:~downloads-test/trusty/x-1", -1)
 		url.URL.Name = n
-		err := s.store.AddCharmWithArchive(url, getCharm(n))
+		err := s.store.AddCharmWithArchive(url, getSearchCharm(n))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)

--- a/internal/v4/status_test.go
+++ b/internal/v4/status_test.go
@@ -25,15 +25,15 @@ func (s *APISuite) TestStatus(c *gc.C) {
 	for _, id := range []*router.ResolvedURL{
 		newResolvedURL("cs:~charmers/precise/wordpress-2", 2),
 		newResolvedURL("cs:~charmers/precise/wordpress-3", 3),
-		newResolvedURL("cs:~foo/precise/arble-9", -1),
-		newResolvedURL("cs:~bar/utopic/arble-10", -1),
-		newResolvedURL("cs:~charmers/bundle/oflaughs-3", 3),
-		newResolvedURL("cs:~bar/bundle/oflaughs-4", -1),
+		newResolvedURL("cs:~foo/precise/mysql-9", 1),
+		newResolvedURL("cs:~bar/utopic/mysql-10", -1),
+		newResolvedURL("cs:~charmers/bundle/wordpress-simple-3", 3),
+		newResolvedURL("cs:~bar/bundle/wordpress-simple-4", -1),
 	} {
 		if id.URL.Series == "bundle" {
-			s.addPublicBundle(c, "wordpress-simple", id)
+			s.addPublicBundle(c, id.URL.Name, id, false)
 		} else {
-			s.addPublicCharm(c, "wordpress", id)
+			s.addPublicCharm(c, id.URL.Name, id)
 		}
 	}
 	now := time.Now()
@@ -84,7 +84,7 @@ func (s *APISuite) TestStatus(c *gc.C) {
 		},
 		"entities": {
 			Name:   "Entities in charm store",
-			Value:  "4 charms; 2 bundles; 3 promulgated",
+			Value:  "4 charms; 2 bundles; 4 promulgated",
 			Passed: true,
 		},
 		"base_entities": {

--- a/internal/v5/content_test.go
+++ b/internal/v5/content_test.go
@@ -20,7 +20,6 @@ import (
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
-	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 )
@@ -52,7 +51,7 @@ func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/trusty/wordpress-42", 42)
 	s.addPublicCharm(c, "wordpress", id)
 	id = newResolvedURL("cs:~charmers/bundle/nopositionbundle-42", 42)
-	s.addPublicBundle(c, "wordpress-simple", id)
+	s.addPublicBundle(c, "wordpress-simple", id, true)
 
 	for i, test := range serveDiagramErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -66,34 +65,29 @@ func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
 }
 
 func (s *APISuite) TestServeDiagram(c *gc.C) {
-	bundle := &testingBundle{
-		data: &charm.BundleData{
-			Services: map[string]*charm.ServiceSpec{
-				"wordpress": {
-					Charm: "wordpress",
-					Annotations: map[string]string{
-						"gui-x": "100",
-						"gui-y": "200",
-					},
+	bundle := storetesting.NewBundle(&charm.BundleData{
+		Services: map[string]*charm.ServiceSpec{
+			"wordpress": {
+				Charm: "wordpress",
+				Annotations: map[string]string{
+					"gui-x": "100",
+					"gui-y": "200",
 				},
-				"mysql": {
-					Charm: "utopic/mysql-23",
-					Annotations: map[string]string{
-						"gui-x": "200",
-						"gui-y": "200",
-					},
+			},
+			"mysql": {
+				Charm: "utopic/mysql-23",
+				Annotations: map[string]string{
+					"gui-x": "200",
+					"gui-y": "200",
 				},
 			},
 		},
-	}
+	},
+	)
 
 	url := newResolvedURL("cs:~charmers/bundle/wordpressbundle-42", 42)
-	err := s.store.AddBundle(bundle, charmstore.AddParams{
-		URL:      url,
-		BlobName: "blobName",
-		BlobHash: fakeBlobHash,
-		BlobSize: fakeBlobSize,
-	})
+	s.addRequiredCharms(c, bundle)
+	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 	c.Assert(err, gc.IsNil)
@@ -138,8 +132,8 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 }
 
 func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
-	bundle := &testingBundle{
-		data: &charm.BundleData{
+	bundle := storetesting.NewBundle(
+		&charm.BundleData{
 			Services: map[string]*charm.ServiceSpec{
 				"wordpress": {
 					Charm: "wordpress",
@@ -152,16 +146,11 @@ func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 					},
 				},
 			},
-		},
-	}
+		})
 
 	url := newResolvedURL("cs:~charmers/bundle/wordpressbundle-42", 42)
-	err := s.store.AddBundle(bundle, charmstore.AddParams{
-		URL:      url,
-		BlobName: "blobName",
-		BlobHash: fakeBlobHash,
-		BlobSize: fakeBlobSize,
-	})
+	s.addRequiredCharms(c, bundle)
+	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 	c.Assert(err, gc.IsNil)
@@ -301,7 +290,7 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 }
 
 func (s *APISuite) TestServeBundleIcon(c *gc.C) {
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/something-32", 32))
+	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/something-32", 32), true)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,

--- a/internal/v5/export_test.go
+++ b/internal/v5/export_test.go
@@ -8,7 +8,6 @@ var (
 	ErrProbablyNotXML    = errProbablyNotXML
 	TestAddAuditCallback = &testAddAuditCallback
 
-	BundleCharms              = (*ReqHandler).bundleCharms
 	GetNewPromulgatedRevision = (*ReqHandler).getNewPromulgatedRevision
 
 	ResolveURL = resolveURL

--- a/internal/v5/list_test.go
+++ b/internal/v5/list_test.go
@@ -65,7 +65,7 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 
 func (s *ListSuite) addCharmsToStore(c *gc.C) {
 	for name, id := range exportListTestCharms {
-		err := s.store.AddCharmWithArchive(id, getCharm(name))
+		err := s.store.AddCharmWithArchive(id, getListCharm(name))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 		c.Assert(err, gc.IsNil)
@@ -82,16 +82,18 @@ func (s *ListSuite) addCharmsToStore(c *gc.C) {
 	}
 }
 
-func getListCharm(name string) *charm.CharmDir {
+func getListCharm(name string) *storetesting.Charm {
 	ca := storetesting.Charms.CharmDir(name)
-	ca.Meta().Categories = append(strings.Split(name, "-"), "bar")
-	return ca
+	meta := ca.Meta()
+	meta.Categories = append(strings.Split(name, "-"), "bar")
+	return storetesting.NewCharm(meta)
 }
 
-func getListBundle(name string) *charm.BundleDir {
+func getListBundle(name string) *storetesting.Bundle {
 	ba := storetesting.Charms.BundleDir(name)
-	ba.Data().Tags = append(strings.Split(name, "-"), "baz")
-	return ba
+	data := ba.Data()
+	data.Tags = append(strings.Split(name, "-"), "baz")
+	return storetesting.NewBundle(data)
 }
 
 func (s *ListSuite) TestSuccessfulList(c *gc.C) {
@@ -180,7 +182,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 		about: "archive-size",
 		query: "name=mysql&include=archive-size",
 		meta: map[string]interface{}{
-			"archive-size": params.ArchiveSizeResponse{438},
+			"archive-size": params.ArchiveSizeResponse{getListCharm("mysql").Size()},
 		},
 	}, {
 		about: "bundle-metadata",
@@ -407,7 +409,7 @@ func (s *ListSuite) TestSortUnsupportedListField(c *gc.C) {
 
 func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/precise/wordpress-24", 24)
-	err := s.store.AddCharmWithArchive(id, getCharm("wordpress"))
+	err := s.store.AddCharmWithArchive(id, getListCharm("wordpress"))
 	c.Assert(err, gc.IsNil)
 	err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 

--- a/internal/v5/search_test.go
+++ b/internal/v5/search_test.go
@@ -70,7 +70,7 @@ func (s *SearchSuite) SetUpTest(c *gc.C) {
 
 func (s *SearchSuite) addCharmsToStore(c *gc.C) {
 	for name, id := range exportTestCharms {
-		err := s.store.AddCharmWithArchive(id, getCharm(name))
+		err := s.store.AddCharmWithArchive(id, getSearchCharm(name))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 		c.Assert(err, gc.IsNil)
@@ -78,7 +78,7 @@ func (s *SearchSuite) addCharmsToStore(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 	}
 	for name, id := range exportTestBundles {
-		err := s.store.AddBundleWithArchive(id, getBundle(name))
+		err := s.store.AddBundleWithArchive(id, getSearchBundle(name))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&id.URL, "read", params.Everyone, id.URL.User)
 		c.Assert(err, gc.IsNil)
@@ -87,16 +87,18 @@ func (s *SearchSuite) addCharmsToStore(c *gc.C) {
 	}
 }
 
-func getCharm(name string) *charm.CharmDir {
+func getSearchCharm(name string) *storetesting.Charm {
 	ca := storetesting.Charms.CharmDir(name)
-	ca.Meta().Categories = append(strings.Split(name, "-"), "bar")
-	return ca
+	meta := ca.Meta()
+	meta.Categories = append(strings.Split(name, "-"), "bar")
+	return storetesting.NewCharm(meta)
 }
 
-func getBundle(name string) *charm.BundleDir {
+func getSearchBundle(name string) *storetesting.Bundle {
 	ba := storetesting.Charms.BundleDir(name)
-	ba.Data().Tags = append(strings.Split(name, "-"), "baz")
-	return ba
+	data := ba.Data()
+	data.Tags = append(strings.Split(name, "-"), "baz")
+	return storetesting.NewBundle(data)
 }
 
 func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
@@ -468,13 +470,13 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		about: "archive-size",
 		query: "name=mysql&include=archive-size",
 		meta: map[string]interface{}{
-			"archive-size": params.ArchiveSizeResponse{438},
+			"archive-size": params.ArchiveSizeResponse{getSearchCharm("mysql").Size()},
 		},
 	}, {
 		about: "bundle-metadata",
 		query: "name=wordpress-simple&type=bundle&include=bundle-metadata",
 		meta: map[string]interface{}{
-			"bundle-metadata": getBundle("wordpress-simple").Data(),
+			"bundle-metadata": getSearchBundle("wordpress-simple").Data(),
 		},
 	}, {
 		about: "bundle-machine-count",
@@ -492,13 +494,13 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		about: "charm-actions",
 		query: "name=wordpress&type=charm&include=charm-actions",
 		meta: map[string]interface{}{
-			"charm-actions": getCharm("wordpress").Actions(),
+			"charm-actions": getSearchCharm("wordpress").Actions(),
 		},
 	}, {
 		about: "charm-config",
 		query: "name=wordpress&type=charm&include=charm-config",
 		meta: map[string]interface{}{
-			"charm-config": getCharm("wordpress").Config(),
+			"charm-config": getSearchCharm("wordpress").Config(),
 		},
 	}, {
 		about: "charm-related",
@@ -537,7 +539,7 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 					},
 				},
 			},
-			"charm-config": getCharm("wordpress").Config(),
+			"charm-config": getSearchCharm("wordpress").Config(),
 		},
 	}}
 	for i, test := range tests {
@@ -720,7 +722,7 @@ func (s *SearchSuite) TestDownloadsBoost(c *gc.C) {
 	for n, cnt := range charmDownloads {
 		url := newResolvedURL("cs:~downloads-test/trusty/x-1", -1)
 		url.URL.Name = n
-		err := s.store.AddCharmWithArchive(url, getCharm(n))
+		err := s.store.AddCharmWithArchive(url, getSearchCharm(n))
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)

--- a/internal/v5/status_test.go
+++ b/internal/v5/status_test.go
@@ -25,15 +25,15 @@ func (s *APISuite) TestStatus(c *gc.C) {
 	for _, id := range []*router.ResolvedURL{
 		newResolvedURL("cs:~charmers/precise/wordpress-2", 2),
 		newResolvedURL("cs:~charmers/precise/wordpress-3", 3),
-		newResolvedURL("cs:~foo/precise/arble-9", -1),
-		newResolvedURL("cs:~bar/utopic/arble-10", -1),
-		newResolvedURL("cs:~charmers/bundle/oflaughs-3", 3),
-		newResolvedURL("cs:~bar/bundle/oflaughs-4", -1),
+		newResolvedURL("cs:~foo/precise/mysql-9", 1),
+		newResolvedURL("cs:~bar/utopic/mysql-10", -1),
+		newResolvedURL("cs:~charmers/bundle/wordpress-simple-3", 3),
+		newResolvedURL("cs:~bar/bundle/wordpress-simple-4", -1),
 	} {
 		if id.URL.Series == "bundle" {
-			s.addPublicBundle(c, "wordpress-simple", id)
+			s.addPublicBundle(c, id.URL.Name, id, false)
 		} else {
-			s.addPublicCharm(c, "wordpress", id)
+			s.addPublicCharm(c, id.URL.Name, id)
 		}
 	}
 	now := time.Now()
@@ -84,7 +84,7 @@ func (s *APISuite) TestStatus(c *gc.C) {
 		},
 		"entities": {
 			Name:   "Entities in charm store",
-			Value:  "4 charms; 2 bundles; 3 promulgated",
+			Value:  "4 charms; 2 bundles; 4 promulgated",
 			Passed: true,
 		},
 		"base_entities": {


### PR DESCRIPTION
internal/charmstore: move upload logic from API level

The API tests were second-guessing the charmstore behaviour
with respect to blob uploading, which was fine but we're
changing the upload behaviour, so now we make all the
tests use the regular streaming blob upload code.

There are no semantic changes to the production code.

We will need to move some tests from the API levels
to the charmstore level, because charmstore package
coverage is now poor, but we will do that in a new PR
because this one is large enough already.

To summarise:
- the charm upload streaming code moves from internal/v5 to internal/charmstore.
- the code related to adding entities in internal/charmstore moves into addentity.go.
- in internal/storetesting we add NewCharm and NewBundle to make it easy to
  generate a charm or bundle along with its archive.
- we remove relationTestingCharm and replace it with a more general variant that
  uses storetesting.NewCharm.
- we fix a bug in charmstore.Pool.Close that meant the audit logger was never
  closed (caught by go vet)
- we add a test helper that adds any charms required by a bundle, because
  bundle verification now requires that all bundles added by tests have their
  prerequisite charms in the store.
- we align the v4 tests somewhat closer with the diverged v5 tests.
