### PR TITLE
internal/router: remove development channel remnants

### DIFF
--- a/internal/charmstore/addentity.go
+++ b/internal/charmstore/addentity.go
@@ -415,7 +415,7 @@ func (s *Store) addCharm(c charm.Charm, p addParams) (err error) {
 	logger.Infof("add charm url %s; promulgated rev %d", &id, p.url.PromulgatedRevision)
 	entity := &mongodoc.Entity{
 		URL:                     &id,
-		PromulgatedURL:          p.url.DocPromulgatedURL(),
+		PromulgatedURL:          p.url.PromulgatedURL(),
 		BlobHash:                p.blobHash,
 		BlobHash256:             p.blobHash256,
 		BlobName:                p.blobName,
@@ -481,7 +481,7 @@ func (s *Store) addBundle(b charm.Bundle, p addParams) error {
 		BundleMachineCount: newInt(bundleMachineCount(bundleData)),
 		BundleReadMe:       b.ReadMe(),
 		BundleCharms:       urls,
-		PromulgatedURL:     p.url.DocPromulgatedURL(),
+		PromulgatedURL:     p.url.PromulgatedURL(),
 	}
 	denormalizeEntity(entity)
 

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -397,7 +397,7 @@ func (s *AddEntitySuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool, ur
 		exists, err := store.ES.HasDocument(s.TestIndex, typeName, id)
 		c.Assert(err, gc.IsNil)
 		c.Assert(exists, gc.Equals, true)
-		if purl := url.DocPromulgatedURL(); purl != nil {
+		if purl := url.PromulgatedURL(); purl != nil {
 			c.Assert(result.PromulgatedURL, jc.DeepEquals, purl)
 		}
 	}
@@ -423,7 +423,7 @@ func (s *AddEntitySuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool, ur
 		CharmConfig:             ch.Config(),
 		CharmProvidedInterfaces: []string{"http", "logging", "monitoring"},
 		CharmRequiredInterfaces: []string{"mysql", "varnish"},
-		PromulgatedURL:          url.DocPromulgatedURL(),
+		PromulgatedURL:          url.PromulgatedURL(),
 		SupportedSeries:         ch.Meta().Series,
 	}))
 
@@ -458,7 +458,6 @@ func (s *AddEntitySuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bo
 	}
 	store := s.newStore(c, true)
 	defer store.Close()
-
 	// Add the bundle to the store.
 	beforeAdding := time.Now()
 	s.addRequiredCharms(c, bundle)
@@ -507,7 +506,7 @@ func (s *AddEntitySuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bo
 		},
 		BundleMachineCount: newInt(2),
 		BundleUnitCount:    newInt(2),
-		PromulgatedURL:     url.DocPromulgatedURL(),
+		PromulgatedURL:     url.PromulgatedURL(),
 	}))
 
 	// The bundle archive has been properly added to the blob store.
@@ -528,7 +527,7 @@ func (s *AddEntitySuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bo
 	// Try inserting the bundle again - it should fail because the bundle is
 	// already there.
 	err = store.AddBundleWithArchive(url, bundle)
-	c.Assert(errgo.Cause(err), gc.Equals, params.ErrDuplicateUpload)
+	c.Assert(errgo.Cause(err), gc.Equals, params.ErrDuplicateUpload, gc.Commentf("error: %v", err))
 }
 
 // assertBlobFields asserts that the blob-related fields in doc are as expected.

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -287,7 +287,7 @@ func (s *StoreSuite) TestFindEntities(c *gc.C) {
 		for i, url := range expect {
 			c.Assert(gotEntities[i], jc.DeepEquals, &mongodoc.Entity{
 				URL:            &url.URL,
-				PromulgatedURL: url.DocPromulgatedURL(),
+				PromulgatedURL: url.PromulgatedURL(),
 			}, gc.Commentf("index %d", i))
 		}
 
@@ -2782,7 +2782,7 @@ func (s *StoreSuite) TestPublish(c *gc.C) {
 		entity, err := store.FindEntity(test.url, nil)
 		c.Assert(err, gc.IsNil)
 		c.Assert(entity, jc.DeepEquals, denormalizedEntity(test.expectedEntity))
-		baseEntity, err := store.FindBaseEntity(test.url.UserOwnedURL(), nil)
+		baseEntity, err := store.FindBaseEntity(&test.url.URL, nil)
 		c.Assert(err, gc.IsNil)
 		c.Assert(baseEntity, jc.DeepEquals, storetesting.NormalizeBaseEntity(test.expectedBaseEntity))
 	}

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -155,9 +155,6 @@ func (e *Entity) PreferredURL(usePromulgated bool) *charm.URL {
 	} else {
 		u = *e.URL
 	}
-	if e.Development {
-		u.Channel = charm.DevelopmentChannel
-	}
 	return &u
 }
 
