### PR TITLE
Remove most references to devlopment channels in the entity URL.

### DIFF
--- a/internal/charmstore/addentity.go
+++ b/internal/charmstore/addentity.go
@@ -412,7 +412,7 @@ func (s *Store) addCharm(c charm.Charm, p addParams) (err error) {
 	// final gateway before a potentially invalid url might be stored
 	// in the database.
 	id := p.url.URL
-	logger.Infof("add charm url %s; prev %d; dev %v", &id, p.url.PromulgatedRevision, p.url.Development)
+	logger.Infof("add charm url %s; prev %d", &id, p.url.PromulgatedRevision)
 	entity := &mongodoc.Entity{
 		URL:                     &id,
 		PromulgatedURL:          p.url.DocPromulgatedURL(),
@@ -430,7 +430,6 @@ func (s *Store) addCharm(c charm.Charm, p addParams) (err error) {
 		CharmProvidedInterfaces: interfacesForRelations(c.Meta().Provides),
 		CharmRequiredInterfaces: interfacesForRelations(c.Meta().Requires),
 		SupportedSeries:         c.Meta().Series,
-		Development:             p.url.Development,
 	}
 	denormalizeEntity(entity)
 
@@ -483,7 +482,6 @@ func (s *Store) addBundle(b charm.Bundle, p addParams) error {
 		BundleReadMe:       b.ReadMe(),
 		BundleCharms:       urls,
 		PromulgatedURL:     p.url.DocPromulgatedURL(),
-		Development:        p.url.Development,
 	}
 	denormalizeEntity(entity)
 
@@ -515,13 +513,12 @@ func (s *Store) addEntity(entity *mongodoc.Entity) (err error) {
 		Write: perms,
 	}
 	baseEntity := &mongodoc.BaseEntity{
-		URL:             entity.BaseURL,
-		User:            entity.User,
-		Name:            entity.Name,
-		Public:          false,
-		ACLs:            acls,
-		DevelopmentACLs: acls,
-		Promulgated:     entity.PromulgatedURL != nil,
+		URL:         entity.BaseURL,
+		User:        entity.User,
+		Name:        entity.Name,
+		Public:      false,
+		ACLs:        acls,
+		Promulgated: entity.PromulgatedURL != nil,
 	}
 	err = s.DB.BaseEntities().Insert(baseEntity)
 	if err != nil && !mgo.IsDup(err) {

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -73,12 +73,6 @@ func (s *AddEntitySuite) TestAddUserOwnedCharmArchive(c *gc.C) {
 	s.checkAddCharm(c, charmArchive, false, router.MustNewResolvedURL("~charmers/precise/wordpress-1", -1))
 }
 
-func (s *AddEntitySuite) TestAddDevelopmentCharmArchive(c *gc.C) {
-	charmArchive := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
-	url := router.MustNewResolvedURL("~charmers/development/precise/wordpress-1", 1)
-	s.checkAddCharm(c, charmArchive, false, url)
-}
-
 func (s *AddEntitySuite) TestAddBundleDir(c *gc.C) {
 	bundleDir := storetesting.Charms.BundleDir("wordpress-simple")
 	s.checkAddBundle(c, bundleDir, false, router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 3))
@@ -104,15 +98,6 @@ func (s *AddEntitySuite) TestAddUserOwnedBundleArchive(c *gc.C) {
 	)
 	c.Assert(err, gc.IsNil)
 	s.checkAddBundle(c, bundleArchive, false, router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", -1))
-}
-
-func (s *AddEntitySuite) TestAddDevelopmentBundleArchive(c *gc.C) {
-	bundleArchive, err := charm.ReadBundleArchive(
-		storetesting.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
-	)
-	c.Assert(err, gc.IsNil)
-	url := router.MustNewResolvedURL("~charmers/development/bundle/wordpress-simple-2", 3)
-	s.checkAddBundle(c, bundleArchive, false, url)
 }
 
 func (s *AddEntitySuite) TestAddCharmWithBundleSeries(c *gc.C) {
@@ -440,7 +425,6 @@ func (s *AddEntitySuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool, ur
 		CharmRequiredInterfaces: []string{"mysql", "varnish"},
 		PromulgatedURL:          url.DocPromulgatedURL(),
 		SupportedSeries:         ch.Meta().Series,
-		Development:             url.Development,
 	}))
 
 	// The charm archive has been properly added to the blob store.
@@ -524,7 +508,6 @@ func (s *AddEntitySuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bo
 		BundleMachineCount: newInt(2),
 		BundleUnitCount:    newInt(2),
 		PromulgatedURL:     url.DocPromulgatedURL(),
-		Development:        url.Development,
 	}))
 
 	// The bundle archive has been properly added to the blob store.
