### PR TITLE
internal/charmstore: better tests for UploadEntity.

### DIFF
--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -212,36 +212,72 @@ func (s *ArchiveSuite) TestGetCountersDisabled(c *gc.C) {
 
 var archivePostErrorsTests = []struct {
 	about           string
-	path            string
+	url             string
 	noContentLength bool
+	noHash          bool
+	entity          charmstore.ArchiverTo
 	expectStatus    int
 	expectMessage   string
 	expectCode      params.ErrorCode
 }{{
 	about:         "revision specified",
-	path:          "~charmers/precise/wordpress-23/archive",
+	url:           "~charmers/precise/wordpress-23",
 	expectStatus:  http.StatusBadRequest,
 	expectMessage: "revision specified, but should not be specified",
 	expectCode:    params.ErrBadRequest,
 }, {
 	about:         "no hash given",
-	path:          "~charmers/precise/wordpress/archive",
+	url:           "~charmers/precise/wordpress",
+	noHash:        true,
 	expectStatus:  http.StatusBadRequest,
 	expectMessage: "hash parameter not specified",
 	expectCode:    params.ErrBadRequest,
 }, {
 	about:           "no content length",
-	path:            "~charmers/precise/wordpress/archive?hash=1234563",
+	url:             "~charmers/precise/wordpress",
 	noContentLength: true,
 	expectStatus:    http.StatusBadRequest,
 	expectMessage:   "Content-Length not specified",
 	expectCode:      params.ErrBadRequest,
 }, {
 	about:         "invalid channel",
-	path:          "~charmers/bad-wolf/trusty/wordpress/archive",
+	url:           "~charmers/bad-wolf/trusty/wordpress",
 	expectStatus:  http.StatusNotFound,
 	expectMessage: "not found",
 	expectCode:    params.ErrNotFound,
+}, {
+	about:         "no series",
+	url:           "~charmers/juju-gui",
+	expectStatus:  http.StatusForbidden,
+	expectMessage: "series not specified in url or charm metadata",
+	expectCode:    params.ErrEntityIdNotAllowed,
+}, {
+	about: "url series not in metadata",
+	url:   "~charmers/precise/juju-gui",
+	entity: storetesting.NewCharm(&charm.Meta{
+		Series: []string{"trusty"},
+	}),
+	expectStatus:  http.StatusForbidden,
+	expectMessage: `"precise" series not listed in charm metadata`,
+	expectCode:    params.ErrEntityIdNotAllowed,
+}, {
+	about: "bad combination of series",
+	url:   "~charmers/juju-gui",
+	entity: storetesting.NewCharm(&charm.Meta{
+		Series: []string{"precise", "win10"},
+	}),
+	expectStatus:  http.StatusBadRequest,
+	expectMessage: `cannot mix series from ubuntu and windows in single charm`,
+	expectCode:    params.ErrInvalidEntity,
+}, {
+	about: "unknown series",
+	url:   "~charmers/juju-gui",
+	entity: storetesting.NewCharm(&charm.Meta{
+		Series: []string{"precise", "nosuchseries"},
+	}),
+	expectStatus:  http.StatusBadRequest,
+	expectMessage: `unrecognized series "nosuchseries" in metadata`,
+	expectCode:    params.ErrInvalidEntity,
 }}
 
 func (s *ArchiveSuite) TestPostErrors(c *gc.C) {
@@ -250,16 +286,24 @@ func (s *ArchiveSuite) TestPostErrors(c *gc.C) {
 	}
 	for i, test := range archivePostErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
-		var body io.Reader = strings.NewReader("bogus")
+		if test.entity == nil {
+			test.entity = storetesting.NewCharm(nil)
+		}
+		blob, hashSum := getBlob(test.entity)
+		body := io.Reader(blob)
 		if test.noContentLength {
 			// net/http will automatically add a Content-Length header
 			// if it sees *strings.Reader, but not if it's a type it doesn't
 			// know about.
 			body = exoticReader{body}
 		}
+		path := storeURL(test.url) + "/archive"
+		if !test.noHash {
+			path += "?hash=" + hashSum
+		}
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler: s.srv,
-			URL:     storeURL(test.path),
+			URL:     path,
 			Method:  "POST",
 			Header: http.Header{
 				"Content-Type": {"application/zip"},
@@ -518,65 +562,6 @@ func (s *ArchiveSuite) TestPostMultiSeriesCharm(c *gc.C) {
 func (s *ArchiveSuite) TestPostMultiSeriesDevelopmentCharm(c *gc.C) {
 	// A charm that did not exist before should get revision 0.
 	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/juju-gui-0", -1), "multi-series")
-}
-
-var charmPostErrorTests = []struct {
-	about        string
-	url          *charm.URL
-	charm        string
-	expectStatus int
-	expectBody   interface{}
-}{{
-	about:        "no series",
-	url:          charm.MustParseURL("~charmers/juju-gui-0"),
-	charm:        "wordpress",
-	expectStatus: http.StatusForbidden,
-	expectBody: params.Error{
-		Message: "series not specified in url or charm metadata",
-		Code:    params.ErrEntityIdNotAllowed,
-	},
-}, {
-	about:        "url series not in metadata",
-	url:          charm.MustParseURL("~charmers/precise/juju-gui-0"),
-	charm:        "multi-series",
-	expectStatus: http.StatusForbidden,
-	expectBody: params.Error{
-		Message: `"precise" series not listed in charm metadata`,
-		Code:    params.ErrEntityIdNotAllowed,
-	},
-}, {
-	about:        "bad combination of series",
-	url:          charm.MustParseURL("~charmers/juju-gui-0"),
-	charm:        "multi-series-bad-combination",
-	expectStatus: http.StatusBadRequest,
-	expectBody: params.Error{
-		Message: `cannot mix series from ubuntu and windows in single charm`,
-		Code:    params.ErrInvalidEntity,
-	},
-}, {
-	about:        "unknown series",
-	url:          charm.MustParseURL("~charmers/juju-gui-0"),
-	charm:        "multi-series-unknown",
-	expectStatus: http.StatusBadRequest,
-	expectBody: params.Error{
-		Message: `unrecognised series "nosuchseries" in metadata`,
-		Code:    params.ErrInvalidEntity,
-	},
-}}
-
-func (s *ArchiveSuite) TestCharmPostError(c *gc.C) {
-	for i, test := range charmPostErrorTests {
-		c.Logf("%d. %s", i, test.about)
-		s.assertUploadCharmError(
-			c,
-			"POST",
-			test.url,
-			nil,
-			test.charm,
-			test.expectStatus,
-			test.expectBody,
-		)
-	}
 }
 
 func (s *ArchiveSuite) TestPostMultiSeriesCharmRevisionAfterAllSingleSeriesOnes(c *gc.C) {
@@ -1107,8 +1092,8 @@ func (s *ArchiveSuite) assertUpload(c *gc.C, method string, url *router.Resolved
 // specified error. The URL must hold the expected revision that the
 // charm will be given when uploaded.
 func (s *ArchiveSuite) assertUploadCharmError(c *gc.C, method string, url, purl *charm.URL, charmName string, expectStatus int, expectBody interface{}) {
-	ch := storetesting.Charms.CharmArchive(c.MkDir(), charmName)
-	s.assertUploadError(c, method, url, purl, ch.Path, expectStatus, expectBody)
+	ch := storetesting.Charms.CharmDir(charmName)
+	s.assertUploadError(c, method, url, purl, ch, expectStatus, expectBody)
 }
 
 // assertUploadError asserts that we get an error when uploading
@@ -1116,18 +1101,8 @@ func (s *ArchiveSuite) assertUploadCharmError(c *gc.C, method string, url, purl 
 // The reason this method does not take a *router.ResolvedURL
 // is so that we can test what happens when an inconsistent promulgated URL
 // is passed in.
-func (s *ArchiveSuite) assertUploadError(c *gc.C, method string, url, purl *charm.URL, fileName string, expectStatus int, expectBody interface{}) {
-	f, err := os.Open(fileName)
-	c.Assert(err, gc.IsNil)
-	defer f.Close()
-
-	// Calculate blob hashes.
-	hash := blobstore.NewHash()
-	size, err := io.Copy(hash, f)
-	c.Assert(err, gc.IsNil)
-	hashSum := fmt.Sprintf("%x", hash.Sum(nil))
-	_, err = f.Seek(0, 0)
-	c.Assert(err, gc.IsNil)
+func (s *ArchiveSuite) assertUploadError(c *gc.C, method string, url, purl *charm.URL, entity charmstore.ArchiverTo, expectStatus int, expectBody interface{}) {
+	blob, hashSum := getBlob(entity)
 
 	uploadURL := *url
 	if method == "POST" {
@@ -1142,16 +1117,29 @@ func (s *ArchiveSuite) assertUploadError(c *gc.C, method string, url, purl *char
 		Handler:       s.srv,
 		URL:           storeURL(path),
 		Method:        method,
-		ContentLength: size,
+		ContentLength: int64(blob.Len()),
 		Header: http.Header{
 			"Content-Type": {"application/zip"},
 		},
-		Body:         f,
+		Body:         blob,
 		Username:     testUsername,
 		Password:     testPassword,
 		ExpectStatus: expectStatus,
 		ExpectBody:   expectBody,
 	})
+}
+
+// getBlob returns the contents and blob checksum of the given entity.
+func getBlob(entity charmstore.ArchiverTo) (blob *bytes.Buffer, hash string) {
+	blob = new(bytes.Buffer)
+	err := entity.ArchiveTo(blob)
+	if err != nil {
+		panic(err)
+	}
+	h := blobstore.NewHash()
+	h.Write(blob.Bytes())
+	hash = fmt.Sprintf("%x", h.Sum(nil))
+	return blob, hash
 }
 
 var archiveFileErrorsTests = []struct {

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -14,7 +14,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2/bson"
@@ -41,29 +40,29 @@ var _ = gc.Suite(&RelationsSuite{})
 // metaCharmRelatedCharms defines a bunch of charms to be used in
 // the relation tests.
 var metaCharmRelatedCharms = map[string]charm.Charm{
-	"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(relationMeta(
+	"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides website http",
 		"requires cache memcache",
 		"requires nfs mount",
 	)),
-	"42 ~charmers/utopic/memcached-42": storetesting.NewCharm(relationMeta(
+	"42 ~charmers/utopic/memcached-42": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides cache memcache",
 	)),
-	"1 ~charmers/precise/nfs-1": storetesting.NewCharm(relationMeta(
+	"1 ~charmers/precise/nfs-1": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides nfs mount",
 	)),
-	"47 ~charmers/trusty/haproxy-47": storetesting.NewCharm(relationMeta(
+	"47 ~charmers/trusty/haproxy-47": storetesting.NewCharm(storetesting.RelationMeta(
 		"requires reverseproxy http",
 	)),
-	"48 ~charmers/precise/haproxy-48": storetesting.NewCharm(relationMeta(
+	"48 ~charmers/precise/haproxy-48": storetesting.NewCharm(storetesting.RelationMeta(
 		"requires reverseproxy http",
 	)),
 	// development charms should not be included in any results.
-	"49 ~charmers/development/precise/haproxy-49": storetesting.NewCharm(relationMeta(
+	"49 ~charmers/development/precise/haproxy-49": storetesting.NewCharm(storetesting.RelationMeta(
 		"requires reverseproxy http",
 	)),
 	"1 ~charmers/multi-series-20": storetesting.NewCharm(
-		metaWithSupportedSeries(relationMeta(
+		storetesting.MetaWithSupportedSeries(storetesting.RelationMeta(
 			"requires reverseproxy http",
 		), "precise", "trusty", "utopic",
 		)),
@@ -133,7 +132,7 @@ var metaCharmRelatedTests = []struct {
 }, {
 	about: "no relations found",
 	charms: map[string]charm.Charm{
-		"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(relationMeta(
+		"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides website http",
 			"requires cache memcache",
 			"requires nfs mount",
@@ -149,16 +148,16 @@ var metaCharmRelatedTests = []struct {
 }, {
 	about: "multiple revisions of the same related charm",
 	charms: map[string]charm.Charm{
-		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(relationMeta(
+		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(storetesting.RelationMeta(
 			"requires cache memcache",
 		)),
-		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(relationMeta(
+		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(relationMeta(
+		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"3 ~charmers/utopic/memcached-3": storetesting.NewCharm(relationMeta(
+		"3 ~charmers/utopic/memcached-3": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
 	},
@@ -177,26 +176,26 @@ var metaCharmRelatedTests = []struct {
 }, {
 	about: "reference ordering",
 	charms: map[string]charm.Charm{
-		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(relationMeta(
+		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(storetesting.RelationMeta(
 			"requires cache memcache",
 			"requires nfs mount",
 		)),
-		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(relationMeta(
+		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(relationMeta(
+		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"90 ~charmers/utopic/redis-90": storetesting.NewCharm(relationMeta(
+		"90 ~charmers/utopic/redis-90": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"47 ~charmers/trusty/nfs-47": storetesting.NewCharm(relationMeta(
+		"47 ~charmers/trusty/nfs-47": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides nfs mount",
 		)),
-		"42 ~charmers/precise/nfs-42": storetesting.NewCharm(relationMeta(
+		"42 ~charmers/precise/nfs-42": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides nfs mount",
 		)),
-		"47 ~charmers/precise/nfs-47": storetesting.NewCharm(relationMeta(
+		"47 ~charmers/precise/nfs-47": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides nfs mount",
 		)),
 	},
@@ -288,52 +287,6 @@ func (s *RelationsSuite) TestMetaCharmRelatedIncludeError(c *gc.C) {
 			Message: `cannot retrieve the charm requires: unrecognized metadata name "no-such"`,
 		},
 	})
-}
-
-func metaWithSupportedSeries(m *charm.Meta, series ...string) *charm.Meta {
-	m.Series = series
-	return m
-}
-
-func relationMeta(relations ...string) *charm.Meta {
-	provides := make(map[string]charm.Relation)
-	requires := make(map[string]charm.Relation)
-	for _, rel := range relations {
-		r, err := parseRelation(rel)
-		if err != nil {
-			panic(fmt.Errorf("bad relation %q", err))
-		}
-		if r.Role == charm.RoleProvider {
-			provides[r.Name] = r
-		} else {
-			requires[r.Name] = r
-		}
-	}
-	return &charm.Meta{
-		Provides: provides,
-		Requires: requires,
-	}
-}
-
-func parseRelation(s string) (charm.Relation, error) {
-	fields := strings.Fields(s)
-	if len(fields) != 3 {
-		return charm.Relation{}, errgo.Newf("wrong field count")
-	}
-	r := charm.Relation{
-		Scope:     charm.ScopeGlobal,
-		Name:      fields[1],
-		Interface: fields[2],
-	}
-	switch fields[0] {
-	case "provides":
-		r.Role = charm.RoleProvider
-	case "requires":
-		r.Role = charm.RoleRequirer
-	default:
-		return charm.Relation{}, errgo.Newf("unknown role")
-	}
-	return r, nil
 }
 
 // metaBundlesContainingBundles defines a bunch of bundles to be used in

--- a/internal/v5/bench_test.go
+++ b/internal/v5/bench_test.go
@@ -53,26 +53,26 @@ func (s *BenchmarkSuite) BenchmarkMeta(c *gc.C) {
 }
 
 var benchmarkCharmRelatedAddCharms = map[string]charm.Charm{
-	"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(relationMeta(
+	"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(storetesting.RelationMeta(
 		"requires cache memcache",
 		"requires nfs mount",
 	)),
-	"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(relationMeta(
+	"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides cache memcache",
 	)),
-	"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(relationMeta(
+	"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides cache memcache",
 	)),
-	"90 ~charmers/utopic/redis-90": storetesting.NewCharm(relationMeta(
+	"90 ~charmers/utopic/redis-90": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides cache memcache",
 	)),
-	"47 ~charmers/trusty/nfs-47": storetesting.NewCharm(relationMeta(
+	"47 ~charmers/trusty/nfs-47": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides nfs mount",
 	)),
-	"42 ~charmers/precise/nfs-42": storetesting.NewCharm(relationMeta(
+	"42 ~charmers/precise/nfs-42": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides nfs mount",
 	)),
-	"47 ~charmers/precise/nfs-47": storetesting.NewCharm(relationMeta(
+	"47 ~charmers/precise/nfs-47": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides nfs mount",
 	)),
 }

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -14,7 +14,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2/bson"
@@ -41,29 +40,29 @@ var _ = gc.Suite(&RelationsSuite{})
 // metaCharmRelatedCharms defines a bunch of charms to be used in
 // the relation tests.
 var metaCharmRelatedCharms = map[string]charm.Charm{
-	"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(relationMeta(
+	"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides website http",
 		"requires cache memcache",
 		"requires nfs mount",
 	)),
-	"42 ~charmers/utopic/memcached-42": storetesting.NewCharm(relationMeta(
+	"42 ~charmers/utopic/memcached-42": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides cache memcache",
 	)),
-	"1 ~charmers/precise/nfs-1": storetesting.NewCharm(relationMeta(
+	"1 ~charmers/precise/nfs-1": storetesting.NewCharm(storetesting.RelationMeta(
 		"provides nfs mount",
 	)),
-	"47 ~charmers/trusty/haproxy-47": storetesting.NewCharm(relationMeta(
+	"47 ~charmers/trusty/haproxy-47": storetesting.NewCharm(storetesting.RelationMeta(
 		"requires reverseproxy http",
 	)),
-	"48 ~charmers/precise/haproxy-48": storetesting.NewCharm(relationMeta(
+	"48 ~charmers/precise/haproxy-48": storetesting.NewCharm(storetesting.RelationMeta(
 		"requires reverseproxy http",
 	)),
 	// development charms should not be included in any results.
-	"49 ~charmers/development/precise/haproxy-49": storetesting.NewCharm(relationMeta(
+	"49 ~charmers/development/precise/haproxy-49": storetesting.NewCharm(storetesting.RelationMeta(
 		"requires reverseproxy http",
 	)),
 	"1 ~charmers/multi-series-20": storetesting.NewCharm(
-		metaWithSupportedSeries(relationMeta(
+		storetesting.MetaWithSupportedSeries(storetesting.RelationMeta(
 			"requires reverseproxy http",
 		), "precise", "trusty", "utopic",
 		)),
@@ -136,7 +135,7 @@ var metaCharmRelatedTests = []struct {
 }, {
 	about: "no relations found",
 	charms: map[string]charm.Charm{
-		"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(relationMeta(
+		"0 ~charmers/utopic/wordpress-0": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides website http",
 			"requires cache memcache",
 			"requires nfs mount",
@@ -152,16 +151,16 @@ var metaCharmRelatedTests = []struct {
 }, {
 	about: "multiple revisions of the same related charm",
 	charms: map[string]charm.Charm{
-		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(relationMeta(
+		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(storetesting.RelationMeta(
 			"requires cache memcache",
 		)),
-		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(relationMeta(
+		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(relationMeta(
+		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"3 ~charmers/utopic/memcached-3": storetesting.NewCharm(relationMeta(
+		"3 ~charmers/utopic/memcached-3": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
 	},
@@ -180,26 +179,26 @@ var metaCharmRelatedTests = []struct {
 }, {
 	about: "reference ordering",
 	charms: map[string]charm.Charm{
-		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(relationMeta(
+		"0 ~charmers/trusty/wordpress-0": storetesting.NewCharm(storetesting.RelationMeta(
 			"requires cache memcache",
 			"requires nfs mount",
 		)),
-		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(relationMeta(
+		"1 ~charmers/utopic/memcached-1": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(relationMeta(
+		"2 ~charmers/utopic/memcached-2": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"90 ~charmers/utopic/redis-90": storetesting.NewCharm(relationMeta(
+		"90 ~charmers/utopic/redis-90": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides cache memcache",
 		)),
-		"47 ~charmers/trusty/nfs-47": storetesting.NewCharm(relationMeta(
+		"47 ~charmers/trusty/nfs-47": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides nfs mount",
 		)),
-		"42 ~charmers/precise/nfs-42": storetesting.NewCharm(relationMeta(
+		"42 ~charmers/precise/nfs-42": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides nfs mount",
 		)),
-		"47 ~charmers/precise/nfs-47": storetesting.NewCharm(relationMeta(
+		"47 ~charmers/precise/nfs-47": storetesting.NewCharm(storetesting.RelationMeta(
 			"provides nfs mount",
 		)),
 	},
@@ -317,52 +316,6 @@ func (s *RelationsSuite) TestMetaCharmRelatedIncludeError(c *gc.C) {
 			Message: `cannot retrieve the charm requires: unrecognized metadata name "no-such"`,
 		},
 	})
-}
-
-func metaWithSupportedSeries(m *charm.Meta, series ...string) *charm.Meta {
-	m.Series = series
-	return m
-}
-
-func relationMeta(relations ...string) *charm.Meta {
-	provides := make(map[string]charm.Relation)
-	requires := make(map[string]charm.Relation)
-	for _, rel := range relations {
-		r, err := parseRelation(rel)
-		if err != nil {
-			panic(fmt.Errorf("bad relation %q", err))
-		}
-		if r.Role == charm.RoleProvider {
-			provides[r.Name] = r
-		} else {
-			requires[r.Name] = r
-		}
-	}
-	return &charm.Meta{
-		Provides: provides,
-		Requires: requires,
-	}
-}
-
-func parseRelation(s string) (charm.Relation, error) {
-	fields := strings.Fields(s)
-	if len(fields) != 3 {
-		return charm.Relation{}, errgo.Newf("wrong field count")
-	}
-	r := charm.Relation{
-		Scope:     charm.ScopeGlobal,
-		Name:      fields[1],
-		Interface: fields[2],
-	}
-	switch fields[0] {
-	case "provides":
-		r.Role = charm.RoleProvider
-	case "requires":
-		r.Role = charm.RoleRequirer
-	default:
-		return charm.Relation{}, errgo.Newf("unknown role")
-	}
-	return r, nil
 }
 
 // metaBundlesContainingBundles defines a bunch of bundles to be used in


### PR DESCRIPTION
Test coverage back up to about 90% in internal/charmstore/addentity.go.