@@ -340,7 +337,6 @@ func BaseURL(url *charm.URL) *charm.URL {
 	newURL := *url
 	newURL.Revision = -1
 	newURL.Series = ""
-	newURL.Channel = ""
 	return &newURL
 }
 

--- a/internal/mongodoc/doc_test.go
+++ b/internal/mongodoc/doc_test.go
@@ -85,15 +85,15 @@ var preferredURLTests = []struct {
 		PromulgatedURL: charm.MustParseURL("trusty/c-2"),
 		Development:    true,
 	},
-	expectURLFalse: "cs:~dmr/development/trusty/c-1",
-	expectURLTrue:  "cs:development/trusty/c-2",
+	expectURLFalse: "cs:~dmr/trusty/c-1",
+	expectURLTrue:  "cs:trusty/c-2",
 }, {
 	entity: &mongodoc.Entity{
 		URL:         charm.MustParseURL("~dmr/trusty/c-1"),
 		Development: true,
 	},
-	expectURLFalse: "cs:~dmr/development/trusty/c-1",
-	expectURLTrue:  "cs:~dmr/development/trusty/c-1",
+	expectURLFalse: "cs:~dmr/trusty/c-1",
+	expectURLTrue:  "cs:~dmr/trusty/c-1",
 }}
 
 func (s *DocSuite) TestPreferredURL(c *gc.C) {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -117,10 +117,10 @@ var routerGetTests = []struct {
 		},
 	},
 	urlStr:       "/development/trusty/wordpress-34/foo",