@@ -589,13 +572,12 @@ func assertBaseEntity(c *gc.C, store *Store, url *charm.URL, promulgated bool) {
 		Write: []string{url.User},
 	}
 	c.Assert(baseEntity, jc.DeepEquals, &mongodoc.BaseEntity{
-		URL:             url,
-		User:            url.User,
-		Name:            url.Name,
-		Public:          false,
-		ACLs:            expectACLs,
-		DevelopmentACLs: expectACLs,
-		Promulgated:     mongodoc.IntBool(promulgated),
+		URL:         url,
+		User:        url.User,
+		Name:        url.Name,
+		Public:      false,
+		ACLs:        expectACLs,
+		Promulgated: mongodoc.IntBool(promulgated),
 	})
 }
 

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -83,7 +83,7 @@ func (s *Store) UpdateSearch(r *router.ResolvedURL) error {
 	if s.ES == nil || s.ES.Database == nil {
 		return nil
 	}
-	if r.Development || r.URL.Series != "" && !series.Series[r.URL.Series].SearchIndex {
+	if r.URL.Series != "" && !series.Series[r.URL.Series].SearchIndex {
 		return nil
 	}
 

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -141,19 +141,6 @@ func (s *StoreSearchSuite) TestNoExportDeprecated(c *gc.C) {
 	c.Assert(present, gc.Equals, false)
 }
 
-func (s *StoreSearchSuite) TestNoExportDevelopment(c *gc.C) {
-	rurl := router.MustNewResolvedURL("cs:~charmers/development/trusty/mysql-42", -1)
-	err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("mysql"))
-	c.Assert(err, gc.IsNil)
-
-	var entity *mongodoc.Entity
-	err = s.store.DB.Entities().FindId(rurl.URL.String()).One(&entity)
-	c.Assert(err, gc.IsNil)
-	present, err := s.store.ES.HasDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL))
-	c.Assert(err, gc.IsNil)
-	c.Assert(present, gc.Equals, false)
-}
-
 func (s *StoreSearchSuite) TestExportOnlyLatest(c *gc.C) {
 	charmArchive := storetesting.Charms.CharmDir("wordpress")
 	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-24", -1)

--- a/internal/entitycache/cache.go
+++ b/internal/entitycache/cache.go
@@ -64,7 +64,6 @@ type Cache struct {
 var requiredEntityFields = map[string]int{
 	"_id":             1,
 	"promulgated-url": 1,
-	"development":     1,
 	"baseurl":         1,
 }
 
@@ -677,9 +676,6 @@ type entity struct {
 
 func (e entity) url() *charm.URL {
 	u := *e.URL
-	if e.Development {
-		u.Channel = charm.DevelopmentChannel
-	}
 	return &u
 }
 
@@ -688,9 +684,6 @@ func (e entity) promulgatedURL() *charm.URL {
 		return nil
 	}
 	u := *e.PromulgatedURL
-	if e.Development {
-		u.Channel = charm.DevelopmentChannel
-	}
 	return &u
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -138,10 +138,6 @@ type ResolvedURL struct {
 	// PromulgatedRevision holds the revision of the promulgated version of the
 	// charm or -1 if the corresponding entity is not promulgated.
 	PromulgatedRevision int
-
-	// Development holds whether the original entity URL included the
-	// "development" channel.
-	Development bool
 }
 
 // MustNewResolvedURL returns a new ResolvedURL by parsing
@@ -159,7 +155,6 @@ func MustNewResolvedURL(urlStr string, promulgatedRev int) *ResolvedURL {
 	return &ResolvedURL{
 		URL:                 *url.WithChannel(""),
 		PromulgatedRevision: promulgatedRev,
-		Development:         url.Channel == charm.DevelopmentChannel,
 	}
 }
 
@@ -167,9 +162,6 @@ func MustNewResolvedURL(urlStr string, promulgatedRev int) *ResolvedURL {
 // The returned *charm.URL may be modified freely.
 func (id *ResolvedURL) UserOwnedURL() *charm.URL {
 	u := id.URL
-	if id.Development {
-		u.Channel = charm.DevelopmentChannel
-	}
 	return &u
 }
 
@@ -222,12 +214,10 @@ func (id *ResolvedURL) GoString() string {
 		URL                 string
 		PreferredSeries     string
 		PromulgatedRevision int
-		Development         bool
 	}{
 		URL:                 id.URL.String(),
 		PreferredSeries:     id.PreferredSeries,
 		PromulgatedRevision: id.PromulgatedRevision,
-		Development:         id.Development,
 	}
 	return fmt.Sprintf("%#v", gid)
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -459,19 +459,6 @@ var routerGetTests = []struct {
 		CharmURL: "cs:precise/wordpress-42",
 	},
 }, {
-	about: "meta handler with development channel",
-	handlers: Handlers{
-		Meta: map[string]BulkIncludeHandler{
-			"foo": testMetaHandler(0),
-		},
-	},
-	urlStr: "/development/precise/wordpress/meta/foo",
-	expectWillIncludeMetadata: []string{"foo"},
-	expectStatus:              http.StatusOK,
-	expectBody: &metaHandlerTestResp{
-		CharmURL: "cs:development/precise/wordpress-0",
-	},
-}, {
 	about: "meta handler with additional elements",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
@@ -748,21 +735,6 @@ var routerGetTests = []struct {
 		},
 	},
 }, {
-	about:  "bulk meta handler, single development id",
-	urlStr: "/meta/foo?id=~user/development/wily/wordpress-42",
-	handlers: Handlers{
-		Meta: map[string]BulkIncludeHandler{
-			"foo": testMetaHandler(0),
-		},
-	},
-	expectWillIncludeMetadata: []string{"foo"},
-	expectStatus:              http.StatusOK,
-	expectBody: map[string]metaHandlerTestResp{
-		"~user/development/wily/wordpress-42": {
-			CharmURL: "cs:~user/development/wily/wordpress-42",
-		},
-	},
-}, {
 	about:  "bulk meta handler, single id with invalid channel",
 	urlStr: "/meta/foo?id=~user/bad-wolf/wily/wordpress-42",
 	handlers: Handlers{
@@ -794,7 +766,7 @@ var routerGetTests = []struct {
 			CharmURL: "cs:utopic/foo-32",
 		},
 		"development/django": {
-			CharmURL: "cs:development/precise/django-0",
+			CharmURL: "cs:precise/django-0",
 		},
 	},
 }, {
@@ -834,13 +806,13 @@ var routerGetTests = []struct {
 			},
 		},
 		"development/django-47": {
-			Id: charm.MustParseURL("cs:development/precise/django-47"),
+			Id: charm.MustParseURL("cs:precise/django-47"),
 			Meta: map[string]interface{}{
 				"foo": metaHandlerTestResp{
-					CharmURL: "cs:development/precise/django-47",
+					CharmURL: "cs:precise/django-47",
 				},
 				"bar/something": metaHandlerTestResp{
-					CharmURL: "cs:development/precise/django-47",
+					CharmURL: "cs:precise/django-47",
 					Path:     "/something",
 				},
 			},
@@ -1494,19 +1466,13 @@ var routerPutTests = []struct {
 				"baz/ppp":  "baz/ppp-mysql-val",
 			},
 		},
-		"development/trusty/django-47": {
+		"trusty/django-47": {
 			Meta: map[string]interface{}{
 				"foo": "foo-django-val",
 			},
 		},
 	},
 	expectRecordedCalls: []interface{}{
-		metaHandlerTestPutParams{
-			NumHandlers: 1,
-			Id:          "cs:development/trusty/django-47",
-			Paths:       []string{""},
-			Values:      []interface{}{"foo-django-val"},
-		},
 		metaHandlerTestPutParams{
 			NumHandlers: 3,
 			Id:          "cs:precise/mysql-134",
@@ -1518,6 +1484,12 @@ var routerPutTests = []struct {
 			Id:          "cs:precise/wordpress-42",
 			Paths:       []string{"", ""},
 			Values:      []interface{}{"foo-wordpress-val", "bar-wordpress-val"},
+		},
+		metaHandlerTestPutParams{
+			NumHandlers: 1,
+			Id:          "cs:trusty/django-47",
+			Paths:       []string{""},
+			Values:      []interface{}{"foo-django-val"},
 		},
 	},
 }, {
@@ -2351,17 +2323,17 @@ var resolvedURLTests = []struct {
 	expectPromulgatedURL: charm.MustParseURL("precise/wordpress-4"),
 }, {
 	rurl:               MustNewResolvedURL("~who/development/trusty/wordpress-42", -1),
-	expectUserOwnedURL: charm.MustParseURL("~who/development/trusty/wordpress-42"),
-	expectPreferredURL: charm.MustParseURL("~who/development/trusty/wordpress-42"),
+	expectUserOwnedURL: charm.MustParseURL("~who/trusty/wordpress-42"),
+	expectPreferredURL: charm.MustParseURL("~who/trusty/wordpress-42"),
 }, {
 	rurl:               MustNewResolvedURL("~charmers/precise/wordpress-23", -1),
 	expectUserOwnedURL: charm.MustParseURL("~charmers/precise/wordpress-23"),
 	expectPreferredURL: charm.MustParseURL("~charmers/precise/wordpress-23"),
 }, {
 	rurl:                 MustNewResolvedURL("~charmers/development/trusty/wordpress-42", 0),
-	expectUserOwnedURL:   charm.MustParseURL("~charmers/development/trusty/wordpress-42"),
-	expectPreferredURL:   charm.MustParseURL("development/trusty/wordpress-0"),
-	expectPromulgatedURL: charm.MustParseURL("development/trusty/wordpress-0"),
+	expectUserOwnedURL:   charm.MustParseURL("~charmers/trusty/wordpress-42"),
+	expectPreferredURL:   charm.MustParseURL("trusty/wordpress-0"),
+	expectPromulgatedURL: charm.MustParseURL("trusty/wordpress-0"),
 }, {
 	rurl:                 withPreferredSeries(MustNewResolvedURL("~charmers/wordpress-42", 0), "trusty"),
 	expectUserOwnedURL:   charm.MustParseURL("~charmers/wordpress-42"),

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -110,7 +110,7 @@ func (b BaseEntityBuilder) WithPromulgated(promulgated bool) BaseEntityBuilder {
 	return b
 }
 
-// WithACLs sets the non-development ACLs field on the BaseEntity.
+// WithACLs sets the ACLs field on the BaseEntity.
 func (b BaseEntityBuilder) WithACLs(acls mongodoc.ACL) BaseEntityBuilder {
 	b = b.copy()
 	b.baseEntity.ACLs = acls

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -155,7 +155,6 @@ func resolveURL(cache *entitycache.Cache, url *charm.URL) (*router.ResolvedURL, 
 	rurl := &router.ResolvedURL{
 		URL:                 *entity.URL,
 		PromulgatedRevision: -1,
-		Development:         url.Channel == charm.DevelopmentChannel,
 	}
 	if url.User == "" {
 		rurl.PromulgatedRevision = entity.PromulgatedRevision
@@ -216,7 +215,7 @@ func (h ReqHandler) metaRevisionInfo(id *router.ResolvedURL, path string, flags 
 		q = q.Sort("-revision")
 	}
 	var docs []*mongodoc.Entity
-	if err := q.Select(bson.D{{"_id", 1}, {"promulgated-url", 1}, {"supportedseries", 1}, {"development", 1}}).All(&docs); err != nil {
+	if err := q.Select(bson.D{{"_id", 1}, {"promulgated-url", 1}, {"supportedseries", 1}}).All(&docs); err != nil {
 		return "", errgo.Notef(err, "cannot get ids")
 	}
 
@@ -280,13 +279,7 @@ func (h ReqHandler) serveExpandId(id *router.ResolvedURL, w http.ResponseWriter,
 	// Note that we don't do any permission checking of the returned URLs.
 	// This is because we know that the user is allowed to read at
 	// least the resolved URL passed into serveExpandId.
-	// If this does not specify "development", then no development
-	// revisions will be chosen, so the single ACL already checked
-	// is sufficient. If it *does* specify "development", then we assume
-	// that the development ACLs are more restrictive than the
-	// non-development ACLs, and given that, we can allow all
-	// the URLs.
-	q := h.Store.EntitiesQuery(baseURL).Select(bson.D{{"_id", 1}, {"promulgated-url", 1}, {"development", 1}, {"supportedseries", 1}})
+	q := h.Store.EntitiesQuery(baseURL).Select(bson.D{{"_id", 1}, {"promulgated-url", 1}, {"supportedseries", 1}})
 	if id.PromulgatedRevision != -1 {
 		q = q.Sort("-series", "-promulgated-revision")
 	} else {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -621,10 +621,6 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read:  []string{params.Everyone, "charmers"},
 		Write: []string{"charmers"},
 	})
-	s.assertGet(c, "development/wordpress/meta/perm", params.PermResponse{
-		Read:  []string{params.Everyone, "charmers"},
-		Write: []string{"charmers"},
-	})
 	e, err := s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.ACLs.Read, gc.DeepEquals, []string{params.Everyone, "charmers"})
@@ -646,11 +642,6 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 				Write: []string{"admin"},
 			},
 		})
-		// The development perms did not mutate.
-		s.assertGet(c, "development/"+u+"/meta/perm", params.PermResponse{
-			Read:  []string{params.Everyone, "charmers"},
-			Write: []string{"charmers"},
-		})
 	}
 	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
@@ -659,25 +650,14 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read:  []string{"bob"},
 		Write: []string{"admin"},
 	})
-	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{
-		Read:  []string{params.Everyone, "charmers"},
-		Write: []string{"charmers"},
-	})
 
-	// Try restoring everyone's read permission on the published charm, and
-	// adding write permissions to bob for the development charm.
+	// Try restoring everyone's read permissions.
 	s.assertPut(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
-	s.assertPut(c, "development/wordpress/meta/perm/write", []string{"bob", "admin"})
 	s.assertGet(c, "wordpress/meta/perm", params.PermResponse{
 		Read:  []string{"bob", params.Everyone},
 		Write: []string{"admin"},
 	})
-	s.assertGet(c, "development/wordpress/meta/perm", params.PermResponse{
-		Read:  []string{params.Everyone, "charmers"},
-		Write: []string{"bob", "admin"},
-	})
 	s.assertGet(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
-	s.assertGet(c, "development/wordpress/meta/perm/read", []string{params.Everyone, "charmers"})
 	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.Public, jc.IsTrue)
@@ -685,37 +665,8 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read:  []string{"bob", params.Everyone},
 		Write: []string{"admin"},
 	})
-	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{
-		Read:  []string{params.Everyone, "charmers"},
-		Write: []string{"bob", "admin"},
-	})
 
-	// Try deleting all development permissions.
-	s.assertPut(c, "development/wordpress/meta/perm/read", []string{})
-	s.assertPut(c, "development/wordpress/meta/perm/write", []string{})
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler:      s.srv,
-		Do:           bakeryDo(nil),
-		URL:          storeURL("development/wordpress/meta/perm"),
-		ExpectStatus: http.StatusUnauthorized,
-		ExpectBody: params.Error{
-			Code:    params.ErrUnauthorized,
-			Message: `unauthorized: access denied for user "bob"`,
-		},
-	})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.Public, jc.IsTrue)
-	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{})
-	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{
-		Read:  []string{"bob", params.Everyone},
-		Write: []string{"admin"},
-	})
-
-	// Try deleting all published permissions.
+	// Try deleting all permissions.
 	s.assertPut(c, "wordpress/meta/perm/read", []string{})
 	s.assertPut(c, "wordpress/meta/perm/write", []string{})
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -734,7 +685,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	c.Assert(e.ACLs, jc.DeepEquals, mongodoc.ACL{})
 	c.Assert(e.ACLs.Read, gc.DeepEquals, []string{})
 
-	// Try setting all published permissions in one request.
+	// Try setting all permissions in one request.
 	s.assertPut(c, "wordpress/meta/perm", params.PermRequest{
 		Read:  []string{"bob"},
 		Write: []string{"admin"},
@@ -747,20 +698,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Write: []string{"admin"},
 	})
 
-	// Try setting all development permissions in one request.
-	s.assertPut(c, "development/wordpress/meta/perm", params.PermRequest{
-		Read:  []string{"who", params.Everyone},
-		Write: []string{"who"},
-	})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.Public, jc.IsFalse)
-	c.Assert(e.DevelopmentACLs, jc.DeepEquals, mongodoc.ACL{
-		Read:  []string{"who", params.Everyone},
-		Write: []string{"who"},
-	})
-
-	// Try only read permissions to published meta/perm endpoint.
+	// Try only read permissions to meta/perm endpoint.
 	var readRequest = struct {
 		Read []string
 	}{Read: []string{"joe"}}