-	expectStatus: http.StatusOK,
-	expectBody: idHandlerTestResp{
-		Method:   "GET",
-		CharmURL: "cs:development/trusty/wordpress-34",
+	expectStatus: http.StatusNotFound,
+	expectBody: params.Error{
+		Code:    params.ErrNotFound,
+		Message: "not found",
 	},
 }, {
 	about: "id handler with invalid channel",
@@ -147,19 +147,6 @@ var routerGetTests = []struct {
 	expectBody: idHandlerTestResp{
 		Method:   "GET",
 		CharmURL: "cs:win81/visualstudio-2012",
-	},
-}, {
-	about: "windows development id handler",
-	handlers: Handlers{
-		Id: map[string]IdHandler{
-			"foo": testIdHandler,
-		},
-	},
-	urlStr:       "/development/win81/visualstudio-2012/foo",
-	expectStatus: http.StatusOK,
-	expectBody: idHandlerTestResp{
-		Method:   "GET",
-		CharmURL: "cs:development/win81/visualstudio-2012",
 	},
 }, {
 	about: "wily id handler",
@@ -208,10 +195,10 @@ var routerGetTests = []struct {
 		},
 	},
 	urlStr:       "/development/wordpress/foo",
-	expectStatus: http.StatusOK,
-	expectBody: idHandlerTestResp{
-		Method:   "GET",
-		CharmURL: "cs:development/wordpress",
+	expectStatus: http.StatusNotFound,
+	expectBody: params.Error{
+		Code:    params.ErrNotFound,
+		Message: "not found",
 	},
 }, {
 	about: "id handler with extra path",
@@ -301,11 +288,10 @@ var routerGetTests = []struct {
 		},
 	},
 	urlStr:       "/~joe/development/precise/wordpress-34/foo/blah/arble",
-	expectStatus: http.StatusOK,
-	expectBody: idHandlerTestResp{
-		Method:   "GET",
-		CharmURL: "cs:~joe/development/precise/wordpress-34",
-		Path:     "/blah/arble",
+	expectStatus: http.StatusNotFound,
+	expectBody: params.Error{
+		Code:    params.ErrNotFound,
+		Message: "not found",
 	},
 }, {
 	about: "id handler with user, invalid channel and extra path",
@@ -750,7 +736,7 @@ var routerGetTests = []struct {
 	},
 }, {
 	about:  "bulk meta handler, several ids",
-	urlStr: "/meta/foo?id=precise/wordpress-42&id=utopic/foo-32&id=development/django",
+	urlStr: "/meta/foo?id=precise/wordpress-42&id=utopic/foo-32&id=django",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo": testMetaHandler(0),
@@ -765,13 +751,13 @@ var routerGetTests = []struct {
 		"utopic/foo-32": {
 			CharmURL: "cs:utopic/foo-32",
 		},
-		"development/django": {
+		"django": {
 			CharmURL: "cs:precise/django-0",
 		},
 	},
 }, {
 	about:  "bulk meta/any handler, several ids",
-	urlStr: "/meta/any?id=precise/wordpress-42&id=utopic/foo-32&id=development/django-47&include=foo&include=bar/something",
+	urlStr: "/meta/any?id=precise/wordpress-42&id=utopic/foo-32&id=django-47&include=foo&include=bar/something",
 	handlers: Handlers{
 		Meta: map[string]BulkIncludeHandler{
 			"foo":  testMetaHandler(0),
@@ -805,7 +791,7 @@ var routerGetTests = []struct {
 				},
 			},
 		},
-		"development/django-47": {
+		"django-47": {
 			Id: charm.MustParseURL("cs:precise/django-47"),
 			Meta: map[string]interface{}{
 				"foo": metaHandlerTestResp{
@@ -2019,12 +2005,6 @@ var splitIdTests = []struct {
 	path:      "~user/wordpress",
 	expectURL: "cs:~user/wordpress",
 }, {
-	path:      "development/wordpress",
-	expectURL: "cs:development/wordpress",
-}, {
-	path:      "~user/development/wordpress",
-	expectURL: "cs:~user/development/wordpress",
-}, {
 	path:        "",
 	expectError: `URL has invalid charm or bundle name: ""`,
 }, {
@@ -2313,35 +2293,21 @@ func (s *RouterSuite) TestHandlers(c *gc.C) {
 
 var resolvedURLTests = []struct {
 	rurl                 *ResolvedURL
-	expectUserOwnedURL   *charm.URL
 	expectPreferredURL   *charm.URL
 	expectPromulgatedURL *charm.URL
 }{{
 	rurl:                 MustNewResolvedURL("~charmers/precise/wordpress-23", 4),
-	expectUserOwnedURL:   charm.MustParseURL("~charmers/precise/wordpress-23"),
 	expectPreferredURL:   charm.MustParseURL("precise/wordpress-4"),
 	expectPromulgatedURL: charm.MustParseURL("precise/wordpress-4"),
 }, {
-	rurl:               MustNewResolvedURL("~who/development/trusty/wordpress-42", -1),
-	expectUserOwnedURL: charm.MustParseURL("~who/trusty/wordpress-42"),
-	expectPreferredURL: charm.MustParseURL("~who/trusty/wordpress-42"),
-}, {
 	rurl:               MustNewResolvedURL("~charmers/precise/wordpress-23", -1),
-	expectUserOwnedURL: charm.MustParseURL("~charmers/precise/wordpress-23"),
 	expectPreferredURL: charm.MustParseURL("~charmers/precise/wordpress-23"),
 }, {
-	rurl:                 MustNewResolvedURL("~charmers/development/trusty/wordpress-42", 0),
-	expectUserOwnedURL:   charm.MustParseURL("~charmers/trusty/wordpress-42"),
-	expectPreferredURL:   charm.MustParseURL("trusty/wordpress-0"),
-	expectPromulgatedURL: charm.MustParseURL("trusty/wordpress-0"),
-}, {
 	rurl:                 withPreferredSeries(MustNewResolvedURL("~charmers/wordpress-42", 0), "trusty"),
-	expectUserOwnedURL:   charm.MustParseURL("~charmers/wordpress-42"),
 	expectPreferredURL:   charm.MustParseURL("trusty/wordpress-0"),
 	expectPromulgatedURL: charm.MustParseURL("wordpress-0"),
 }, {
 	rurl:               withPreferredSeries(MustNewResolvedURL("~charmers/wordpress-42", -1), "trusty"),
-	expectUserOwnedURL: charm.MustParseURL("~charmers/wordpress-42"),
 	expectPreferredURL: charm.MustParseURL("~charmers/trusty/wordpress-42"),
 }}
 
@@ -2360,9 +2326,7 @@ func (*RouterSuite) TestResolvedURL(c *gc.C) {
 	}
 	for i, test := range resolvedURLTests {
 		c.Logf("test %d: %#v", i, test.rurl)
-		testMethod("UserOwnedURL", test.rurl, test.rurl.UserOwnedURL, test.expectUserOwnedURL)
 		testMethod("PromulgatedURL", test.rurl, test.rurl.PromulgatedURL, test.expectPromulgatedURL)
-
 		testMethod("PreferredURL", test.rurl, test.rurl.PreferredURL, test.expectPreferredURL)
 	}
 }

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -922,7 +922,7 @@ func (s *ArchiveSuite) assertUpload(c *gc.C, method string, url *router.Resolved
 	_, err = f.Seek(0, 0)
 	c.Assert(err, gc.IsNil)
 
-	uploadURL := url.UserOwnedURL()
+	uploadURL := url.URL
 	if method == "POST" {
 		uploadURL.Revision = -1
 	}
@@ -958,7 +958,7 @@ func (s *ArchiveSuite) assertUpload(c *gc.C, method string, url *router.Resolved
 	c.Assert(entity.PreV5BlobHash, gc.Not(gc.Equals), "")
 	c.Assert(entity.PreV5BlobSize, gc.Not(gc.Equals), int64(0))
 
-	c.Assert(entity.PromulgatedURL, gc.DeepEquals, url.DocPromulgatedURL())
+	c.Assert(entity.PromulgatedURL, gc.DeepEquals, url.PromulgatedURL())
 	c.Assert(entity.Development, gc.Equals, false)
 
 	return expectId, entity.PreV5BlobSize

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -505,7 +505,7 @@ func (h *ReqHandler) baseEntityQuery(id *router.ResolvedURL, fields map[string]i
 }
 
 func (h *ReqHandler) entityQuery(id *router.ResolvedURL, selector map[string]int, req *http.Request) (interface{}, error) {
-	val, err := h.Cache.Entity(id.UserOwnedURL(), selector)
+	val, err := h.Cache.Entity(&id.URL, selector)
 	if errgo.Cause(err) == params.ErrNotFound {
 		logger.Infof("entity %#v not found: %#v", id, err)
 		return nil, errgo.WithCausef(nil, params.ErrNotFound, "no matching charm or bundle for %s", id)
@@ -772,7 +772,7 @@ func (h *ReqHandler) metaRevisionInfo(id *router.ResolvedURL, path string, flags
 		if id.PromulgatedRevision != -1 {
 			response.Revisions = append(response.Revisions, rurl.PromulgatedURL())
 		} else {
-			response.Revisions = append(response.Revisions, rurl.UserOwnedURL())
+			response.Revisions = append(response.Revisions, &rurl.URL)
 		}
 	}
 	if err := iter.Err(); err != nil {

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -170,7 +170,7 @@ func (h *ReqHandler) servePostArchive(id *charm.URL, w http.ResponseWriter, req 
 		// The hash matches the hash of the latest revision, so
 		// no need to upload anything.
 		return httprequest.WriteJSON(w, http.StatusOK, &params.ArchiveUploadResponse{
-			Id:            oldURL.UserOwnedURL(),
+			Id:            &oldURL.URL,
 			PromulgatedId: oldURL.PromulgatedURL(),
 		})
 	}
@@ -195,7 +195,7 @@ func (h *ReqHandler) servePostArchive(id *charm.URL, w http.ResponseWriter, req 
 		)
 	}
 	return httprequest.WriteJSON(w, http.StatusOK, &params.ArchiveUploadResponse{
-		Id:            rid.UserOwnedURL(),
+		Id:            &rid.URL,
 		PromulgatedId: rid.PromulgatedURL(),
 	})
 }
@@ -255,7 +255,7 @@ func (h *ReqHandler) servePutArchive(id *charm.URL, w http.ResponseWriter, req *
 		)
 	}
 	return httprequest.WriteJSON(w, http.StatusOK, &params.ArchiveUploadResponse{
-		Id:            rid.UserOwnedURL(),
+		Id:            &rid.URL,
 		PromulgatedId: rid.PromulgatedURL(),
 	})
 	return nil
@@ -353,7 +353,6 @@ func (h *ReqHandler) getNewPromulgatedRevision(id *charm.URL) (int, error) {
 	query := h.Store.EntitiesQuery(&charm.URL{
 		Series:   id.Series,
 		Name:     id.Name,
-		Channel:  id.Channel,
 		Revision: -1,
 	})
 	var entity mongodoc.Entity

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -921,7 +921,7 @@ func (s *commonArchiveSuite) assertUpload(c *gc.C, method string, url *router.Re
 	_, err = f.Seek(0, 0)
 	c.Assert(err, gc.IsNil)
 
-	uploadURL := url.UserOwnedURL()
+	uploadURL := url.URL
 	if method == "POST" {
 		uploadURL.Revision = -1
 	}
@@ -956,7 +956,7 @@ func (s *commonArchiveSuite) assertUpload(c *gc.C, method string, url *router.Re
 	if url.URL.Series != "" {
 		c.Assert(entity.BlobHash256, gc.Equals, hash256Sum)
 	}
-	c.Assert(entity.PromulgatedURL, gc.DeepEquals, url.DocPromulgatedURL())
+	c.Assert(entity.PromulgatedURL, gc.DeepEquals, url.PromulgatedURL())
 	c.Assert(entity.Development, gc.Equals, false)
 	// Test that the expected entry has been created
 	// in the blob store.

--- a/internal/v5/auth.go
+++ b/internal/v5/auth.go
@@ -196,7 +196,7 @@ func (h *ReqHandler) entityAuthInfo(entityIds []*router.ResolvedURL) (public boo
 	requiredTerms = make(map[string]bool)
 	public = true
 	for i, entityId := range entityIds {
-		entity, err := h.Cache.Entity(entityId.UserOwnedURL(), charmstore.FieldSelector("charmmeta"))
+		entity, err := h.Cache.Entity(&entityId.URL, charmstore.FieldSelector("charmmeta"))
 		if err != nil {
 			return false, nil, nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
 		}
@@ -308,14 +308,14 @@ func (h *ReqHandler) AuthorizeEntity(id *router.ResolvedURL, req *http.Request) 
 // then the DevelopmentACLs will be used. If the entity is not published
 // at all then the unpublished ACLs are used.
 func (h *ReqHandler) entityACLs(id *router.ResolvedURL) (mongodoc.ACL, error) {
-	entity, err := h.Cache.Entity(id.UserOwnedURL(), charmstore.FieldSelector("development", "stable"))
+	entity, err := h.Cache.Entity(&id.URL, charmstore.FieldSelector("development", "stable"))
 	if err != nil {
 		if errgo.Cause(err) == params.ErrNotFound {
 			return mongodoc.ACL{}, errgo.WithCausef(nil, params.ErrNotFound, "entity %q not found", id)
 		}
 		return mongodoc.ACL{}, errgo.Notef(err, "cannot retrieve entity %q for authorization", id)
 	}
-	baseEntity, err := h.Cache.BaseEntity(id.UserOwnedURL(), charmstore.FieldSelector("acls", "developmentacls", "stableacls"))
+	baseEntity, err := h.Cache.BaseEntity(&id.URL, charmstore.FieldSelector("acls", "developmentacls", "stableacls"))
 	if err != nil {
 		return mongodoc.ACL{}, errgo.Notef(err, "cannot retrieve base entity %q for authorization", id)
 	}

--- a/internal/v5/content.go
+++ b/internal/v5/content.go
@@ -29,7 +29,7 @@ func (h *ReqHandler) serveDiagram(id *router.ResolvedURL, w http.ResponseWriter,
 	if id.URL.Series != "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "diagrams not supported for charms")
 	}
-	entity, err := h.Cache.Entity(id.UserOwnedURL(), charmstore.FieldSelector("bundledata"))
+	entity, err := h.Cache.Entity(&id.URL, charmstore.FieldSelector("bundledata"))
 	if err != nil {
 		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
@@ -72,7 +72,7 @@ var allowedReadMe = map[string]bool{
 // GET id/readme
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idreadme
 func (h *ReqHandler) serveReadMe(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error {
-	entity, err := h.Cache.Entity(id.UserOwnedURL(), charmstore.FieldSelector("contents", "blobname"))
+	entity, err := h.Cache.Entity(&id.URL, charmstore.FieldSelector("contents", "blobname"))
 	if err != nil {
 		return errgo.NoteMask(err, "cannot get README", errgo.Is(params.ErrNotFound))
 	}
@@ -98,7 +98,7 @@ func (h *ReqHandler) serveIcon(id *router.ResolvedURL, w http.ResponseWriter, re
 	if id.URL.Series == "bundle" {
 		return errgo.WithCausef(nil, params.ErrNotFound, "icons not supported for bundles")
 	}
-	entity, err := h.Cache.Entity(id.UserOwnedURL(), charmstore.FieldSelector("contents", "blobname"))
+	entity, err := h.Cache.Entity(&id.URL, charmstore.FieldSelector("contents", "blobname"))
 	if err != nil {
 		return errgo.NoteMask(err, "cannot get icon", errgo.Is(params.ErrNotFound))
 	}


### PR DESCRIPTION
DocPromulgatedURL and UserOwnedURL are no longer necessary.
The router no longer needs to recognise channels, but it rejects them because
the charm package can still parse them.