@@ -1370,91 +1308,46 @@ var resolveURLTests = []struct {
 	url:    "wordpress",
 	expect: newResolvedURL("cs:~charmers/trusty/wordpress-25", 25),
 }, {
-	url:    "development/wordpress",
-	expect: newResolvedURL("cs:~charmers/development/trusty/wordpress-25", 25),
-}, {
 	url:    "precise/wordpress",
 	expect: newResolvedURL("cs:~charmers/precise/wordpress-24", 24),
-}, {
-	url:    "development/precise/wordpress",
-	expect: newResolvedURL("cs:~charmers/development/precise/wordpress-24", 24),
 }, {
 	url:    "utopic/bigdata",
 	expect: newResolvedURL("cs:~charmers/utopic/bigdata-10", 10),
 }, {
-	url:    "development/utopic/bigdata",
-	expect: newResolvedURL("cs:~charmers/development/utopic/bigdata-10", 10),
-}, {
 	url:    "~charmers/precise/wordpress",
 	expect: newResolvedURL("cs:~charmers/precise/wordpress-24", -1),
 }, {
-	url:    "~charmers/development/precise/wordpress",
-	expect: newResolvedURL("cs:~charmers/development/precise/wordpress-24", -1),
-}, {
 	url:      "~charmers/precise/wordpress-99",
-	notFound: true,
-}, {
-	url:      "~charmers/development/precise/wordpress-99",
 	notFound: true,
 }, {
 	url:    "~charmers/wordpress",
 	expect: newResolvedURL("cs:~charmers/trusty/wordpress-25", -1),
 }, {
-	url:    "~charmers/development/wordpress",
-	expect: newResolvedURL("cs:~charmers/development/trusty/wordpress-25", -1),
-}, {
 	url:      "~charmers/wordpress-24",
-	notFound: true,
-}, {
-	url:      "~charmers/development/wordpress-24",
 	notFound: true,
 }, {
 	url:    "~bob/wordpress",
 	expect: newResolvedURL("cs:~bob/trusty/wordpress-1", -1),
 }, {
-	url:    "~bob/development/wordpress",
-	expect: newResolvedURL("cs:~bob/development/trusty/wordpress-1", -1),
-}, {
 	url:    "~bob/precise/wordpress",
 	expect: newResolvedURL("cs:~bob/precise/wordpress-2", -1),
-}, {
-	url:    "~bob/development/precise/wordpress",
-	expect: newResolvedURL("cs:~bob/development/precise/wordpress-2", -1),
 }, {
 	url:    "bigdata",
 	expect: newResolvedURL("cs:~charmers/utopic/bigdata-10", 10),
 }, {
-	url:    "development/bigdata",
-	expect: newResolvedURL("cs:~charmers/development/utopic/bigdata-10", 10),
-}, {
 	url:      "wordpress-24",
-	notFound: true,
-}, {
-	url:      "development/wordpress-24",
 	notFound: true,
 }, {
 	url:    "bundlelovin",
 	expect: newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10),
 }, {
-	url:    "development/bundlelovin",
-	expect: newResolvedURL("cs:~charmers/development/bundle/bundlelovin-10", 10),
-}, {
 	url:      "wordpress-26",
-	notFound: true,
-}, {
-	url:      "development/wordpress-26",
 	notFound: true,
 }, {
 	url:      "foo",
 	notFound: true,
 }, {
-	url:      "development/foo",
-	notFound: true,
-}, {
 	url:      "trusty/bigdata",
-	notFound: true,
-}, {
-	url:      "development/trusty/bigdata",
 	notFound: true,
 }, {
 	url:      "~bob/wily/django-47",
@@ -1469,24 +1362,6 @@ var resolveURLTests = []struct {
 	url:      "django",
 	notFound: true,
 }, {
-	url:    "~bob/development/wily/django-47",
-	expect: newResolvedURL("cs:~bob/development/wily/django-47", -1),
-}, {
-	url:    "~bob/development/wily/django",
-	expect: newResolvedURL("cs:~bob/development/wily/django-47", -1),
-}, {
-	url:    "~bob/development/django",
-	expect: newResolvedURL("cs:~bob/development/wily/django-47", -1),
-}, {
-	url:    "development/wily/django-27",
-	expect: newResolvedURL("cs:~bob/development/wily/django-47", 27),
-}, {
-	url:    "development/wily/django",
-	expect: newResolvedURL("cs:~bob/development/wily/django-47", 27),
-}, {
-	url:    "development/django",
-	expect: newResolvedURL("cs:~bob/development/wily/django-47", 27),
-}, {
 	url:      "~bob/trusty/haproxy-0",
 	notFound: true,
 }, {
@@ -1497,27 +1372,6 @@ var resolveURLTests = []struct {
 	notFound: true,
 }, {
 	url:      "haproxy",
-	notFound: true,
-}, {
-	url:    "~bob/development/trusty/haproxy-0",
-	expect: newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1),
-}, {
-	url:    "~bob/development/trusty/haproxy",
-	expect: newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1),
-}, {
-	url:    "~bob/development/haproxy",
-	expect: newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1),
-}, {
-	url:      "~bob/development/trusty/haproxy-1",
-	notFound: true,
-}, {
-	url:      "development/trusty/haproxy-27",
-	notFound: true,
-}, {
-	url:      "development/trusty/haproxy",
-	notFound: true,
-}, {
-	url:      "development/haproxy",
 	notFound: true,
 }, {
 	// V4 SPECIFIC
@@ -1542,8 +1396,6 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/other-2", -1))
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10), true)
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10), true)
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/wily/django-47", 27))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/trusty/haproxy-0", -1))
 	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
 
 	cache := entitycache.New(s.store)
@@ -1582,27 +1434,6 @@ var serveExpandIdTests = []struct {
 		{Id: "cs:~charmers/wily/wordpress-5"},
 	},
 }, {
-	about: "fully qualified development URL",
-	url:   "~charmers/development/trusty/wordpress-47",
-	expect: []params.ExpandedId{
-		// V4 SPECIFIC
-		{Id: "cs:~charmers/utopic/wordpress-42"},
-		{Id: "cs:~charmers/development/trusty/wordpress-48"},
-		{Id: "cs:~charmers/trusty/wordpress-47"},
-		{Id: "cs:~charmers/development/trusty/wordpress-7"},
-		{Id: "cs:~charmers/development/utopic/wordpress-7"},
-		{Id: "cs:~charmers/development/vivid/wordpress-7"},
-		{Id: "cs:~charmers/development/wily/wordpress-7"},
-		{Id: "cs:~charmers/development/trusty/wordpress-6"},
-		{Id: "cs:~charmers/development/utopic/wordpress-6"},
-		{Id: "cs:~charmers/development/vivid/wordpress-6"},
-		{Id: "cs:~charmers/development/wily/wordpress-6"},
-		{Id: "cs:~charmers/trusty/wordpress-5"},
-		{Id: "cs:~charmers/utopic/wordpress-5"},
-		{Id: "cs:~charmers/vivid/wordpress-5"},
-		{Id: "cs:~charmers/wily/wordpress-5"},
-	},
-}, {
 	about: "promulgated URL",
 	url:   "trusty/wordpress-47",
 	expect: []params.ExpandedId{
@@ -1615,37 +1446,9 @@ var serveExpandIdTests = []struct {
 		{Id: "cs:wily/wordpress-49"},
 	},
 }, {
-	about: "development promulgated URL",
-	url:   "development/trusty/wordpress-48",
-	expect: []params.ExpandedId{
-		// V4 SPECIFIC
-		{Id: "cs:utopic/wordpress-42"},
-		{Id: "cs:development/trusty/wordpress-48"},
-		{Id: "cs:trusty/wordpress-47"},
-		{Id: "cs:development/trusty/wordpress-51"},
-		{Id: "cs:development/utopic/wordpress-51"},
-		{Id: "cs:development/vivid/wordpress-51"},
-		{Id: "cs:development/wily/wordpress-51"},
-		{Id: "cs:development/trusty/wordpress-50"},
-		{Id: "cs:development/utopic/wordpress-50"},
-		{Id: "cs:development/vivid/wordpress-50"},
-		{Id: "cs:development/wily/wordpress-50"},
-		{Id: "cs:trusty/wordpress-49"},
-		{Id: "cs:utopic/wordpress-49"},
-		{Id: "cs:vivid/wordpress-49"},
-		{Id: "cs:wily/wordpress-49"},
-	},
-}, {
 	about: "non-promulgated charm",
 	url:   "~bob/precise/builder",
 	expect: []params.ExpandedId{
-		{Id: "cs:~bob/precise/builder-5"},
-	},
-}, {
-	about: "non-promulgated charm with development URL",
-	url:   "~bob/development/precise/builder",
-	expect: []params.ExpandedId{
-		{Id: "cs:~bob/development/precise/builder-6"},
 		{Id: "cs:~bob/precise/builder-5"},
 	},
 }, {
@@ -1683,16 +1486,12 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	// so it is ok to reuse the same charm for all the entities.
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-42", 42))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/development/trusty/wordpress-48", 48))
 	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/development/wordpress-6", 50))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/development/wordpress-7", 51))
 
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/haproxy-1", 1))
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/haproxy-1", 1))
 
 	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/builder-5", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/development/precise/builder-6", -1))
 
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/mongo-0", 0), true)
 	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-0", 0), true)
@@ -3013,438 +2812,6 @@ func (s *APISuite) TestEndpointRequiringBaseEntityWithPromulgatedId(c *gc.C) {
 			Promulgated: false,
 		},
 	})
-}
-
-var publishTests = []struct {
-	about      string
-	db         []*router.ResolvedURL
-	id         string
-	publish    bool
-	expectDB   []*router.ResolvedURL
-	expectBody params.PublishResponse
-}{{
-	about: "publish: one development charm present, fully qualified id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", -1),
-	},
-	id:      "~who/wily/django-42",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-42"),
-	},
-}, {
-	about: "publish: one development charm present, fully qualified id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 47),
-	},
-	id:      "wily/django-47",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", 47),
-	},
-	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/wily/django-42"),
-		PromulgatedId: charm.MustParseURL("wily/django-47"),
-	},
-}, {
-	about: "publish: one development charm present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", -1),
-	},
-	id:      "~who/wily/django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-42"),
-	},
-}, {
-	about: "publish: one development charm present, partial id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 47),
-	},
-	id:      "django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", 47),
-	},
-	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/wily/django-42"),
-		PromulgatedId: charm.MustParseURL("wily/django-47"),
-	},
-}, {
-	about: "publish: one published charm present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-1", -1),
-	},
-	id:      "~who/django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-1", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-1"),
-	},
-}, {
-	about: "publish: one published charm present, fully qualified id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-2", 0),
-	},
-	id:      "wily/django-0",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-2", 0),
-	},
-	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/wily/django-2"),
-		PromulgatedId: charm.MustParseURL("wily/django-0"),
-	},
-}, {
-	about: "publish: multiple development charms present, fully qualified id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
-		newResolvedURL("~who/development/trusty/django-1", -1),
-	},
-	id:      "~who/wily/django-1",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
-		newResolvedURL("~who/development/trusty/django-1", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-1"),
-	},
-}, {
-	about: "publish: multiple development charms present, fully qualified id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 10),
-		newResolvedURL("~who/development/wily/django-43", 11),
-		newResolvedURL("~who/development/wily/django-44", 12),
-		newResolvedURL("~who/development/wily/rails-100", 10),
-	},
-	id:      "wily/django-10",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-42", 10),
-		newResolvedURL("~who/development/wily/django-43", 11),
-		newResolvedURL("~who/development/wily/django-44", 12),
-		newResolvedURL("~who/development/wily/rails-100", 10),
-	},
-	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/wily/django-42"),
-		PromulgatedId: charm.MustParseURL("wily/django-10"),
-	},
-}, {
-	about: "publish: multiple development charms present, fully qualified id, promulgated, last one published",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 10),
-		newResolvedURL("~who/development/wily/django-43", 11),
-		newResolvedURL("~who/development/wily/django-44", 12),
-		newResolvedURL("~who/development/wily/rails-100", 10),
-	},
-	id:      "wily/django-12",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-42", 10),
-		newResolvedURL("~who/development/wily/django-43", 11),
-		newResolvedURL("~who/wily/django-44", 12),
-		newResolvedURL("~who/development/wily/rails-100", 10),
-	},
-	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/wily/django-44"),
-		PromulgatedId: charm.MustParseURL("wily/django-12"),
-	},
-}, {
-	about: "publish: multiple development charms present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/trusty/django-42", -1),
-		newResolvedURL("~who/development/trusty/django-47", -1),
-	},
-	id:      "~who/wily/django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/wily/django-1", -1),
-		newResolvedURL("~who/development/trusty/django-42", -1),
-		newResolvedURL("~who/development/trusty/django-47", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-1"),
-	},
-}, {
-	about: "publish: multiple development charms present, partial id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", 0),
-		newResolvedURL("~who/development/wily/django-1", 1),
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/development/trusty/django-47", 11),
-	},
-	id:      "django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", 0),
-		newResolvedURL("~who/development/wily/django-1", 1),
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
-	},
-	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/trusty/django-47"),
-		PromulgatedId: charm.MustParseURL("trusty/django-11"),
-	},
-}, {
-	about: "publish: multiple published charms present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
-	},
-	id:      "~who/wily/django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/wily/django-2", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/wily/django-2"),
-	},
-}, {
-	about: "publish: multiple published charms present, partial id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
-		newResolvedURL("~who/trusty/django-48", 12),
-		newResolvedURL("~who/development/trusty/django-49", 13),
-	},
-	id:      "django",
-	publish: true,
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
-		newResolvedURL("~who/trusty/django-48", 12),
-		newResolvedURL("~who/trusty/django-49", 13),
-	},
-	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/trusty/django-49"),
-		PromulgatedId: charm.MustParseURL("trusty/django-13"),
-	},
-}, {
-	about: "unpublish: one published charm present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-1", -1),
-	},
-	id: "~who/django",
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-1", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/development/wily/django-1"),
-	},
-}, {
-	about: "unpublish: one published charm present, fully qualified id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-2", 0),
-	},
-	id: "wily/django-0",
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-2", 0),
-	},
-	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/development/wily/django-2"),
-		PromulgatedId: charm.MustParseURL("development/wily/django-0"),
-	},
-}, {
-	about: "unpublish: multiple published charms present, partial id, not promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
-	},
-	id: "~who/wily/django",
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/wily/django-0", -1),
-		newResolvedURL("~who/development/wily/django-1", -1),
-		newResolvedURL("~who/development/wily/django-2", -1),
-	},
-	expectBody: params.PublishResponse{
-		Id: charm.MustParseURL("~who/development/wily/django-0"),
-	},
-}, {
-	about: "unpublish: multiple published charms present, partial id, promulgated",
-	db: []*router.ResolvedURL{
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
-		newResolvedURL("~who/trusty/django-48", 12),
-		newResolvedURL("~who/development/trusty/django-49", 13),
-	},
-	id: "django",
-	expectDB: []*router.ResolvedURL{
-		newResolvedURL("~who/development/trusty/django-42", 10),
-		newResolvedURL("~who/trusty/django-47", 11),
-		newResolvedURL("~who/development/trusty/django-48", 12),
-		newResolvedURL("~who/development/trusty/django-49", 13),
-	},
-	expectBody: params.PublishResponse{
-		Id:            charm.MustParseURL("~who/development/trusty/django-48"),
-		PromulgatedId: charm.MustParseURL("development/trusty/django-12"),
-	},
-}}
-
-func (s *APISuite) TestPublish(c *gc.C) {
-	for i, test := range publishTests {
-		c.Logf("test %d: %s", i, test.about)
-
-		// Add the initial entities to the database.
-		for _, rurl := range test.db {
-			s.addPublicCharm(c, "wordpress", rurl)
-		}
-
-		// Build the proper request body.
-		body := mustMarshalJSON(params.PublishRequest{
-			Published: test.publish,
-		})
-
-		// Check that the request/response process works as expected.
-		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-			Handler:      s.srv,
-			URL:          storeURL(test.id + "/publish"),
-			Method:       "PUT",
-			Header:       http.Header{"Content-Type": {"application/json"}},
-			Username:     testUsername,
-			Password:     testPassword,
-			Body:         strings.NewReader(body),
-			ExpectStatus: http.StatusOK,
-			ExpectBody:   test.expectBody,
-		})
-
-		// Check that the database now includes the expected entities.
-		for _, rurl := range test.expectDB {
-			e, err := s.store.FindEntity(rurl, nil)
-			c.Assert(err, gc.IsNil)
-			c.Assert(charmstore.EntityResolvedURL(e), jc.DeepEquals, rurl)
-		}
-
-		// Remove all entities from the database.
-		_, err := s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
-		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
-	}
-}
-
-var publishErrorsTests = []struct {
-	about        string
-	method       string
-	id           string
-	contentType  string
-	body         string
-	expectStatus int
-	expectBody   params.Error
-}{{
-	about:        "get method not allowed",
-	method:       "GET",
-	id:           "~who/wily/django-42",
-	expectStatus: http.StatusMethodNotAllowed,
-	expectBody: params.Error{
-		Code:    params.ErrMethodNotAllowed,
-		Message: "GET not allowed",
-	},
-}, {
-	about:        "post method not allowed",
-	method:       "POST",
-	id:           "~who/wily/django-42",
-	expectStatus: http.StatusMethodNotAllowed,
-	expectBody: params.Error{
-		Code:    params.ErrMethodNotAllowed,
-		Message: "POST not allowed",
-	},
-}, {
-	about:        "invalid channel",
-	method:       "PUT",
-	id:           "~who/development/wily/django-42",
-	expectStatus: http.StatusForbidden,
-	expectBody: params.Error{
-		Code:    params.ErrForbidden,
-		Message: `can only set publish on published URL, "cs:~who/development/wily/django-42" provided`,
-	},
-}, {
-	about:        "unexpected content type",
-	method:       "PUT",
-	id:           "~who/wily/django-42",
-	contentType:  "text/invalid",
-	expectStatus: http.StatusBadRequest,
-	expectBody: params.Error{
-		Code:    params.ErrBadRequest,
-		Message: `cannot unmarshal publish request body: cannot unmarshal into field: unexpected content type text/invalid; want application/json; content: "{\"Published\":true}"`,
-	},
-}, {
-	about:        "invalid body",
-	method:       "PUT",
-	id:           "~who/wily/django-42",
-	body:         "bad wolf",
-	expectStatus: http.StatusBadRequest,
-	expectBody: params.Error{
-		Code:    params.ErrBadRequest,
-		Message: "cannot unmarshal publish request body: cannot unmarshal into field: cannot unmarshal request body: invalid character 'b' looking for beginning of value",
-	},
-}, {
-	about:        "entity to be published not found",
-	method:       "PUT",
-	id:           "~who/wily/django-42",
-	expectStatus: http.StatusNotFound,
-	expectBody: params.Error{
-		Code:    params.ErrNotFound,
-		Message: `no matching charm or bundle for "cs:~who/development/wily/django-42"`,
-	},
-}, {
-	about:  "entity to be unpublished not found",
-	method: "PUT",
-	id:     "~who/wily/django-42",
-	body: mustMarshalJSON(params.PublishRequest{
-		Published: false,
-	}),
-	expectStatus: http.StatusNotFound,
-	expectBody: params.Error{
-		Code:    params.ErrNotFound,
-		Message: `no matching charm or bundle for "cs:~who/wily/django-42"`,
-	},
-}}
-
-func (s *APISuite) TestPublishErrors(c *gc.C) {
-	for i, test := range publishErrorsTests {
-		c.Logf("test %d: %s", i, test.about)
-		contentType := test.contentType
-		if contentType == "" {
-			contentType = "application/json"
-		}
-		body := test.body
-		if body == "" {
-			body = mustMarshalJSON(params.PublishRequest{
-				Published: true,
-			})
-		}
-		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-			Handler:      s.srv,
-			URL:          storeURL(test.id + "/publish"),
-			Method:       test.method,
-			Header:       http.Header{"Content-Type": {contentType}},
-			Username:     testUsername,
-			Password:     testPassword,
-			Body:         strings.NewReader(body),
-			ExpectStatus: test.expectStatus,
-			ExpectBody:   test.expectBody,
-		})
-	}
 }
 
 func (s *APISuite) TestTooManyConcurrentRequests(c *gc.C) {

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -77,51 +77,6 @@ func (s *ArchiveSuite) TestGet(c *gc.C) {
 	c.Assert(rec.Header().Get(params.ContentHashHeader), gc.Equals, hashOfBytes(archiveBytes))
 	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/precise/wordpress-0")
 	assertCacheControl(c, rec.Header(), true)
-
-	// The development version of the entity can also be retrieved.
-	err = s.store.SetPerms(id.URL.WithChannel(charm.DevelopmentChannel), "read", params.Everyone, id.URL.User)
-	c.Assert(err, gc.IsNil)
-	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     storeURL("~charmers/development/precise/wordpress-0/archive"),
-	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
-	c.Assert(rec.Header().Get(params.ContentHashHeader), gc.Equals, hashOfBytes(archiveBytes))
-	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/development/precise/wordpress-0")
-}
-
-func (s *ArchiveSuite) TestGetDevelopment(c *gc.C) {
-	id := newResolvedURL("cs:~charmers/development/trusty/wordpress-0", -1)
-	wordpress := s.assertUploadCharm(c, "POST", id, "wordpress")
-	url := id.PreferredURL()
-	err := s.store.SetPerms(url, "read", params.Everyone, id.URL.User)
-	c.Assert(err, gc.IsNil)
-
-	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
-	c.Assert(err, gc.IsNil)
-
-	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     storeURL("~charmers/development/trusty/wordpress-0/archive"),
-	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
-	c.Assert(rec.Header().Get(params.ContentHashHeader), gc.Equals, hashOfBytes(archiveBytes))
-	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/development/trusty/wordpress-0")
-
-	// It is not possible to use the published URL to retrieve the archive,
-	err = s.store.SetPerms(url.WithChannel(""), "read", params.Everyone, id.URL.User)
-	c.Assert(err, gc.IsNil)
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler:      s.srv,
-		URL:          storeURL("~charmers/trusty/wordpress-0/archive"),
-		ExpectStatus: http.StatusNotFound,
-		ExpectBody: params.Error{
-			Code:    params.ErrNotFound,
-			Message: `no matching charm or bundle for "cs:~charmers/trusty/wordpress-0"`,
-		},
-	})
 }
 
 func (s *ArchiveSuite) TestGetWithPartialId(c *gc.C) {
@@ -463,10 +418,7 @@ func (s *ArchiveSuite) TestPostCharm(c *gc.C) {
 	// Subsequent charm uploads should increment the revision by 1.
 	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-1", -1), "mysql")
 
-	// Subsequent development charm uploads should increment the revision by 1.
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/precise/wordpress-2", -1), "wordpress")
-
-	// Retrieving the published version returns the last non-development charm.
+	// Retrieving the published version returns the latest charm.
 	err := s.store.SetPerms(charm.MustParseURL("~charmers/wordpress"), "read", params.Everyone)
 	c.Assert(err, gc.IsNil)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -478,115 +430,15 @@ func (s *ArchiveSuite) TestPostCharm(c *gc.C) {
 }
 
 func (s *ArchiveSuite) TestPostCurrentVersion(c *gc.C) {
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/precise/wordpress-0", -1), "wordpress")
+	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress")
 
 	// Subsequent charm uploads should not increment the revision by 1.
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/precise/wordpress-0", -1), "wordpress")
-}
-
-func (s *ArchiveSuite) TestPostDevelopmentPromulgated(c *gc.C) {
-	s.assertUploadCharm(c, "PUT", newResolvedURL("~charmers/development/trusty/wordpress-0", 0), "wordpress")
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/trusty/wordpress-1", 1), "mysql")
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/trusty/wordpress-1", 1), "mysql")
-
-	// The promulgated charm can be accessed via its development URL.
-	err := s.store.SetPerms(charm.MustParseURL("~charmers/development/wordpress"), "read", params.Everyone)
-	c.Assert(err, gc.IsNil)
-	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     storeURL("development/wordpress/archive"),
-	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:development/trusty/wordpress-1")
-
-	// The promulgated charm cannot be retrieved using the published URL.
-	err = s.store.SetPerms(charm.MustParseURL("~charmers/wordpress"), "read", params.Everyone)
-	c.Assert(err, gc.IsNil)
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler:      s.srv,
-		URL:          storeURL("wordpress/archive"),
-		ExpectStatus: http.StatusNotFound,
-		ExpectBody: params.Error{
-			Code:    params.ErrNotFound,
-			Message: `no matching charm or bundle for "cs:wordpress"`,
-		},
-	})
-}
-
-var uploadAndPublishTests = []struct {
-	about             string
-	existing          string
-	upload            string
-	expectId          string
-	expectDevelopment bool
-}{{
-	about:             "upload same development entity",
-	existing:          "~who/development/django-0",
-	upload:            "~who/development/django",
-	expectId:          "~who/development/django-0",
-	expectDevelopment: true,
-}, {
-	about:    "upload same published entity",
-	existing: "~who/django-0",
-	upload:   "~who/django",
-	expectId: "~who/django-0",
-}, {
-	about:    "existing development, upload published",
-	existing: "~who/development/django-0",
-	upload:   "~who/django",
-	expectId: "~who/django-0",
-}, {
-	about:    "existing published, upload development",
-	existing: "~who/django-0",
-	upload:   "~who/development/django",
-	expectId: "~who/development/django-0",
-}}
-
-func (s *ArchiveSuite) TestUploadAndPublish(c *gc.C) {
-	for i, test := range uploadAndPublishTests {
-		c.Logf("%d. %s", i, test.about)
-
-		// Upload the pre-existing entity.
-		rurl := newResolvedURL(test.existing, -1)
-		s.assertUploadCharm(c, "POST", rurl, "multi-series")
-
-		// Upload the same charm again, using the upload URL.
-		body, hash, size := archiveInfo(c, "multi-series")
-		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-			Handler:       s.srv,
-			URL:           storeURL(test.upload + "/archive?hash=" + hash),
-			Method:        "POST",
-			ContentLength: size,
-			Header:        http.Header{"Content-Type": {"application/zip"}},
-			Body:          body,
-			Username:      testUsername,
-			Password:      testPassword,
-			ExpectBody: params.ArchiveUploadResponse{
-				Id: charm.MustParseURL(test.expectId),
-			},
-		})
-
-		// Check the development flag of the entity.
-		entity, err := s.store.FindEntity(rurl, charmstore.FieldSelector("development"))
-		c.Assert(err, gc.IsNil)
-		c.Assert(entity.Development, gc.Equals, test.expectDevelopment)
-
-		// Remove all entities from the store.
-		_, err = s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
-		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
-	}
+	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress")
 }
 
 func (s *ArchiveSuite) TestPostMultiSeriesCharm(c *gc.C) {
 	// A charm that did not exist before should get revision 0.
 	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/juju-gui-0", -1), "multi-series")
-}
-
-func (s *ArchiveSuite) TestPostMultiSeriesDevelopmentCharm(c *gc.C) {
-	// A charm that did not exist before should get revision 0.
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/development/juju-gui-0", -1), "multi-series")
 }
 
 func (s *ArchiveSuite) TestPostMultiSeriesCharmRevisionAfterAllSingleSeriesOnes(c *gc.C) {
@@ -1107,7 +959,7 @@ func (s *ArchiveSuite) assertUpload(c *gc.C, method string, url *router.Resolved
 	c.Assert(entity.PreV5BlobSize, gc.Not(gc.Equals), int64(0))
 
 	c.Assert(entity.PromulgatedURL, gc.DeepEquals, url.DocPromulgatedURL())
-	c.Assert(entity.Development, gc.Equals, url.Development)
+	c.Assert(entity.Development, gc.Equals, false)
 
 	return expectId, entity.PreV5BlobSize
 }

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -199,8 +199,6 @@ func (s *commonSuite) addPublicCharm(c *gc.C, charmName string, rurl *router.Res
 func (s *commonSuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	err := s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
 	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
 }
 
 func (s *commonSuite) addPublicBundle(c *gc.C, bundleName string, rurl *router.ResolvedURL, addRequiredCharms bool) (*router.ResolvedURL, charm.Bundle) {
@@ -223,9 +221,6 @@ func (s *commonSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
 		c.Assert(err, gc.IsNil, gc.Commentf("id %q", id))
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)
-		if url.Development {
-			err = s.store.SetPerms(url.UserOwnedURL(), "read", params.Everyone, url.URL.User)
-		}
 	}
 }
 

--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -32,7 +32,6 @@ func (h ReqHandler) metaCharmRelated(entity *mongodoc.Entity, id *router.Resolve
 	fields := bson.D{
 		{"_id", 1},
 		{"supportedseries", 1},
-		{"development", 1},
 		{"charmrequiredinterfaces", 1},
 		{"charmprovidedinterfaces", 1},
 		{"promulgated-url", 1},

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -57,10 +57,6 @@ var metaCharmRelatedCharms = map[string]charm.Charm{
 	"48 ~charmers/precise/haproxy-48": storetesting.NewCharm(storetesting.RelationMeta(
 		"requires reverseproxy http",
 	)),
-	// development charms should not be included in any results.
-	"49 ~charmers/development/precise/haproxy-49": storetesting.NewCharm(storetesting.RelationMeta(
-		"requires reverseproxy http",
-	)),
 	"1 ~charmers/multi-series-20": storetesting.NewCharm(
 		storetesting.MetaWithSupportedSeries(storetesting.RelationMeta(
 			"requires reverseproxy http",
@@ -687,6 +683,5 @@ func mustParseResolvedURL(urlStr string) *router.ResolvedURL {
 	return &router.ResolvedURL{
 		URL:                 *url.WithChannel(""),
 		PromulgatedRevision: promRev,
-		Development:         url.Channel == charm.DevelopmentChannel,
 	}
 }

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -319,11 +319,8 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("wordpress"))
 		c.Assert(err, gc.IsNil)
 
-		// Change the ACLs for the testing charm
-		// (both published and development versions).
+		// Change the ACLs for the testing charm.
 		err = s.store.SetPerms(&rurl.URL, "read", test.readPerm...)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "read", test.readPerm...)
 		c.Assert(err, gc.IsNil)
 
 		// Define an helper function used to send requests and check responses.
@@ -346,25 +343,12 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		makeRequest("~charmers/wordpress/meta/archive-size", test.expectStatus, test.expectBody)
 		makeRequest("~charmers/wordpress/expand-id", test.expectStatus, test.expectBody)
 
-		// Perform meta and id requests to the development channel.
-		makeRequest("~charmers/development/wordpress/meta/archive-size", test.expectStatus, test.expectBody)
-		makeRequest("~charmers/development/wordpress/expand-id", test.expectStatus, test.expectBody)
-
 		// Remove permissions for the published charm.
 		err = s.store.SetPerms(&rurl.URL, "read")
 		c.Assert(err, gc.IsNil)
 
-		// Check that now accessing the published charm is not allowed,
-		// but accessing the development charm still works as expected.
+		// Check that now accessing the published charm is not allowed.
 		makeRequest("~charmers/wordpress/meta/archive-size", http.StatusUnauthorized, nil)
-		makeRequest("~charmers/development/wordpress/meta/archive-size", test.expectStatus, test.expectBody)
-
-		// Remove permissions for the development charm as well.
-		err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "read")
-		c.Assert(err, gc.IsNil)
-
-		// Check that now accessing the development charm is also denied.
-		makeRequest("~charmers/development/wordpress/meta/archive-size", http.StatusUnauthorized, nil)
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
@@ -468,10 +452,7 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 
 		// Change the ACLs for the testing charm.
-		// (both published and development versions).
 		err = s.store.SetPerms(&rurl.URL, "write", test.writePerm...)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "write", test.writePerm...)
 		c.Assert(err, gc.IsNil)
 
 		makeRequest := func(path string, expectStatus int, expectBody interface{}) {
@@ -493,25 +474,15 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 			}
 		}
 
-		// Perform a meta PUT request to the published and development URLs.
+		// Perform a meta PUT request to the URLs.
 		makeRequest("~charmers/wordpress/meta/extra-info/key", test.expectStatus, test.expectBody)
-		makeRequest("~charmers/development/wordpress/meta/extra-info/key", test.expectStatus, test.expectBody)
 
-		// Remove permissions to write on the published entity.
+		// Remove permissions to write on the entity.
 		err = s.store.SetPerms(&rurl.URL, "write")
 		c.Assert(err, gc.IsNil)
 
-		// Check that now writing to the published charm is not allowed,
-		// but accessing the development charm still works as expected.
+		// Check that now writing to the charm is not allowed.
 		makeRequest("~charmers/wordpress/meta/extra-info/key", http.StatusUnauthorized, nil)
-		makeRequest("~charmers/development/wordpress/meta/extra-info/key", test.expectStatus, test.expectBody)
-
-		// Remove write permissions for the development charm as well.
-		err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "write")
-		c.Assert(err, gc.IsNil)
-
-		// Check that now modifying the development charm is also denied.
-		makeRequest("~charmers/development/wordpress/meta/extra-info/key", http.StatusUnauthorized, nil)
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
@@ -533,10 +504,6 @@ var uploadEntityAuthorizationTests = []struct {
 	// promulgated holds whether the corresponding promulgated entity must be
 	// already present in the charm store before performing the upload.
 	promulgated bool
-	// developmentWriteAcls can be used to set customized write ACLs for the
-	// development entity before performing the upload. If empty, default ACLs
-	// are used.
-	developmentWriteAcls []string
 	// writeAcls can be used to set customized write ACLs for the published
 	// entity before performing the upload. If empty, default ACLs are used.
 	writeAcls []string
@@ -551,19 +518,10 @@ var uploadEntityAuthorizationTests = []struct {
 	username: "who",
 	id:       "~who/utopic/django",
 }, {
-	about:    "user owned development entity",
-	username: "who",
-	id:       "~who/development/utopic/django",
-}, {
 	about:    "group owned entity",
 	username: "dalek",
 	groups:   []string{"group1", "group2"},
 	id:       "~group1/utopic/django",
-}, {
-	about:    "group owned development entity",
-	username: "dalek",
-	groups:   []string{"group1", "group2"},
-	id:       "~group1/development/utopic/django",
 }, {
 	about:    "specific group",
 	username: "dalek",
@@ -576,27 +534,10 @@ var uploadEntityAuthorizationTests = []struct {
 	id:          "~charmers/utopic/django",
 	promulgated: true,
 }, {
-	about:       "promulgated entity in development",
-	username:    "sisko",
-	groups:      []string{"group1", "charmers"},
-	id:          "~charmers/development/utopic/django",
-	promulgated: true,
-}, {
 	about:        "unauthorized: promulgated entity",
 	username:     "sisko",
 	groups:       []string{"group1", "group2"},
 	id:           "~charmers/utopic/django",
-	promulgated:  true,
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "sisko"`,
-	},
-}, {
-	about:        "unauthorized: promulgated entity in development",
-	username:     "sisko",
-	groups:       []string{"group1", "group2"},
-	id:           "~charmers/development/utopic/django",
 	promulgated:  true,
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -612,25 +553,8 @@ var uploadEntityAuthorizationTests = []struct {
 		Message: "unauthorized: no username declared",
 	},
 }, {
-	about:        "unauthorized: anonymous user, development entity",
-	id:           "~who/development/utopic/django",
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: "unauthorized: no username declared",
-	},
-}, {
 	about:        "unauthorized: anonymous user and promulgated entity",
 	id:           "~charmers/utopic/django",
-	promulgated:  true,
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: "unauthorized: no username declared",
-	},
-}, {
-	about:        "unauthorized: anonymous user and promulgated entity in development",
-	id:           "~charmers/development/utopic/django",
 	promulgated:  true,
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -647,29 +571,10 @@ var uploadEntityAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:        "unauthorized: user does not match for a development entity",
-	username:     "kirk",
-	id:           "~picard/development/utopic/django",
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
-	},
-}, {
 	about:        "unauthorized: group does not match",
 	username:     "kirk",
 	groups:       []string{"group1", "group2", "group3"},
 	id:           "~group0/utopic/django",
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
-	},
-}, {
-	about:        "unauthorized: group does not match for a development entity",
-	username:     "kirk",
-	groups:       []string{"group1", "group2", "group3"},
-	id:           "~group0/development/utopic/django",
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
@@ -687,28 +592,7 @@ var uploadEntityAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "janeway"`,
 	},
 }, {
-	about:        "unauthorized: specific group and promulgated entity in development",
-	username:     "janeway",
-	groups:       []string{"group1"},
-	id:           "~charmers/development/utopic/django",
-	promulgated:  true,
-	expectStatus: http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "janeway"`,
-	},
-}, {
-	about:                "unauthorized: published entity no development permissions",
-	username:             "picard",
-	id:                   "~picard/wily/django",
-	developmentWriteAcls: []string{"group2"},
-	expectStatus:         http.StatusUnauthorized,
-	expectBody: params.Error{
-		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "picard"`,
-	},
-}, {
-	about:        "unauthorized: published entity no published permissions",
+	about:        "unauthorized: entity no permissions",
 	username:     "picard",
 	id:           "~picard/wily/django",
 	writeAcls:    []string{"kirk"},
@@ -735,7 +619,7 @@ func (s *authSuite) TestUploadEntityAuthorization(c *gc.C) {
 		}
 
 		// Add a pre-existing entity if required.
-		if test.promulgated || len(test.developmentWriteAcls) != 0 || len(test.writeAcls) != 0 {
+		if test.promulgated || len(test.writeAcls) != 0 {
 			id := charm.MustParseURL(test.id).WithRevision(0)
 			revision := -1
 			if test.promulgated {
@@ -743,9 +627,6 @@ func (s *authSuite) TestUploadEntityAuthorization(c *gc.C) {
 			}
 			rurl := newResolvedURL(id.String(), revision)
 			s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-			if len(test.developmentWriteAcls) != 0 {
-				s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "write", test.developmentWriteAcls...)
-			}
 			if len(test.writeAcls) != 0 {
 				s.store.SetPerms(&rurl.URL, "write", test.writeAcls...)
 			}

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -220,8 +220,6 @@ func (s *commonSuite) addPublicCharm(c *gc.C, charmName string, rurl *router.Res
 func (s *commonSuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	err := s.store.SetPerms(&rurl.URL, "read", params.Everyone, rurl.URL.User)
 	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(rurl.URL.WithChannel(charm.DevelopmentChannel), "read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
 }
 
 func (s *commonSuite) addPublicBundle(c *gc.C, bundleName string, rurl *router.ResolvedURL, addRequiredCharms bool) (*router.ResolvedURL, charm.Bundle) {
@@ -244,9 +242,6 @@ func (s *commonSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
 		c.Assert(err, gc.IsNil, gc.Commentf("id %q", id))
 		err = s.store.SetPerms(&url.URL, "read", params.Everyone, url.URL.User)
 		c.Assert(err, gc.IsNil)
-		if url.Development {
-			err = s.store.SetPerms(url.UserOwnedURL(), "read", params.Everyone, url.URL.User)
-		}
 	}
 }
 

--- a/internal/v5/relations.go
+++ b/internal/v5/relations.go
@@ -34,7 +34,6 @@ func (h *ReqHandler) metaCharmRelated(entity *mongodoc.Entity, id *router.Resolv
 	fields := bson.D{
 		{"_id", 1},
 		{"supportedseries", 1},
-		{"development", 1},
 		{"charmrequiredinterfaces", 1},
 		{"charmprovidedinterfaces", 1},
 		{"promulgated-url", 1},

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -57,10 +57,6 @@ var metaCharmRelatedCharms = map[string]charm.Charm{
 	"48 ~charmers/precise/haproxy-48": storetesting.NewCharm(storetesting.RelationMeta(
 		"requires reverseproxy http",
 	)),
-	// development charms should not be included in any results.
-	"49 ~charmers/development/precise/haproxy-49": storetesting.NewCharm(storetesting.RelationMeta(
-		"requires reverseproxy http",
-	)),
 	"1 ~charmers/multi-series-20": storetesting.NewCharm(
 		storetesting.MetaWithSupportedSeries(storetesting.RelationMeta(
 			"requires reverseproxy http",
@@ -716,6 +712,5 @@ func mustParseResolvedURL(urlStr string) *router.ResolvedURL {
 	return &router.ResolvedURL{
 		URL:                 *url.WithChannel(""),
 		PromulgatedRevision: promRev,
-		Development:         url.Channel == charm.DevelopmentChannel,
 	}
 }


### PR DESCRIPTION
There are some references that have been kept to ensure that if a
development URL was used with the charmstore, it could not cause a
violation of invariants in the database.
