### PR TITLE
internal/v5: resolve URLs based on channel parameter

### DIFF
--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -123,13 +123,13 @@ func (h *Handler) Close() {
 }
 
 func (h *Handler) newReqHandler() (*reqHandler, error) {
-	v4h, err := h.v4.NewReqHandler()
+	v4h, err := h.v4.NewReqHandler(new(http.Request))
 	if err != nil {
 		return nil, errgo.Mask(err, errgo.Is(charmstore.ErrTooManySessions))
 	}
 	rh := reqHandlerPool.Get().(*reqHandler)
 	rh.v4 = v4h
-	rh.store = v4h.Store
+	rh.store = v4h.Store.Store
 	return rh, nil
 }
 

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -26,6 +26,7 @@ import (
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/legacy"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting/stats"
@@ -300,7 +301,7 @@ func (s *APISuite) TestCharmInfoCounters(c *gc.C) {
 
 func (s *APISuite) TestAPIInfoWithGatedCharm(c *gc.C) {
 	wordpressURL, _ := s.addPublicCharm(c, "wordpress", "cs:precise/wordpress-0")
-	s.store.SetPerms(&wordpressURL.URL, "unpublished.read", "bob")
+	s.store.SetPerms(&wordpressURL.URL, "stable.read", "bob")
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          "/charm-info?charms=" + wordpressURL.URL.String(),
@@ -402,9 +403,15 @@ func (s *APISuite) addPublicCharm(c *gc.C, charmName, curl string) (*router.Reso
 	archive := storetesting.Charms.CharmArchive(c.MkDir(), charmName)
 	err := s.store.AddCharmWithArchive(rurl, archive)
 	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "unpublished.read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.setPublic(c, rurl)
 	return rurl, archive
+}
+
+func (s *APISuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
+	err := s.store.SetPerms(&rurl.URL, "stable.read", params.Everyone)
+	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(rurl, mongodoc.StableChannel)
+	c.Assert(err, gc.IsNil)
 }
 
 var serveCharmEventErrorsTests = []struct {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -518,7 +518,7 @@ func (s *APISuite) TestEndpointGet(c *gc.C) {
 func (s *APISuite) TestAllMetaEndpointsTested(c *gc.C) {
 	// Make sure that we're testing all the metadata
 	// endpoints that we need to.
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
 		URL:     storeURL("precise/wordpress-23/meta"),
@@ -563,9 +563,9 @@ var testEntities = []*router.ResolvedURL{
 func (s *APISuite) addTestEntities(c *gc.C) []*router.ResolvedURL {
 	for _, e := range testEntities {
 		if e.URL.Series == "bundle" {
-			s.addPublicBundle(c, e.URL.Name, e, true)
+			s.addPublicBundleFromRepo(c, e.URL.Name, e, true)
 		} else {
-			s.addPublicCharm(c, e.URL.Name, e)
+			s.addPublicCharmFromRepo(c, e.URL.Name, e)
 		}
 		// Associate some extra-info data with the entity.
 		key := e.URL.Path() + "/meta/extra-info/key"
@@ -620,7 +620,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		err := s.store.AddCharmWithArchive(u, storetesting.NewCharm(nil))
 		c.Assert(err, gc.IsNil)
 	}
-	s.assertGet(c, "wordpress/meta/perm", params.PermResponse{
+	s.assertGet(c, "wordpress/meta/perm?channel=unpublished", params.PermResponse{
 		Read:  []string{"charmers"},
 		Write: []string{"charmers"},
 	})
@@ -889,7 +889,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 func (s *APISuite) TestMetaPermPutUnauthorized(c *gc.C) {
 	id := "precise/wordpress-23"
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.noMacaroonSrv,
 		URL:     storeURL("~charmers/" + id + "/meta/perm/read"),
@@ -908,7 +908,7 @@ func (s *APISuite) TestMetaPermPutUnauthorized(c *gc.C) {
 
 func (s *APISuite) TestExtraInfo(c *gc.C) {
 	id := "precise/wordpress-23"
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
 	s.checkInfo(c, "extra-info", id)
 	s.checkInfo(c, "common-info", id)
 }
@@ -1058,7 +1058,7 @@ var extraInfoBadPutRequestsTests = []struct {
 }}
 
 func (s *APISuite) TestExtraInfoBadPutRequests(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
 	path := "precise/wordpress-23/meta/"
 	for i, test := range extraInfoBadPutRequestsTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -1100,7 +1100,7 @@ func (s *APISuite) TestExtraInfoBadPutRequests(c *gc.C) {
 }
 
 func (s *APISuite) TestExtraInfoPutUnauthorized(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,
 		URL:     storeURL("precise/wordpress-23/meta/extra-info"),
@@ -1164,9 +1164,9 @@ func (s *APISuite) TestExtraInfoPutUnauthorized(c *gc.C) {
 }
 
 func (s *APISuite) TestCommonInfo(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-24", 24))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/trusty/wordpress-1", 1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-24", 24))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/trusty/wordpress-1", 1))
 
 	s.assertPut(c, "wordpress/meta/common-info/key", "something")
 
@@ -1232,7 +1232,7 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 }
 
 func (s *APISuite) TestMetaAnyWithNoIncludesAndNoEntity(c *gc.C) {
-	wordpressURL, _ := s.addPublicCharm(
+	wordpressURL, _ := s.addPublicCharmFromRepo(
 		c,
 		"wordpress",
 		newResolvedURL("cs:~charmers/precise/wordpress-23", 23),
@@ -1269,7 +1269,7 @@ func (s *APISuite) TestMetaAnyWithNoIncludesAndNoEntity(c *gc.C) {
 // In this test we rely on the charm.v2 testing repo package and
 // dummy charm that has actions included.
 func (s *APISuite) TestMetaCharmActions(c *gc.C) {
-	url, dummy := s.addPublicCharm(c, "dummy", newResolvedURL("cs:~charmers/precise/dummy-10", 10))
+	url, dummy := s.addPublicCharmFromRepo(c, "dummy", newResolvedURL("cs:~charmers/precise/dummy-10", 10))
 	s.assertGet(c, "precise/dummy-10/meta/charm-actions", dummy.Actions())
 	s.assertGet(c, "precise/dummy-10/meta/any?include=charm-actions",
 		params.MetaAnyResponse{
@@ -1281,8 +1281,9 @@ func (s *APISuite) TestMetaCharmActions(c *gc.C) {
 	)
 }
 
+// V4 SPECIFIC
 func (s *APISuite) TestMetaCharmMetadataElidesSeriesFromMultiSeriesCharm(c *gc.C) {
-	_, ch := s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-10", 10))
+	_, ch := s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-10", 10))
 	expectMeta := *ch.Meta()
 	c.Assert(expectMeta.Series, gc.Not(gc.HasLen), 0)
 	expectMeta.Series = nil
@@ -1294,8 +1295,8 @@ func (s *APISuite) TestBulkMeta(c *gc.C) {
 	// whether the meta/any logic is hooked up correctly.
 	// Detailed tests for this feature are in the router package.
 
-	_, wordpress := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
-	_, mysql := s.addPublicCharm(c, "mysql", newResolvedURL("cs:~charmers/precise/mysql-10", 10))
+	_, wordpress := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	_, mysql := s.addPublicCharmFromRepo(c, "mysql", newResolvedURL("cs:~charmers/precise/mysql-10", 10))
 	s.assertGet(c,
 		"meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10",
 		map[string]*charm.Meta{
@@ -1310,8 +1311,8 @@ func (s *APISuite) TestBulkMetaAny(c *gc.C) {
 	// whether the meta/any logic is hooked up correctly.
 	// Detailed tests for this feature are in the router package.
 
-	wordpressURL, wordpress := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
-	mysqlURL, mysql := s.addPublicCharm(c, "mysql", newResolvedURL("cs:~charmers/precise/mysql-10", 10))
+	wordpressURL, wordpress := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	mysqlURL, mysql := s.addPublicCharmFromRepo(c, "mysql", newResolvedURL("cs:~charmers/precise/mysql-10", 10))
 	s.assertGet(c,
 		"meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10",
 		map[string]params.MetaAnyResponse{
@@ -1359,14 +1360,11 @@ func (s *APISuite) TestMetaCharmTags(c *gc.C) {
 	url := newResolvedURL("~charmers/precise/wordpress-0", -1)
 	for i, test := range metaCharmTagsTests {
 		c.Logf("%d: %s", i, test.about)
-		wordpress := storetesting.Charms.CharmDir("wordpress")
-		meta := wordpress.Meta()
-		meta.Tags, meta.Categories = test.tags, test.categories
 		url.URL.Revision = i
-		err := s.store.AddCharmWithArchive(url, storetesting.NewCharm(meta))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+			Tags:       test.tags,
+			Categories: test.categories,
+		}), url)
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler:      s.srv,
 			URL:          storeURL(url.URL.Path() + "/meta/tags"),
@@ -1380,18 +1378,15 @@ func (s *APISuite) TestPromulgatedMetaCharmTags(c *gc.C) {
 	url := newResolvedURL("~charmers/precise/wordpress-0", 0)
 	for i, test := range metaCharmTagsTests {
 		c.Logf("%d: %s", i, test.about)
-		wordpress := storetesting.Charms.CharmDir("wordpress")
-		meta := wordpress.Meta()
-		meta.Tags, meta.Categories = test.tags, test.categories
 		url.URL.Revision = i
 		url.PromulgatedRevision = i
-		err := s.store.AddCharmWithArchive(url, storetesting.NewCharm(meta))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+			Tags:       test.tags,
+			Categories: test.categories,
+		}), url)
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler:      s.srv,
-			URL:          storeURL(url.PromulgatedURL().Path() + "/meta/tags"),
+			URL:          storeURL(url.URL.Path() + "/meta/tags"),
 			ExpectStatus: http.StatusOK,
 			ExpectBody:   params.TagsResponse{test.expectTags},
 		})
@@ -1399,15 +1394,15 @@ func (s *APISuite) TestPromulgatedMetaCharmTags(c *gc.C) {
 }
 
 func (s *APISuite) TestBundleTags(c *gc.C) {
-	b := storetesting.Charms.BundleDir("wordpress-simple")
-	s.addRequiredCharms(c, b)
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", -1)
-	data := b.Data()
-	data.Tags = []string{"foo", "bar"}
-	err := s.store.AddBundleWithArchive(url, storetesting.NewBundle(data))
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
+		Tags: []string{"foo", "bar"},
+		Services: map[string]*charm.ServiceSpec{
+			"wordpress": {
+				Charm: "wordpress",
+			},
+		},
+	}), url, true)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL(url.URL.Path() + "/meta/tags"),
@@ -1417,18 +1412,18 @@ func (s *APISuite) TestBundleTags(c *gc.C) {
 }
 
 func (s *APISuite) TestPromulgatedBundleTags(c *gc.C) {
-	b := storetesting.Charms.BundleDir("wordpress-simple")
-	s.addRequiredCharms(c, b)
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", 2)
-	data := b.Data()
-	data.Tags = []string{"foo", "bar"}
-	err := s.store.AddBundleWithArchive(url, storetesting.NewBundle(data))
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
+		Tags: []string{"foo", "bar"},
+		Services: map[string]*charm.ServiceSpec{
+			"wordpress": {
+				Charm: "wordpress",
+			},
+		},
+	}), url, true)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
-		URL:          storeURL(url.PromulgatedURL().Path() + "/meta/tags"),
+		URL:          storeURL(url.URL.Path() + "/meta/tags"),
 		ExpectStatus: http.StatusOK,
 		ExpectBody:   params.TagsResponse{[]string{"foo", "bar"}},
 	})
@@ -1448,7 +1443,7 @@ func (s *APISuite) TestIdsAreResolved(c *gc.C) {
 	// passed to the router. Given how Router is
 	// defined, and the ResolveURL tests, this should
 	// be sufficient to "join the dots".
-	_, wordpress := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	_, wordpress := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
 	s.assertGet(c, "wordpress/meta/charm-metadata", wordpress.Meta())
 }
 
@@ -1559,27 +1554,27 @@ var resolveURLTests = []struct {
 }}
 
 func (s *APISuite) TestResolveURL(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-24", 24))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-24", 24))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-25", 25))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-10", 10))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/saucy/bigdata-99", 99))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/bigdata-10", 10))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/trusty/wordpress-1", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/wordpress-2", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/other-2", -1))
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10), true)
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10), true)
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-24", 24))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-24", 24))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-25", 25))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-10", 10))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/saucy/bigdata-99", 99))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/bigdata-10", 10))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~bob/trusty/wordpress-1", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~bob/precise/wordpress-2", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~bob/precise/other-2", -1))
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10), true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10), true)
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
 
-	cache := entitycache.New(v5.ChannelStore{Store: s.store, Channel: mongodoc.UnpublishedChannel})
-	cache.AddEntityFields(map[string]int{"supportedseries": 1})
-	cache.AddEntityFields(v5.RequiredEntityFields)
 	for i, test := range resolveURLTests {
 		c.Logf("test %d: %s", i, test.url)
 		url := charm.MustParseURL(test.url)
-		rurl, err := v4.ResolveURL(cache, url)
+		rurl, err := v4.ResolveURL(entitycache.New(&v5.StoreWithChannel{
+			Store:   s.store,
+			Channel: mongodoc.UnpublishedChannel,
+		}), url)
 		if test.notFound {
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 			c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for ".*"`)
@@ -1659,17 +1654,17 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	// Add a bunch of entities in the database.
 	// Note that expand-id only cares about entity identifiers,
 	// so it is ok to reuse the same charm for all the entities.
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-42", 42))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-42", 42))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/haproxy-1", 1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/haproxy-1", 1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/haproxy-1", 1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/haproxy-1", 1))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/builder-5", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~bob/precise/builder-5", -1))
 
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/mongo-0", 0), true)
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-0", 0), true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/mongo-0", 0), true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-0", 0), true)
 
 	for i, test := range serveExpandIdTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -1829,33 +1824,33 @@ var serveMetaRevisionInfoTests = []struct {
 }}
 
 func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mysql-41", 41))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mysql-42", 42))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mysql-41", 41))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mysql-42", 42))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-9", 9))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-41", 41))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-42", 42))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-43", 43))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-9", 9))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-41", 41))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-42", 42))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-43", 43))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-42", 42))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-42", 42))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-0", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-1", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-2", 0))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-3", 1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~openstack-charmers/trusty/cinder-0", 2))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~openstack-charmers/trusty/cinder-1", 3))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-4", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-5", 4))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-6", 5))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-0", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-1", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-2", 0))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-3", 1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~openstack-charmers/trusty/cinder-0", 2))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~openstack-charmers/trusty/cinder-1", 3))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-4", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-5", 4))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-6", 5))
 
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-1", 40))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-2", 41))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-1", 40))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-2", 41))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-1", 40))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-2", 41))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-3", 42))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-4", 43))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-1", 40))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-2", 41))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/mixed-3", 42))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/mixed-4", 43))
 
 	for i, test := range serveMetaRevisionInfoTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -2125,9 +2120,9 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 
 			// Add the required entities to the database.
 			if url.URL.Series == "bundle" {
-				s.addPublicBundle(c, "wordpress-simple", url, true)
+				s.addPublicBundleFromRepo(c, "wordpress-simple", url, true)
 			} else {
-				s.addPublicCharm(c, "wordpress", url)
+				s.addPublicCharmFromRepo(c, "wordpress", url)
 			}
 
 			// Simulate the entity was downloaded at the specified dates.
@@ -2183,7 +2178,7 @@ var metaStatsWithLegacyDownloadCountsTests = []struct {
 // logic.
 func (s *APISuite) TestMetaStatsWithLegacyDownloadCounts(c *gc.C) {
 	patchLegacyDownloadCountsEnabled(s.AddCleanup, true)
-	id, _ := s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/utopic/wordpress-42", 42))
+	id, _ := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/utopic/wordpress-42", 42))
 	url := storeURL("utopic/wordpress-42/meta/stats")
 
 	for i, test := range metaStatsWithLegacyDownloadCountsTests {
@@ -2390,7 +2385,7 @@ func (s *APISuite) TestChangesPublishedErrors(c *gc.C) {
 // a range of charms with known time stamps.
 func (s *APISuite) publishCharmsAtKnownTimes(c *gc.C, charms []publishSpec) {
 	for _, ch := range publishedCharms {
-		id, _ := s.addPublicCharm(c, "wordpress", ch.id)
+		id, _ := s.addPublicCharmFromRepo(c, "wordpress", ch.id)
 		t := ch.published().PublishTime
 		err := s.store.UpdateEntity(id, bson.D{{"$set", bson.D{{"uploadtime", t}}}})
 		c.Assert(err, gc.IsNil)
@@ -2447,12 +2442,108 @@ func (s *APISuite) TestHash256Laziness(c *gc.C) {
 	// TODO frankban: remove this test after updating entities in the
 	// production db with their SHA256 hash value. Entities are updated by
 	// running the cshash256 command.
-	id, _ := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~who/precise/wordpress-0", -1))
+	id, _ := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~who/precise/wordpress-0", -1))
 
 	// Retrieve the SHA256 hash.
 	entity, err := s.store.FindEntity(id, charmstore.FieldSelector("blobhash256"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(entity.BlobHash256, gc.Not(gc.Equals), "")
+}
+
+var urlChannelResolvingEntities = []struct {
+	id      *router.ResolvedURL
+	channel mongodoc.Channel
+}{{
+	id:      newResolvedURL("~charmers/precise/wordpress-0", 0),
+	channel: mongodoc.StableChannel,
+}, {
+	id:      newResolvedURL("~charmers/precise/wordpress-1", 1),
+	channel: mongodoc.DevelopmentChannel,
+}, {
+	id:      newResolvedURL("~charmers/precise/wordpress-2", 2),
+	channel: mongodoc.UnpublishedChannel,
+}, {
+	id:      newResolvedURL("~charmers/trusty/mysql-0", 0),
+	channel: mongodoc.UnpublishedChannel,
+}}
+
+var urlChannelResolvingTests = []struct {
+	url          string
+	channel      mongodoc.Channel
+	expectURL    string
+	expectStatus int
+	expectError  params.Error
+}{{
+	url:       "wordpress",
+	expectURL: "cs:precise/wordpress-0",
+}, {
+	url:       "wordpress",
+	channel:   mongodoc.StableChannel,
+	expectURL: "cs:precise/wordpress-0",
+}, {
+	url:       "wordpress",
+	channel:   mongodoc.DevelopmentChannel,
+	expectURL: "cs:precise/wordpress-1",
+}, {
+	url:       "wordpress",
+	channel:   mongodoc.UnpublishedChannel,
+	expectURL: "cs:precise/wordpress-2",
+}, {
+	url:       "~charmers/precise/wordpress",
+	channel:   mongodoc.StableChannel,
+	expectURL: "cs:~charmers/precise/wordpress-0",
+}, {
+	url:          "mysql",
+	expectStatus: http.StatusNotFound,
+	expectError: params.Error{
+		Message: `no matching charm or bundle for "cs:mysql"`,
+		Code:    params.ErrNotFound,
+	},
+}, {
+	url:          "mysql",
+	channel:      "unknown",
+	expectStatus: http.StatusBadRequest,
+	expectError: params.Error{
+		Message: `invalid channel "unknown" specified in request`,
+		Code:    params.ErrBadRequest,
+	},
+}}
+
+func (s *APISuite) TestURLChannelResolving(c *gc.C) {
+	s.discharge = dischargeForUser("charmers")
+	for _, add := range urlChannelResolvingEntities {
+		err := s.store.AddCharmWithArchive(add.id, storetesting.NewCharm(nil))
+		c.Assert(err, gc.IsNil)
+		if add.channel != mongodoc.UnpublishedChannel {
+			err = s.store.Publish(add.id, add.channel)
+			c.Assert(err, gc.IsNil)
+		}
+	}
+	for i, test := range urlChannelResolvingTests {
+		path := test.url + "/meta/any"
+		if test.channel != "" {
+			path += "?channel=" + string(test.channel)
+		}
+		c.Logf("test %d: %v", i, test.url)
+		if test.expectError.Message != "" {
+			httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+				Handler:      s.srv,
+				Do:           bakeryDo(nil),
+				URL:          storeURL(path),
+				ExpectStatus: test.expectStatus,
+				ExpectBody:   test.expectError,
+			})
+		} else {
+			httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+				Handler: s.srv,
+				Do:      bakeryDo(nil),
+				URL:     storeURL(path),
+				ExpectBody: params.MetaAnyResponse{
+					Id: charm.MustParseURL(test.expectURL),
+				},
+			})
+		}
+	}
 }
 
 func basicAuthHeader(username, password string) http.Header {
@@ -2944,8 +3035,9 @@ func (s *APISuite) TestPromulgate(c *gc.C) {
 		}
 		s.idM.groups = test.groups
 		p := httptesting.JSONCallParams{
-			Handler:      s.srv,
-			URL:          storeURL(test.id + "/promulgate"),
+			Handler: s.srv,
+			// TODO avoid using channel=unpublished here
+			URL:          storeURL(test.id + "/promulgate?channel=unpublished"),
 			Method:       test.method,
 			Body:         test.body,
 			Header:       http.Header{"Content-Type": {"application/json"}},
@@ -2976,7 +3068,7 @@ func (s *APISuite) TestPromulgate(c *gc.C) {
 func (s *APISuite) TestEndpointRequiringBaseEntityWithPromulgatedId(c *gc.C) {
 	// Add a promulgated charm.
 	url := newResolvedURL("~charmers/precise/wordpress-23", 23)
-	s.addPublicCharm(c, "wordpress", url)
+	s.addPublicCharmFromRepo(c, "wordpress", url)
 
 	// Unpromulgate the base entity
 	err := s.store.SetPromulgated(url, false)
@@ -3118,5 +3210,3 @@ func entityACLs(store *charmstore.Store, url *router.ResolvedURL) (mongodoc.ACL,
 	}
 	return be.ChannelACLs[ch], nil
 }
-
-var _ entitycache.Store = v5.ChannelStore{}

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -43,23 +43,22 @@ type ArchiveSuite struct {
 
 var _ = gc.Suite(&ArchiveSuite{})
 
+func (s *ArchiveSuite) SetUpSuite(c *gc.C) {
+	s.enableIdentity = true
+	s.commonSuite.SetUpSuite(c)
+}
+
 func (s *ArchiveSuite) TestGet(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
-	wordpress := s.assertUploadCharm(c, "POST", id, "wordpress")
-	err := s.store.SetPerms(&id.URL, "unpublished.read", params.Everyone, id.URL.User)
-	c.Assert(err, gc.IsNil)
+	ch := storetesting.NewCharm(nil)
+	s.addPublicCharm(c, ch, id)
 
-	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
-	c.Assert(err, gc.IsNil)
-
-	archiveUrl := storeURL("~charmers/precise/wordpress-0/archive")
-	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     archiveUrl,
-	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
-	c.Assert(rec.Header().Get(params.ContentHashHeader), gc.Equals, hashOfBytes(archiveBytes))
+	rec := s.assertArchiveDownload(
+		c,
+		"~charmers/precise/wordpress-0",
+		nil,
+		ch.Bytes(),
+	)
 	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/precise/wordpress-0")
 	assertCacheControl(c, rec.Header(), true)
 
@@ -68,47 +67,49 @@ func (s *ArchiveSuite) TestGet(c *gc.C) {
 	// as net/http is well-tested.
 	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
-		URL:     archiveUrl,
+		URL:     storeURL("~charmers/precise/wordpress-0/archive"),
 		Header:  http.Header{"Range": {"bytes=10-100"}},
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusPartialContent, gc.Commentf("body: %q", rec.Body.Bytes()))
 	c.Assert(rec.Body.Bytes(), gc.HasLen, 100-10+1)
-	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes[10:101])
-	c.Assert(rec.Header().Get(params.ContentHashHeader), gc.Equals, hashOfBytes(archiveBytes))
+	c.Assert(rec.Body.Bytes(), gc.DeepEquals, ch.Bytes()[10:101])
+	c.Assert(rec.Header().Get(params.ContentHashHeader), gc.Equals, hashOfBytes(ch.Bytes()))
 	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/precise/wordpress-0")
 	assertCacheControl(c, rec.Header(), true)
 }
 
 func (s *ArchiveSuite) TestGetWithPartialId(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-42", -1))
-	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     storeURL("~charmers/wordpress/archive"),
-	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	id := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
+	ch := storetesting.NewCharm(nil)
+	s.addPublicCharm(c, ch, id)
+
+	rec := s.assertArchiveDownload(
+		c,
+		"~charmers/wordpress",
+		nil,
+		ch.Bytes(),
+	)
 	// The complete entity id can be retrieved from the response header.
-	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/utopic/wordpress-42")
+	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, id.URL.String())
 }
 
 func (s *ArchiveSuite) TestGetPromulgatedWithPartialId(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/utopic/wordpress-42", 42)
-	err := s.store.AddCharmWithArchive(
-		id,
-		storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"))
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&id.URL, "unpublished.read", params.Everyone, id.URL.User)
-	c.Assert(err, gc.IsNil)
-	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     storeURL("wordpress/archive"),
-	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-	// The complete entity id can be retrieved from the response header.
+	ch := storetesting.NewCharm(nil)
+	s.addPublicCharm(c, ch, id)
+
+	rec := s.assertArchiveDownload(
+		c,
+		"wordpress",
+		nil,
+		ch.Bytes(),
+	)
 	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, id.PromulgatedURL().String())
 }
 
+// V4 SPECIFIC
 func (s *ArchiveSuite) TestGetElidesSeriesFromMultiSeriesCharmMetadata(c *gc.C) {
-	_, ch := s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-0", -1))
+	_, ch := s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-0", -1))
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
 		URL:     storeURL("~charmers/multi-series/archive"),
@@ -148,18 +149,17 @@ func (s *ArchiveSuite) TestGetCounters(c *gc.C) {
 	} {
 		c.Logf("test %d: %s", i, id)
 
-		// Add a charm to the database (including the archive).
-		err := s.store.AddCharmWithArchive(id, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&id.URL, "unpublished.read", params.Everyone, id.URL.User)
-		c.Assert(err, gc.IsNil)
+		ch := storetesting.NewCharm(nil)
+		s.addPublicCharm(c, ch, id)
 
-		// Download the charm archive using the API.
-		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-			Handler: s.srv,
-			URL:     storeURL(id.URL.Path() + "/archive"),
-		})
-		c.Assert(rec.Code, gc.Equals, http.StatusOK)
+		// Download the charm archive using the API, which should increment
+		// the download counts.
+		s.assertArchiveDownload(
+			c,
+			id.URL.Path(),
+			nil,
+			ch.Bytes(),
+		)
 
 		// Check that the downloads count for the entity has been updated.
 		key := []string{params.StatsArchiveDownload, "utopic", "mysql", id.URL.User, "42"}
@@ -171,19 +171,17 @@ func (s *ArchiveSuite) TestGetCounters(c *gc.C) {
 }
 
 func (s *ArchiveSuite) TestGetCountersDisabled(c *gc.C) {
-	url := newResolvedURL("~charmers/utopic/mysql-42", 42)
-	// Add a charm to the database (including the archive).
-	err := s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	id := newResolvedURL("~charmers/utopic/mysql-42", 42)
+	ch := storetesting.NewCharm(nil)
+	s.addPublicCharm(c, ch, id)
 
 	// Download the charm archive using the API, passing stats=0.
-	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     storeURL(url.URL.Path() + "/archive?stats=0"),
-	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	s.assertArchiveDownload(
+		c,
+		"",
+		&httptesting.DoRequestParams{URL: storeURL("~charmers/utopic/mysql-42/archive?stats=0")},
+		ch.Bytes(),
+	)
 
 	// Check that the downloads count for the entity has not been updated.
 	key := []string{params.StatsArchiveDownload, "utopic", "mysql", "", "42"}
@@ -412,18 +410,19 @@ loop:
 }
 
 func (s *ArchiveSuite) TestPostCharm(c *gc.C) {
+	s.discharge = dischargeForUser("charmers")
+
 	// A charm that did not exist before should get revision 0.
 	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress")
 
 	// Subsequent charm uploads should increment the revision by 1.
 	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-1", -1), "mysql")
 
-	// Retrieving the published version returns the latest charm.
-	err := s.store.SetPerms(charm.MustParseURL("~charmers/wordpress"), "unpublished.read", params.Everyone)
-	c.Assert(err, gc.IsNil)
+	// Retrieving the unpublished version returns the latest charm.
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
-		URL:     storeURL("~charmers/wordpress/archive"),
+		URL:     storeURL("~charmers/wordpress/archive?channel=unpublished"),
+		Do:      bakeryDo(nil),
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	c.Assert(rec.Header().Get(params.EntityIdHeader), gc.Equals, "cs:~charmers/precise/wordpress-1")
@@ -770,34 +769,6 @@ func (s *ArchiveSuite) TestPostFailureCounters(c *gc.C) {
 	stats.CheckCounterSum(c, s.store, key, false, 3)
 }
 
-func (s *ArchiveSuite) TestPostErrorReadsFully(c *gc.C) {
-	h := s.handler(c)
-	defer h.Close()
-
-	b := bytes.NewBuffer([]byte("test body"))
-	r, err := http.NewRequest("POST", "/~charmers/trusty/wordpress/archive", b)
-	c.Assert(err, gc.IsNil)
-	r.Header.Set("Content-Type", "application/zip")
-	r.SetBasicAuth(testUsername, testPassword)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, r)
-	c.Assert(rec.Code, gc.Equals, http.StatusBadRequest)
-	c.Assert(b.Len(), gc.Equals, 0)
-}
-
-func (s *ArchiveSuite) TestPostAuthErrorReadsFully(c *gc.C) {
-	h := s.handler(c)
-	defer h.Close()
-	b := bytes.NewBuffer([]byte("test body"))
-	r, err := http.NewRequest("POST", "/~charmers/trusty/wordpress/archive", b)
-	c.Assert(err, gc.IsNil)
-	r.Header.Set("Content-Type", "application/zip")
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, r)
-	c.Assert(rec.Code, gc.Equals, http.StatusUnauthorized)
-	c.Assert(b.Len(), gc.Equals, 0)
-}
-
 func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
 	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress")
 
@@ -1044,12 +1015,7 @@ var archiveFileErrorsTests = []struct {
 }}
 
 func (s *ArchiveSuite) TestArchiveFileErrors(c *gc.C) {
-	wordpress := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
-	url := newResolvedURL("cs:~charmers/utopic/wordpress-0", 0)
-	err := s.store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-0", 0))
 	for i, test := range archiveFileErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -1068,10 +1034,7 @@ func (s *ArchiveSuite) TestArchiveFileErrors(c *gc.C) {
 func (s *ArchiveSuite) TestArchiveFileGet(c *gc.C) {
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), "all-hooks")
 	id := newResolvedURL("cs:~charmers/utopic/all-hooks-0", 0)
-	err := s.store.AddCharmWithArchive(id, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&id.URL, "unpublished.read", params.Everyone, id.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, ch, id)
 	zipFile, err := zip.OpenReader(ch.Path)
 	c.Assert(err, gc.IsNil)
 	defer zipFile.Close()
@@ -1273,17 +1236,51 @@ func (s *ArchiveSuite) TestDeleteCounters(c *gc.C) {
 	stats.CheckCounterSum(c, s.store, key, false, 1)
 }
 
-func (s *ArchiveSuite) TestPostAuthErrors(c *gc.C) {
-	checkAuthErrors(c, s.srv, "POST", "~charmers/utopic/django/archive")
+type basicAuthArchiveSuite struct {
+	commonSuite
 }
 
-func (s *ArchiveSuite) TestDeleteAuthErrors(c *gc.C) {
+var _ = gc.Suite(&basicAuthArchiveSuite{})
+
+func (s *basicAuthArchiveSuite) TestPostAuthErrors(c *gc.C) {
+	s.checkAuthErrors(c, "POST", "~charmers/utopic/django/archive")
+}
+
+func (s *basicAuthArchiveSuite) TestDeleteAuthErrors(c *gc.C) {
 	err := s.store.AddCharmWithArchive(
 		newResolvedURL("~charmers/utopic/django-42", 42),
 		storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"),
 	)
 	c.Assert(err, gc.IsNil)
-	checkAuthErrors(c, s.srv, "DELETE", "utopic/django-42/archive")
+	s.checkAuthErrors(c, "DELETE", "utopic/django-42/archive")
+}
+
+func (s *basicAuthArchiveSuite) TestPostErrorReadsFully(c *gc.C) {
+	h := s.handler(c)
+	defer h.Close()
+
+	b := strings.NewReader("test body")
+	r, err := http.NewRequest("POST", "/~charmers/trusty/wordpress/archive", b)
+	c.Assert(err, gc.IsNil)
+	r.Header.Set("Content-Type", "application/zip")
+	r.SetBasicAuth(testUsername, testPassword)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+	c.Assert(rec.Code, gc.Equals, http.StatusBadRequest)
+	c.Assert(b.Len(), gc.Equals, 0)
+}
+
+func (s *basicAuthArchiveSuite) TestPostAuthErrorReadsFully(c *gc.C) {
+	h := s.handler(c)
+	defer h.Close()
+	b := strings.NewReader("test body")
+	r, err := http.NewRequest("POST", "/~charmers/trusty/wordpress/archive", b)
+	c.Assert(err, gc.IsNil)
+	r.Header.Set("Content-Type", "application/zip")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+	c.Assert(rec.Code, gc.Equals, http.StatusUnauthorized)
+	c.Assert(b.Len(), gc.Equals, 0)
 }
 
 var archiveAuthErrorsTests = []struct {
@@ -1314,8 +1311,7 @@ var archiveAuthErrorsTests = []struct {
 	expectMessage: "invalid user name or password",
 }}
 
-func checkAuthErrors(c *gc.C, handler http.Handler, method, url string) {
-	archiveURL := storeURL(url)
+func (s *basicAuthArchiveSuite) checkAuthErrors(c *gc.C, method, url string) {
 	for i, test := range archiveAuthErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
 		if test.header == nil {
@@ -1325,8 +1321,8 @@ func checkAuthErrors(c *gc.C, handler http.Handler, method, url string) {
 			test.header.Add("Content-Type", "application/zip")
 		}
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-			Handler:      handler,
-			URL:          archiveURL,
+			Handler:      s.srv,
+			URL:          storeURL(url),
 			Method:       method,
 			Header:       test.header,
 			Username:     test.username,
@@ -1440,15 +1436,8 @@ func (s *ArchiveSearchSuite) TestGetSearchUpdate(c *gc.C) {
 		c.Logf("test %d: %s", i, id)
 		url := newResolvedURL(id, -1)
 
-		// Add a charm to the database (including the archive).
-		err := s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "stable.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.Publish(url, mongodoc.StableChannel)
-		c.Assert(err, gc.IsNil)
+		// Add a charm to the database.
+		s.addPublicCharm(c, storetesting.NewCharm(nil), url)
 
 		// Download the charm archive using the API.
 		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -1460,4 +1449,21 @@ func (s *ArchiveSearchSuite) TestGetSearchUpdate(c *gc.C) {
 		// Check that the search record for the entity has been updated.
 		stats.CheckSearchTotalDownloads(c, s.store, &url.URL, 1)
 	}
+}
+
+func (s *commonSuite) assertArchiveDownload(c *gc.C, id string, extraParams *httptesting.DoRequestParams, archiveBytes []byte) *httptest.ResponseRecorder {
+	doParams := httptesting.DoRequestParams{}
+	if extraParams != nil {
+		doParams = *extraParams
+	}
+	doParams.Handler = s.srv
+	if doParams.URL == "" {
+		doParams.URL = storeURL(id + "/archive")
+	}
+	rec := httptesting.DoRequest(c, doParams)
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+
+	c.Assert(rec.Body.Bytes(), gc.DeepEquals, archiveBytes)
+	c.Assert(rec.Header().Get(params.ContentHashHeader), gc.Equals, hashOfBytes(archiveBytes))
+	return rec
 }

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -213,8 +213,15 @@ var readAuthorizationTests = []struct {
 	// groups holds group names the user is member of, as returned by the
 	// discharger.
 	groups []string
-	// readPerm stores a list of users with read permissions.
-	readPerm []string
+	// unpublishedReadPerm stores a list of users with read permissions on
+	// on the unpublished entities.
+	unpublishedReadPerm []string
+	// developmentReadPerm stores a list of users with read permissions on the development channel.
+	developmentReadPerm []string
+	// stableReadPerm stores a list of users with read permissions on the stable channel.
+	stableReadPerm []string
+	// channels contains a list of channels, to which the entity belongs.
+	channels []mongodoc.Channel
 	// expectStatus is the expected HTTP response status.
 	// Defaults to 200 status OK.
 	expectStatus int
@@ -222,24 +229,24 @@ var readAuthorizationTests = []struct {
 	// the body is not checked and the response is assumed to be ok.
 	expectBody interface{}
 }{{
-	about:    "anonymous users are authorized",
-	readPerm: []string{params.Everyone},
+	about:               "anonymous users are authorized",
+	unpublishedReadPerm: []string{params.Everyone},
 }, {
-	about:    "everyone is authorized",
-	username: "dalek",
-	readPerm: []string{params.Everyone},
+	about:               "everyone is authorized",
+	username:            "dalek",
+	unpublishedReadPerm: []string{params.Everyone},
 }, {
-	about:    "everyone and a specific user",
-	username: "dalek",
-	readPerm: []string{params.Everyone, "janeway"},
+	about:               "everyone and a specific user",
+	username:            "dalek",
+	unpublishedReadPerm: []string{params.Everyone, "janeway"},
 }, {
-	about:    "specific user authorized",
-	username: "who",
-	readPerm: []string{"who"},
+	about:               "specific user authorized",
+	username:            "who",
+	unpublishedReadPerm: []string{"who"},
 }, {
-	about:    "multiple specific users authorized",
-	username: "picard",
-	readPerm: []string{"kirk", "picard", "sisko"},
+	about:               "multiple specific users authorized",
+	username:            "picard",
+	unpublishedReadPerm: []string{"kirk", "picard", "sisko"},
 }, {
 	about:        "nobody authorized",
 	username:     "picard",
@@ -249,34 +256,34 @@ var readAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "picard"`,
 	},
 }, {
-	about:        "access denied for user",
-	username:     "kirk",
-	readPerm:     []string{"picard", "sisko"},
-	expectStatus: http.StatusUnauthorized,
+	about:               "access denied for user",
+	username:            "kirk",
+	unpublishedReadPerm: []string{"picard", "sisko"},
+	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:    "everyone is authorized (user is member of groups)",
-	username: "dalek",
-	groups:   []string{"group1", "group2"},
-	readPerm: []string{params.Everyone},
+	about:               "everyone is authorized (user is member of groups)",
+	username:            "dalek",
+	groups:              []string{"group1", "group2"},
+	unpublishedReadPerm: []string{params.Everyone},
 }, {
-	about:    "everyone and a specific group",
-	username: "dalek",
-	groups:   []string{"group2", "group3"},
-	readPerm: []string{params.Everyone, "group1"},
+	about:               "everyone and a specific group",
+	username:            "dalek",
+	groups:              []string{"group2", "group3"},
+	unpublishedReadPerm: []string{params.Everyone, "group1"},
 }, {
-	about:    "specific group authorized",
-	username: "who",
-	groups:   []string{"group1", "group42", "group2"},
-	readPerm: []string{"group42"},
+	about:               "specific group authorized",
+	username:            "who",
+	groups:              []string{"group1", "group42", "group2"},
+	unpublishedReadPerm: []string{"group42"},
 }, {
-	about:    "multiple specific groups authorized",
-	username: "picard",
-	groups:   []string{"group2"},
-	readPerm: []string{"kirk", "group0", "group2"},
+	about:               "multiple specific groups authorized",
+	username:            "picard",
+	groups:              []string{"group2"},
+	unpublishedReadPerm: []string{"kirk", "group0", "group2"},
 }, {
 	about:        "no group authorized",
 	username:     "picard",
@@ -287,10 +294,94 @@ var readAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "picard"`,
 	},
 }, {
-	about:        "access denied for group",
-	username:     "kirk",
-	groups:       []string{"group1", "group2", "group3"},
-	readPerm:     []string{"picard", "sisko", "group42", "group47"},
+	about:               "access denied for group",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
+	expectStatus:        http.StatusUnauthorized,
+	expectBody: params.Error{
+		Code:    params.ErrUnauthorized,
+		Message: `unauthorized: access denied for user "kirk"`,
+	},
+}, {
+	about:               "access provided through development channel",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
+	developmentReadPerm: []string{"group1"},
+	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel},
+}, {
+	about:               "access provided through development channel, but charm not published",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
+	developmentReadPerm: []string{"group1"},
+	expectStatus:        http.StatusUnauthorized,
+	expectBody: params.Error{
+		Code:    params.ErrUnauthorized,
+		Message: `unauthorized: access denied for user "kirk"`,
+	},
+}, {
+	about:               "access provided through stable channel",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
+	developmentReadPerm: []string{"group12"},
+	stableReadPerm:      []string{"group2"},
+	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel, mongodoc.StableChannel},
+}, {
+	about:               "access provided through stable channel, but charm not published",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
+	developmentReadPerm: []string{"group12"},
+	stableReadPerm:      []string{"group2"},
+	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	expectStatus:        http.StatusUnauthorized,
+	expectBody: params.Error{
+		Code:    params.ErrUnauthorized,
+		Message: `unauthorized: access denied for user "kirk"`,
+	},
+}, {
+	about:               "access provided through development channel, but charm on stable channel",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
+	developmentReadPerm: []string{"group1"},
+	stableReadPerm:      []string{"group11"},
+	channels: []mongodoc.Channel{
+		mongodoc.DevelopmentChannel,
+		mongodoc.StableChannel,
+	},
+	expectStatus: http.StatusUnauthorized,
+	expectBody: params.Error{
+		Code:    params.ErrUnauthorized,
+		Message: `unauthorized: access denied for user "kirk"`,
+	},
+}, {
+	about:               "access provided through unpublished ACL, but charm on stable channel",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group1"},
+	stableReadPerm:      []string{"group11"},
+	channels: []mongodoc.Channel{
+		mongodoc.DevelopmentChannel,
+		mongodoc.StableChannel,
+	},
+	expectStatus: http.StatusUnauthorized,
+	expectBody: params.Error{
+		Code:    params.ErrUnauthorized,
+		Message: `unauthorized: access denied for user "kirk"`,
+	},
+}, {
+	about:               "access provided through unpublished ACL, but charm on development channel",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group1"},
+	developmentReadPerm: []string{"group11"},
+	channels: []mongodoc.Channel{
+		mongodoc.DevelopmentChannel,
+	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
@@ -320,12 +411,22 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("wordpress"))
 		c.Assert(err, gc.IsNil)
 
+		// publish the charm on any required channels.
+		if len(test.channels) > 0 {
+			err := s.store.Publish(rurl, test.channels...)
+			c.Assert(err, gc.IsNil)
+		}
+
 		// Change the ACLs for the testing charm.
-		err = s.store.SetPerms(&rurl.URL, "unpublished.read", test.readPerm...)
+		err = s.store.SetPerms(&rurl.URL, "unpublished.read", test.unpublishedReadPerm...)
+		c.Assert(err, gc.IsNil)
+		err = s.store.SetPerms(&rurl.URL, "development.read", test.developmentReadPerm...)
+		c.Assert(err, gc.IsNil)
+		err = s.store.SetPerms(&rurl.URL, "stable.read", test.stableReadPerm...)
 		c.Assert(err, gc.IsNil)
 
 		// Define an helper function used to send requests and check responses.
-		makeRequest := func(path string, expectStatus int, expectBody interface{}) {
+		doRequest := func(path string, expectStatus int, expectBody interface{}) {
 			rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 				Handler: s.srv,
 				Do:      bakeryDo(nil),
@@ -341,15 +442,10 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		}
 
 		// Perform meta and id requests.
-		makeRequest("~charmers/wordpress/meta/archive-size", test.expectStatus, test.expectBody)
-		makeRequest("~charmers/wordpress/expand-id", test.expectStatus, test.expectBody)
-
-		// Remove permissions for the published charm.
-		err = s.store.SetPerms(&rurl.URL, "unpublished.read")
-		c.Assert(err, gc.IsNil)
-
-		// Check that now accessing the published charm is not allowed.
-		makeRequest("~charmers/wordpress/meta/archive-size", http.StatusUnauthorized, nil)
+		// Note that we use the full URL so that we test authorization specifically
+		// on that entity without trying to look up the entity in the stable channel.
+		doRequest("~charmers/utopic/wordpress-42/meta/archive-size", test.expectStatus, test.expectBody)
+		doRequest("~charmers/utopic/wordpress-42/expand-id", test.expectStatus, test.expectBody)
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
@@ -367,7 +463,7 @@ var writeAuthorizationTests = []struct {
 	// discharger.
 	groups []string
 	// writePerm stores a list of users with write permissions.
-	writePerm []string
+	unpublishedWritePerm []string
 	// developmentWritePerm stores a list of users with write permissions on the development channel.
 	developmentWritePerm []string
 	// stableWritePerm stores a list of users with write permissions on the stable channel.
@@ -381,21 +477,21 @@ var writeAuthorizationTests = []struct {
 	// the body is not checked and the response is assumed to be ok.
 	expectBody interface{}
 }{{
-	about:        "anonymous users are not authorized",
-	writePerm:    []string{"who"},
-	expectStatus: http.StatusUnauthorized,
+	about:                "anonymous users are not authorized",
+	unpublishedWritePerm: []string{"who"},
+	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
 		Message: "unauthorized: no username declared",
 	},
 }, {
-	about:     "specific user authorized to write",
-	username:  "dalek",
-	writePerm: []string{"dalek"},
+	about:                "specific user authorized to write",
+	username:             "dalek",
+	unpublishedWritePerm: []string{"dalek"},
 }, {
-	about:     "multiple users authorized",
-	username:  "sisko",
-	writePerm: []string{"kirk", "picard", "sisko"},
+	about:                "multiple users authorized",
+	username:             "sisko",
+	unpublishedWritePerm: []string{"kirk", "picard", "sisko"},
 }, {
 	about:        "no users authorized",
 	username:     "who",
@@ -405,24 +501,24 @@ var writeAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "who"`,
 	},
 }, {
-	about:        "specific user unauthorized",
-	username:     "kirk",
-	writePerm:    []string{"picard", "sisko", "janeway"},
-	expectStatus: http.StatusUnauthorized,
+	about:                "specific user unauthorized",
+	username:             "kirk",
+	unpublishedWritePerm: []string{"picard", "sisko", "janeway"},
+	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:     "access granted for group",
-	username:  "picard",
-	groups:    []string{"group1", "group2"},
-	writePerm: []string{"group2"},
+	about:                "access granted for group",
+	username:             "picard",
+	groups:               []string{"group1", "group2"},
+	unpublishedWritePerm: []string{"group2"},
 }, {
-	about:     "multiple groups authorized",
-	username:  "picard",
-	groups:    []string{"group1", "group2"},
-	writePerm: []string{"kirk", "group0", "group1", "group2"},
+	about:                "multiple groups authorized",
+	username:             "picard",
+	groups:               []string{"group1", "group2"},
+	unpublishedWritePerm: []string{"kirk", "group0", "group1", "group2"},
 }, {
 	about:        "no group authorized",
 	username:     "picard",
@@ -433,11 +529,11 @@ var writeAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "picard"`,
 	},
 }, {
-	about:        "access denied for group",
-	username:     "kirk",
-	groups:       []string{"group1", "group2", "group3"},
-	writePerm:    []string{"picard", "sisko", "group42", "group47"},
-	expectStatus: http.StatusUnauthorized,
+	about:                "access denied for group",
+	username:             "kirk",
+	groups:               []string{"group1", "group2", "group3"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
+	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
 		Message: `unauthorized: access denied for user "kirk"`,
@@ -446,14 +542,14 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through development channel",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
 	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel},
 }, {
 	about:                "access provided through development channel, but charm not published",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -464,7 +560,7 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through stable channel",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group12"},
 	stableWritePerm:      []string{"group2"},
 	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel, mongodoc.StableChannel},
@@ -472,7 +568,7 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through stable channel, but charm not published",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group12"},
 	stableWritePerm:      []string{"group2"},
 	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel},
@@ -485,7 +581,7 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through development channel, but charm on stable channel",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
 	stableWritePerm:      []string{"group11"},
 	channels: []mongodoc.Channel{
@@ -498,11 +594,11 @@ var writeAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:           "access provided through unpublished ACL, but charm on stable channel",
-	username:        "kirk",
-	groups:          []string{"group1", "group2", "group3"},
-	writePerm:       []string{"picard", "sisko", "group42", "group1"},
-	stableWritePerm: []string{"group11"},
+	about:                "access provided through unpublished ACL, but charm on stable channel",
+	username:             "kirk",
+	groups:               []string{"group1", "group2", "group3"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group1"},
+	stableWritePerm:      []string{"group11"},
 	channels: []mongodoc.Channel{
 		mongodoc.DevelopmentChannel,
 		mongodoc.StableChannel,
@@ -516,7 +612,7 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through unpublished ACL, but charm on development channel",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group1"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group1"},
 	developmentWritePerm: []string{"group11"},
 	channels: []mongodoc.Channel{
 		mongodoc.DevelopmentChannel,
@@ -549,7 +645,7 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 		}
 
 		// Change the ACLs for the testing charm.
-		err = s.store.SetPerms(&rurl.URL, "unpublished.write", test.writePerm...)
+		err = s.store.SetPerms(&rurl.URL, "unpublished.write", test.unpublishedWritePerm...)
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&rurl.URL, "development.write", test.developmentWritePerm...)
 		c.Assert(err, gc.IsNil)
@@ -575,8 +671,10 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 			}
 		}
 
-		// Perform a meta PUT request to the URL.
-		makeRequest("~charmers/wordpress/meta/extra-info/key", test.expectStatus, test.expectBody)
+		// Perform a meta PUT request to the URLs.
+		// Note that we use the full URL so that we test authorization specifically
+		// on that entity without trying to look up the entity in the stable channel.
+		makeRequest("~charmers/utopic/wordpress-42/meta/extra-info/key", test.expectStatus, test.expectBody)
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
@@ -813,16 +911,11 @@ func (s *authSuite) TestIsEntityCaveat(c *gc.C) {
 	}
 
 	// Add a charm to the store, used for testing.
-	err := s.store.AddCharmWithArchive(
-		newResolvedURL("~charmers/utopic/wordpress-41", 9),
-		storetesting.Charms.CharmDir("wordpress"))
-	c.Assert(err, gc.IsNil)
-	err = s.store.AddCharmWithArchive(
-		newResolvedURL("~charmers/utopic/wordpress-42", 10),
-		storetesting.Charms.CharmDir("wordpress"))
-	c.Assert(err, gc.IsNil)
-	// Change the ACLs for the testing charm.
-	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "unpublished.read", "bob")
+	s.addPublicCharm(c, storetesting.NewCharm(nil), newResolvedURL("~charmers/utopic/wordpress-41", 9))
+	s.addPublicCharm(c, storetesting.NewCharm(nil), newResolvedURL("~charmers/utopic/wordpress-42", 10))
+	// Change the ACLs for charms we've just uploaded, otherwise
+	// no authorization checking will take place.
+	err := s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")
 	c.Assert(err, gc.IsNil)
 
 	for i, test := range isEntityCaveatTests {
@@ -907,12 +1000,15 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 	// Now check that we can use the obtained macaroon to do stuff
 	// as the declared user.
 
+	rurl := newResolvedURL("~charmers/utopic/wordpress-41", 9)
 	err = s.store.AddCharmWithArchive(
-		newResolvedURL("~charmers/utopic/wordpress-41", 9),
+		rurl,
 		storetesting.Charms.CharmDir("wordpress"))
 	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(rurl, mongodoc.StableChannel)
+	c.Assert(err, gc.IsNil)
 	// Change the ACLs for the testing charm.
-	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "unpublished.read", "bob")
+	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")
 	c.Assert(err, gc.IsNil)
 
 	// First check that we require authorization to access the charm.

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -48,9 +48,9 @@ var serveDiagramErrorsTests = []struct {
 
 func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/trusty/wordpress-42", 42)
-	s.addPublicCharm(c, "wordpress", id)
+	s.addPublicCharmFromRepo(c, "wordpress", id)
 	id = newResolvedURL("cs:~charmers/bundle/nopositionbundle-42", 42)
-	s.addPublicBundle(c, "wordpress-simple", id, true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", id, true)
 
 	for i, test := range serveDiagramErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -88,8 +88,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	s.addRequiredCharms(c, bundle)
 	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -151,8 +150,7 @@ func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 	s.addRequiredCharms(c, bundle)
 	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -207,10 +205,7 @@ func (s *APISuite) TestServeReadMe(c *gc.C) {
 		}
 
 		url.URL.Revision = i
-		err := s.store.AddCharmWithArchive(url, wordpress)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, wordpress, url)
 
 		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 			Handler: s.srv,
@@ -245,8 +240,7 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 	url := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
 	err := s.store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -277,6 +271,7 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 	url.URL.Revision++
 	err = s.store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
+	s.setPublic(c, url)
 
 	// Check that we still get expected svg.
 	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -289,7 +284,7 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 }
 
 func (s *APISuite) TestServeBundleIcon(c *gc.C) {
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/something-32", 32), true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/something-32", 32), true)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
@@ -306,10 +301,7 @@ func (s *APISuite) TestServeDefaultIcon(c *gc.C) {
 	wordpress := storetesting.Charms.ClonedDir(c.MkDir(), "wordpress")
 
 	url := newResolvedURL("cs:~charmers/precise/wordpress-0", 0)
-	err := s.store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, wordpress, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -334,10 +326,7 @@ func (s *APISuite) TestServeDefaultIconForBadXML(c *gc.C) {
 
 		url := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
 		url.URL.Revision = i
-		err := s.store.AddCharmWithArchive(url, wordpress)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, wordpress, url)
 
 		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 			Handler: s.srv,

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -554,17 +554,12 @@ var metaBundlesContainingTests = []struct {
 func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 	// Add the bundles used for testing to the database.
 	for id, b := range metaBundlesContainingBundles {
-		url := mustParseResolvedURL(id)
-		s.addRequiredCharms(c, b)
-		err := s.store.AddBundleWithArchive(url, b)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicBundle(c, b, mustParseResolvedURL(id), true)
 	}
 	for i, test := range metaBundlesContainingTests {
 		c.Logf("test %d: %s", i, test.about)
 		if test.addCharm != nil {
-			s.addPublicCharm(c, "wordpress", test.addCharm)
+			s.addPublicCharmFromRepo(c, "wordpress", test.addCharm)
 		}
 		// Perform the request and ensure the response is what we expect.
 		storeURL := storeURL(test.id + "/meta/bundles-containing" + test.querystring)
@@ -585,17 +580,12 @@ func (s *RelationsSuite) TestMetaBundlesContainingBundleACL(c *gc.C) {
 	// Add the bundles used for testing to the database.
 	for id, b := range metaBundlesContainingBundles {
 		url := mustParseResolvedURL(id)
-		s.addRequiredCharms(c, b)
-		err := s.store.AddBundleWithArchive(url, storetesting.NewBundle(b.Data()))
-		c.Assert(err, gc.IsNil)
+		s.addPublicBundle(c, storetesting.NewBundle(b.Data()), url, true)
 		if url.URL.Name == "useless" {
 			// The useless bundle is not available for "everyone".
-			err = s.store.SetPerms(&url.URL, "unpublished.read", url.URL.User)
+			err := s.store.SetPerms(&url.URL, "stable.read", url.URL.User)
 			c.Assert(err, gc.IsNil)
-			continue
 		}
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
 	}
 
 	// Perform the request and ensure that the useless bundle isn't listed.

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -20,7 +20,6 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v4"
@@ -63,20 +62,10 @@ func (s *SearchSuite) SetUpTest(c *gc.C) {
 
 func (s *SearchSuite) addCharmsToStore(c *gc.C) {
 	for name, id := range exportTestCharms {
-		err := s.store.AddCharmWithArchive(id, getSearchCharm(name))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&id.URL, "stable.read", params.Everyone, id.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.Publish(id, mongodoc.StableChannel)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, getSearchCharm(name), id)
 	}
 	for name, id := range exportTestBundles {
-		err := s.store.AddBundleWithArchive(id, getSearchBundle(name))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&id.URL, "stable.read", params.Everyone, id.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.Publish(id, mongodoc.StableChannel)
-		c.Assert(err, gc.IsNil)
+		s.addPublicBundle(c, getSearchBundle(name), id, false)
 	}
 }
 
@@ -613,16 +602,11 @@ func (s *SearchSuite) TestDownloadsBoost(c *gc.C) {
 	for n, cnt := range charmDownloads {
 		url := newResolvedURL("cs:~downloads-test/trusty/x-1", -1)
 		url.URL.Name = n
-		err := s.store.AddCharmWithArchive(url, getSearchCharm(n))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "stable.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, getSearchCharm(n), url)
 		for i := 0; i < cnt; i++ {
 			err := s.store.IncrementDownloadCounts(url)
 			c.Assert(err, gc.IsNil)
 		}
-		err = s.store.Publish(url, mongodoc.StableChannel)
-		c.Assert(err, gc.IsNil)
 	}
 	err := s.esSuite.ES.RefreshIndex(s.esSuite.TestIndex)
 	c.Assert(err, gc.IsNil)

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -124,17 +124,13 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 		previousMonth: true,
 	}}
 
-	ch := storetesting.Charms.CharmDir("wordpress")
-	rurl := newResolvedURL("~charmers/precise/wordpress-23", 23)
-	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "unpublished.read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, storetesting.Charms.CharmDir("wordpress"), newResolvedURL("~charmers/precise/wordpress-23", 23))
 
 	var countsBefore, countsAfter charmstore.AggregatedCounts
 	for i, test := range tests {
 		c.Logf("test %d. %s", i, test.path)
 
+		var err error
 		_, countsBefore, err = s.store.ArchiveDownloadCounts(ref, true)
 		c.Assert(err, gc.IsNil)
 
@@ -164,12 +160,8 @@ func (s *StatsSuite) TestServerStatsArchiveDownloadOnPromulgatedEntity(c *gc.C) 
 	ref := charm.MustParseURL("~charmers/precise/wordpress-23")
 	path := "/stats/counter/archive-download:*"
 
-	ch := storetesting.Charms.CharmDir("wordpress")
 	rurl := newResolvedURL("~charmers/precise/wordpress-23", 23)
-	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "unpublished.read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, storetesting.Charms.CharmDir("wordpress"), rurl)
 	s.store.SetPromulgated(rurl, true)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -239,17 +231,13 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 		partialUpdate: true,
 	}}
 
-	ch := storetesting.Charms.CharmDir("wordpress")
-	rurl := newResolvedURL("~charmers/precise/wordpress-23", 23)
-	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "unpublished.read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, storetesting.Charms.CharmDir("wordpress"), newResolvedURL("~charmers/precise/wordpress-23", 23))
 
 	for i, test := range tests {
 		c.Logf("test %d. %s", i, test.path)
-		var countsBefore, countsAfter charmstore.AggregatedCounts
+		var countsBefore charmstore.AggregatedCounts
 		if test.partialUpdate {
+			var err error
 			_, countsBefore, err = s.store.ArchiveDownloadCounts(ref, true)
 			c.Assert(err, gc.IsNil)
 		}
@@ -267,7 +255,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 			},
 		})
 		if test.partialUpdate {
-			_, countsAfter, err = s.store.ArchiveDownloadCounts(ref, true)
+			_, countsAfter, err := s.store.ArchiveDownloadCounts(ref, true)
 			c.Assert(err, gc.IsNil)
 			c.Assert(countsAfter.Total-countsBefore.Total, gc.Equals, int64(1))
 			c.Assert(countsAfter.LastDay-countsBefore.LastDay, gc.Equals, int64(1))

--- a/internal/v4/status_test.go
+++ b/internal/v4/status_test.go
@@ -31,9 +31,9 @@ func (s *APISuite) TestStatus(c *gc.C) {
 		newResolvedURL("cs:~bar/bundle/wordpress-simple-4", -1),
 	} {
 		if id.URL.Series == "bundle" {
-			s.addPublicBundle(c, id.URL.Name, id, false)
+			s.addPublicBundleFromRepo(c, id.URL.Name, id, false)
 		} else {
-			s.addPublicCharm(c, id.URL.Name, id)
+			s.addPublicCharmFromRepo(c, id.URL.Name, id)
 		}
 	}
 	now := time.Now()

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -532,7 +532,7 @@ func (s *APISuite) TestEndpointGet(c *gc.C) {
 func (s *APISuite) TestAllMetaEndpointsTested(c *gc.C) {
 	// Make sure that we're testing all the metadata
 	// endpoints that we need to.
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
 		URL:     storeURL("precise/wordpress-23/meta"),
@@ -578,9 +578,9 @@ var testEntities = []*router.ResolvedURL{
 func (s *APISuite) addTestEntities(c *gc.C) []*router.ResolvedURL {
 	for _, e := range testEntities {
 		if e.URL.Series == "bundle" {
-			s.addPublicBundle(c, e.URL.Name, e, true)
+			s.addPublicBundleFromRepo(c, e.URL.Name, e, true)
 		} else {
-			s.addPublicCharm(c, e.URL.Name, e)
+			s.addPublicCharmFromRepo(c, e.URL.Name, e)
 		}
 		// Associate some extra-info data with the entity.
 		key := e.URL.Path() + "/meta/extra-info/key"
@@ -632,7 +632,7 @@ func (s *APISuite) TestMetaPermAudit(c *gc.C) {
 	s.discharge = dischargeForUser("bob")
 
 	url := newResolvedURL("~bob/precise/wordpress-23", 23)
-	s.addPublicCharm(c, "wordpress", url)
+	s.addPublicCharmFromRepo(c, "wordpress", url)
 	s.assertPutNonAdmin(c, "precise/wordpress-23/meta/perm/read", []string{"charlie"})
 	c.Assert(calledEntities, jc.DeepEquals, []audit.Entry{{
 		User: "bob",
@@ -678,7 +678,7 @@ func (s *APISuite) TestMetaPermAudit(c *gc.C) {
 
 func (s *APISuite) TestMetaPermPublicWrite(c *gc.C) {
 	url := newResolvedURL("~bob/precise/wordpress-23", 23)
-	s.addPublicCharm(c, "wordpress", url)
+	s.addPublicCharmFromRepo(c, "wordpress", url)
 	s.assertPut(c, "precise/wordpress-23/meta/perm/write", []string{"everyone"})
 
 	// Even though the endpoint has write permissions open to anyone,
@@ -710,7 +710,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		err := s.store.AddCharmWithArchive(u, storetesting.NewCharm(nil))
 		c.Assert(err, gc.IsNil)
 	}
-	s.assertGet(c, "wordpress/meta/perm", params.PermResponse{
+	s.assertGet(c, "wordpress/meta/perm?channel=unpublished", params.PermResponse{
 		Read:  []string{"charmers"},
 		Write: []string{"charmers"},
 	})
@@ -979,7 +979,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 func (s *APISuite) TestMetaPermPutUnauthorized(c *gc.C) {
 	id := "precise/wordpress-23"
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.noMacaroonSrv,
 		URL:     storeURL("~charmers/" + id + "/meta/perm/read"),
@@ -998,11 +998,11 @@ func (s *APISuite) TestMetaPermPutUnauthorized(c *gc.C) {
 
 func (s *APISuite) TestMetaTerms(c *gc.C) {
 	id1 := "precise/terms-17"
-	s.addPublicCharm(c, "terms", newResolvedURL("~charmers/"+id1, 17))
+	s.addPublicCharmFromRepo(c, "terms", newResolvedURL("~charmers/"+id1, 17))
 	s.assertGet(c, id1+"/meta/terms", []string{"terms-1/1", "terms-2/5"})
 
 	id2 := "precise/mysql-1"
-	s.addPublicCharm(c, "mysql", newResolvedURL("~charmers/"+id2, 1))
+	s.addPublicCharmFromRepo(c, "mysql", newResolvedURL("~charmers/"+id2, 1))
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL(id2 + "meta/terms"),
@@ -1017,7 +1017,7 @@ func (s *APISuite) TestMetaTerms(c *gc.C) {
 
 func (s *APISuite) TestMetaTermsBundle(c *gc.C) {
 	id := newResolvedURL("~charmers/bundle/wordpress-simple-10", 10)
-	s.addPublicBundle(c, "wordpress-simple", id, true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", id, true)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
@@ -1037,7 +1037,7 @@ func (s *APISuite) TestSeries(c *gc.C) {
 			continue
 		}
 		id := k + "/wordpress-23"
-		s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
+		s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
 		s.assertGet(c, id+"/meta/id", map[string]interface{}{
 			"Id":       "cs:" + k + "/wordpress-23",
 			"Series":   k,
@@ -1049,7 +1049,7 @@ func (s *APISuite) TestSeries(c *gc.C) {
 
 func (s *APISuite) TestExtraInfo(c *gc.C) {
 	id := "precise/wordpress-23"
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/"+id, 23))
 	s.checkInfo(c, "extra-info", id)
 	s.checkInfo(c, "common-info", id)
 }
@@ -1199,7 +1199,7 @@ var extraInfoBadPutRequestsTests = []struct {
 }}
 
 func (s *APISuite) TestExtraInfoBadPutRequests(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
 	path := "precise/wordpress-23/meta/"
 	for i, test := range extraInfoBadPutRequestsTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -1241,7 +1241,7 @@ func (s *APISuite) TestExtraInfoBadPutRequests(c *gc.C) {
 }
 
 func (s *APISuite) TestExtraInfoPutUnauthorized(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,
 		URL:     storeURL("precise/wordpress-23/meta/extra-info"),
@@ -1305,9 +1305,9 @@ func (s *APISuite) TestExtraInfoPutUnauthorized(c *gc.C) {
 }
 
 func (s *APISuite) TestCommonInfo(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-24", 24))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/trusty/wordpress-1", 1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-24", 24))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/trusty/wordpress-1", 1))
 
 	s.assertPut(c, "wordpress/meta/common-info/key", "something")
 
@@ -1373,7 +1373,7 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 }
 
 func (s *APISuite) TestMetaAnyWithNoIncludesAndNoEntity(c *gc.C) {
-	wordpressURL, _ := s.addPublicCharm(
+	wordpressURL, _ := s.addPublicCharmFromRepo(
 		c,
 		"wordpress",
 		newResolvedURL("cs:~charmers/precise/wordpress-23", 23),
@@ -1410,7 +1410,7 @@ func (s *APISuite) TestMetaAnyWithNoIncludesAndNoEntity(c *gc.C) {
 // In this test we rely on the charm.v2 testing repo package and
 // dummy charm that has actions included.
 func (s *APISuite) TestMetaCharmActions(c *gc.C) {
-	url, dummy := s.addPublicCharm(c, "dummy", newResolvedURL("cs:~charmers/precise/dummy-10", 10))
+	url, dummy := s.addPublicCharmFromRepo(c, "dummy", newResolvedURL("cs:~charmers/precise/dummy-10", 10))
 	s.assertGet(c, "precise/dummy-10/meta/charm-actions", dummy.Actions())
 	s.assertGet(c, "precise/dummy-10/meta/any?include=charm-actions",
 		params.MetaAnyResponse{
@@ -1427,8 +1427,8 @@ func (s *APISuite) TestBulkMeta(c *gc.C) {
 	// whether the meta/any logic is hooked up correctly.
 	// Detailed tests for this feature are in the router package.
 
-	_, wordpress := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
-	_, mysql := s.addPublicCharm(c, "mysql", newResolvedURL("cs:~charmers/precise/mysql-10", 10))
+	_, wordpress := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	_, mysql := s.addPublicCharmFromRepo(c, "mysql", newResolvedURL("cs:~charmers/precise/mysql-10", 10))
 	s.assertGet(c,
 		"meta/charm-metadata?id=precise/wordpress-23&id=precise/mysql-10",
 		map[string]*charm.Meta{
@@ -1443,8 +1443,8 @@ func (s *APISuite) TestBulkMetaAny(c *gc.C) {
 	// whether the meta/any logic is hooked up correctly.
 	// Detailed tests for this feature are in the router package.
 
-	wordpressURL, wordpress := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
-	mysqlURL, mysql := s.addPublicCharm(c, "mysql", newResolvedURL("cs:~charmers/precise/mysql-10", 10))
+	wordpressURL, wordpress := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	mysqlURL, mysql := s.addPublicCharmFromRepo(c, "mysql", newResolvedURL("cs:~charmers/precise/mysql-10", 10))
 	s.assertGet(c,
 		"meta/any?include=charm-metadata&include=charm-config&id=precise/wordpress-23&id=precise/mysql-10",
 		map[string]params.MetaAnyResponse{
@@ -1492,14 +1492,11 @@ func (s *APISuite) TestMetaCharmTags(c *gc.C) {
 	url := newResolvedURL("~charmers/precise/wordpress-0", -1)
 	for i, test := range metaCharmTagsTests {
 		c.Logf("%d: %s", i, test.about)
-		wordpress := storetesting.Charms.CharmDir("wordpress")
-		meta := wordpress.Meta()
-		meta.Tags, meta.Categories = test.tags, test.categories
 		url.URL.Revision = i
-		err := s.store.AddCharmWithArchive(url, storetesting.NewCharm(meta))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+			Tags:       test.tags,
+			Categories: test.categories,
+		}), url)
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler:      s.srv,
 			URL:          storeURL(url.URL.Path() + "/meta/tags"),
@@ -1513,18 +1510,15 @@ func (s *APISuite) TestPromulgatedMetaCharmTags(c *gc.C) {
 	url := newResolvedURL("~charmers/precise/wordpress-0", 0)
 	for i, test := range metaCharmTagsTests {
 		c.Logf("%d: %s", i, test.about)
-		wordpress := storetesting.Charms.CharmDir("wordpress")
-		meta := wordpress.Meta()
-		meta.Tags, meta.Categories = test.tags, test.categories
 		url.URL.Revision = i
 		url.PromulgatedRevision = i
-		err := s.store.AddCharmWithArchive(url, storetesting.NewCharm(meta))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+			Tags:       test.tags,
+			Categories: test.categories,
+		}), url)
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler:      s.srv,
-			URL:          storeURL(url.PromulgatedURL().Path() + "/meta/tags"),
+			URL:          storeURL(url.URL.Path() + "/meta/tags"),
 			ExpectStatus: http.StatusOK,
 			ExpectBody:   params.TagsResponse{test.expectTags},
 		})
@@ -1532,15 +1526,15 @@ func (s *APISuite) TestPromulgatedMetaCharmTags(c *gc.C) {
 }
 
 func (s *APISuite) TestBundleTags(c *gc.C) {
-	b := storetesting.Charms.BundleDir("wordpress-simple")
-	s.addRequiredCharms(c, b)
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", -1)
-	data := b.Data()
-	data.Tags = []string{"foo", "bar"}
-	err := s.store.AddBundleWithArchive(url, storetesting.NewBundle(data))
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
+		Tags: []string{"foo", "bar"},
+		Services: map[string]*charm.ServiceSpec{
+			"wordpress": {
+				Charm: "wordpress",
+			},
+		},
+	}), url, true)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL(url.URL.Path() + "/meta/tags"),
@@ -1550,18 +1544,18 @@ func (s *APISuite) TestBundleTags(c *gc.C) {
 }
 
 func (s *APISuite) TestPromulgatedBundleTags(c *gc.C) {
-	b := storetesting.Charms.BundleDir("wordpress-simple")
-	s.addRequiredCharms(c, b)
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", 2)
-	data := b.Data()
-	data.Tags = []string{"foo", "bar"}
-	err := s.store.AddBundleWithArchive(url, storetesting.NewBundle(data))
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
+		Tags: []string{"foo", "bar"},
+		Services: map[string]*charm.ServiceSpec{
+			"wordpress": {
+				Charm: "wordpress",
+			},
+		},
+	}), url, true)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
-		URL:          storeURL(url.PromulgatedURL().Path() + "/meta/tags"),
+		URL:          storeURL(url.URL.Path() + "/meta/tags"),
 		ExpectStatus: http.StatusOK,
 		ExpectBody:   params.TagsResponse{[]string{"foo", "bar"}},
 	})
@@ -1581,7 +1575,7 @@ func (s *APISuite) TestIdsAreResolved(c *gc.C) {
 	// passed to the router. Given how Router is
 	// defined, and the ResolveURL tests, this should
 	// be sufficient to "join the dots".
-	_, wordpress := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	_, wordpress := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
 	s.assertGet(c, "wordpress/meta/charm-metadata", wordpress.Meta())
 }
 
@@ -1678,24 +1672,27 @@ var resolveURLTests = []struct {
 }}
 
 func (s *APISuite) TestResolveURL(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-24", 24))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-24", 24))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-25", 25))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-10", 10))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/saucy/bigdata-99", 99))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/bigdata-10", 10))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/trusty/wordpress-1", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/wordpress-2", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/other-2", -1))
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10), true)
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10), true)
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-24", 24))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-24", 24))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-25", 25))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-10", 10))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/saucy/bigdata-99", 99))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/bigdata-10", 10))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~bob/trusty/wordpress-1", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~bob/precise/wordpress-2", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~bob/precise/other-2", -1))
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/bundlelovin-10", 10), true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-10", 10), true)
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~bob/multi-series-0", -1))
 
 	for i, test := range resolveURLTests {
 		c.Logf("test %d: %s", i, test.url)
 		url := charm.MustParseURL(test.url)
-		rurl, err := v5.ResolveURL(entitycache.New(v5.ChannelStore{Store: s.store, Channel: mongodoc.UnpublishedChannel}), url)
+		rurl, err := v5.ResolveURL(entitycache.New(&v5.StoreWithChannel{
+			Store:   s.store,
+			Channel: mongodoc.UnpublishedChannel,
+		}), url)
 		if test.notFound {
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 			c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for ".*"`)
@@ -1767,17 +1764,17 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	// Add a bunch of entities in the database.
 	// Note that expand-id only cares about entity identifiers,
 	// so it is ok to reuse the same charm for all the entities.
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-42", 42))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-42", 42))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/haproxy-1", 1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/haproxy-1", 1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/haproxy-1", 1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/haproxy-1", 1))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~bob/precise/builder-5", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~bob/precise/builder-5", -1))
 
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/mongo-0", 0), true)
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-0", 0), true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/mongo-0", 0), true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/wordpress-simple-0", 0), true)
 
 	for i, test := range serveExpandIdTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -1932,33 +1929,33 @@ var serveMetaRevisionInfoTests = []struct {
 }}
 
 func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mysql-41", 41))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mysql-42", 42))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mysql-41", 41))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mysql-42", 42))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-9", 9))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-41", 41))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-42", 42))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-43", 43))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-9", 9))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-41", 41))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-42", 42))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-43", 43))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-42", 42))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/wordpress-42", 42))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-0", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-1", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-2", 0))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-3", 1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~openstack-charmers/trusty/cinder-0", 2))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~openstack-charmers/trusty/cinder-1", 3))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-4", -1))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-5", 4))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-6", 5))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-0", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-1", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-2", 0))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-3", 1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~openstack-charmers/trusty/cinder-0", 2))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~openstack-charmers/trusty/cinder-1", 3))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-4", -1))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-5", 4))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/cinder-6", 5))
 
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-1", 40))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-2", 41))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-1", 40))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/multi-series-2", 41))
 
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-1", 40))
-	s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-2", 41))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-3", 42))
-	s.addPublicCharm(c, "multi-series", newResolvedURL("cs:~charmers/mixed-4", 43))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-1", 40))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/mixed-2", 41))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/mixed-3", 42))
+	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/mixed-4", 43))
 
 	for i, test := range serveMetaRevisionInfoTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -2233,9 +2230,9 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 
 			// Add the required entities to the database.
 			if url.URL.Series == "bundle" {
-				s.addPublicBundle(c, "wordpress-simple", url, true)
+				s.addPublicBundleFromRepo(c, "wordpress-simple", url, true)
 			} else {
-				s.addPublicCharm(c, "wordpress", url)
+				s.addPublicCharmFromRepo(c, "wordpress", url)
 			}
 
 			// Simulate the entity was downloaded at the specified dates.
@@ -2291,7 +2288,7 @@ var metaStatsWithLegacyDownloadCountsTests = []struct {
 // logic.
 func (s *APISuite) TestMetaStatsWithLegacyDownloadCounts(c *gc.C) {
 	patchLegacyDownloadCountsEnabled(s.AddCleanup, true)
-	id, _ := s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/utopic/wordpress-42", 42))
+	id, _ := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/utopic/wordpress-42", 42))
 	url := storeURL("utopic/wordpress-42/meta/stats")
 
 	for i, test := range metaStatsWithLegacyDownloadCountsTests {
@@ -2498,7 +2495,7 @@ func (s *APISuite) TestChangesPublishedErrors(c *gc.C) {
 // a range of charms with known time stamps.
 func (s *APISuite) publishCharmsAtKnownTimes(c *gc.C, charms []publishSpec) {
 	for _, ch := range publishedCharms {
-		id, _ := s.addPublicCharm(c, "wordpress", ch.id)
+		id, _ := s.addPublicCharmFromRepo(c, "wordpress", ch.id)
 		t := ch.published().PublishTime
 		err := s.store.UpdateEntity(id, bson.D{{"$set", bson.D{{"uploadtime", t}}}})
 		c.Assert(err, gc.IsNil)
@@ -2555,12 +2552,108 @@ func (s *APISuite) TestHash256Laziness(c *gc.C) {
 	// TODO frankban: remove this test after updating entities in the
 	// production db with their SHA256 hash value. Entities are updated by
 	// running the cshash256 command.
-	id, _ := s.addPublicCharm(c, "wordpress", newResolvedURL("cs:~who/precise/wordpress-0", -1))
+	id, _ := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~who/precise/wordpress-0", -1))
 
 	// Retrieve the SHA256 hash.
 	entity, err := s.store.FindEntity(id, charmstore.FieldSelector("blobhash256"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(entity.BlobHash256, gc.Not(gc.Equals), "")
+}
+
+var urlChannelResolvingEntities = []struct {
+	id      *router.ResolvedURL
+	channel mongodoc.Channel
+}{{
+	id:      newResolvedURL("~charmers/precise/wordpress-0", 0),
+	channel: mongodoc.StableChannel,
+}, {
+	id:      newResolvedURL("~charmers/precise/wordpress-1", 1),
+	channel: mongodoc.DevelopmentChannel,
+}, {
+	id:      newResolvedURL("~charmers/precise/wordpress-2", 2),
+	channel: mongodoc.UnpublishedChannel,
+}, {
+	id:      newResolvedURL("~charmers/trusty/mysql-0", 0),
+	channel: mongodoc.UnpublishedChannel,
+}}
+
+var urlChannelResolvingTests = []struct {
+	url          string
+	channel      mongodoc.Channel
+	expectURL    string
+	expectStatus int
+	expectError  params.Error
+}{{
+	url:       "wordpress",
+	expectURL: "cs:precise/wordpress-0",
+}, {
+	url:       "wordpress",
+	channel:   mongodoc.StableChannel,
+	expectURL: "cs:precise/wordpress-0",
+}, {
+	url:       "wordpress",
+	channel:   mongodoc.DevelopmentChannel,
+	expectURL: "cs:precise/wordpress-1",
+}, {
+	url:       "wordpress",
+	channel:   mongodoc.UnpublishedChannel,
+	expectURL: "cs:precise/wordpress-2",
+}, {
+	url:       "~charmers/precise/wordpress",
+	channel:   mongodoc.StableChannel,
+	expectURL: "cs:~charmers/precise/wordpress-0",
+}, {
+	url:          "mysql",
+	expectStatus: http.StatusNotFound,
+	expectError: params.Error{
+		Message: `no matching charm or bundle for "cs:mysql"`,
+		Code:    params.ErrNotFound,
+	},
+}, {
+	url:          "mysql",
+	channel:      "unknown",
+	expectStatus: http.StatusBadRequest,
+	expectError: params.Error{
+		Message: `invalid channel "unknown" specified in request`,
+		Code:    params.ErrBadRequest,
+	},
+}}
+
+func (s *APISuite) TestURLChannelResolving(c *gc.C) {
+	s.discharge = dischargeForUser("charmers")
+	for _, add := range urlChannelResolvingEntities {
+		err := s.store.AddCharmWithArchive(add.id, storetesting.NewCharm(nil))
+		c.Assert(err, gc.IsNil)
+		if add.channel != mongodoc.UnpublishedChannel {
+			err = s.store.Publish(add.id, add.channel)
+			c.Assert(err, gc.IsNil)
+		}
+	}
+	for i, test := range urlChannelResolvingTests {
+		path := test.url + "/meta/any"
+		if test.channel != "" {
+			path += "?channel=" + string(test.channel)
+		}
+		c.Logf("test %d: %v", i, test.url)
+		if test.expectError.Message != "" {
+			httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+				Handler:      s.srv,
+				Do:           bakeryDo(nil),
+				URL:          storeURL(path),
+				ExpectStatus: test.expectStatus,
+				ExpectBody:   test.expectError,
+			})
+		} else {
+			httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+				Handler: s.srv,
+				Do:      bakeryDo(nil),
+				URL:     storeURL(path),
+				ExpectBody: params.MetaAnyResponse{
+					Id: charm.MustParseURL(test.expectURL),
+				},
+			})
+		}
+	}
 }
 
 func basicAuthHeader(username, password string) http.Header {
@@ -3055,8 +3148,9 @@ func (s *APISuite) TestPromulgate(c *gc.C) {
 		}
 		s.idM.groups = test.groups
 		p := httptesting.JSONCallParams{
-			Handler:      s.srv,
-			URL:          storeURL(test.id + "/promulgate"),
+			Handler: s.srv,
+			// TODO avoid using channel=unpublished here
+			URL:          storeURL(test.id + "/promulgate?channel=unpublished"),
 			Method:       test.method,
 			Body:         test.body,
 			Header:       http.Header{"Content-Type": {"application/json"}},
@@ -3106,7 +3200,7 @@ func (s *APISuite) TestPromulgate(c *gc.C) {
 func (s *APISuite) TestEndpointRequiringBaseEntityWithPromulgatedId(c *gc.C) {
 	// Add a promulgated charm.
 	url := newResolvedURL("~charmers/precise/wordpress-23", 23)
-	s.addPublicCharm(c, "wordpress", url)
+	s.addPublicCharmFromRepo(c, "wordpress", url)
 
 	// Unpromulgate the base entity
 	err := s.store.SetPromulgated(url, false)
@@ -3248,5 +3342,3 @@ func entityACLs(store *charmstore.Store, url *router.ResolvedURL) (mongodoc.ACL,
 	}
 	return be.ChannelACLs[ch], nil
 }
-
-var _ entitycache.Store = v5.ChannelStore{}

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -213,8 +213,9 @@ var readAuthorizationTests = []struct {
 	// groups holds group names the user is member of, as returned by the
 	// discharger.
 	groups []string
-	// readPerm stores a list of users with read permissions.
-	readPerm []string
+	// unpublishedReadPerm stores a list of users with read permissions on
+	// on the unpublished entities.
+	unpublishedReadPerm []string
 	// developmentReadPerm stores a list of users with read permissions on the development channel.
 	developmentReadPerm []string
 	// stableReadPerm stores a list of users with read permissions on the stable channel.
@@ -228,24 +229,24 @@ var readAuthorizationTests = []struct {
 	// the body is not checked and the response is assumed to be ok.
 	expectBody interface{}
 }{{
-	about:    "anonymous users are authorized",
-	readPerm: []string{params.Everyone},
+	about:               "anonymous users are authorized",
+	unpublishedReadPerm: []string{params.Everyone},
 }, {
-	about:    "everyone is authorized",
-	username: "dalek",
-	readPerm: []string{params.Everyone},
+	about:               "everyone is authorized",
+	username:            "dalek",
+	unpublishedReadPerm: []string{params.Everyone},
 }, {
-	about:    "everyone and a specific user",
-	username: "dalek",
-	readPerm: []string{params.Everyone, "janeway"},
+	about:               "everyone and a specific user",
+	username:            "dalek",
+	unpublishedReadPerm: []string{params.Everyone, "janeway"},
 }, {
-	about:    "specific user authorized",
-	username: "who",
-	readPerm: []string{"who"},
+	about:               "specific user authorized",
+	username:            "who",
+	unpublishedReadPerm: []string{"who"},
 }, {
-	about:    "multiple specific users authorized",
-	username: "picard",
-	readPerm: []string{"kirk", "picard", "sisko"},
+	about:               "multiple specific users authorized",
+	username:            "picard",
+	unpublishedReadPerm: []string{"kirk", "picard", "sisko"},
 }, {
 	about:        "nobody authorized",
 	username:     "picard",
@@ -255,34 +256,34 @@ var readAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "picard"`,
 	},
 }, {
-	about:        "access denied for user",
-	username:     "kirk",
-	readPerm:     []string{"picard", "sisko"},
-	expectStatus: http.StatusUnauthorized,
+	about:               "access denied for user",
+	username:            "kirk",
+	unpublishedReadPerm: []string{"picard", "sisko"},
+	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:    "everyone is authorized (user is member of groups)",
-	username: "dalek",
-	groups:   []string{"group1", "group2"},
-	readPerm: []string{params.Everyone},
+	about:               "everyone is authorized (user is member of groups)",
+	username:            "dalek",
+	groups:              []string{"group1", "group2"},
+	unpublishedReadPerm: []string{params.Everyone},
 }, {
-	about:    "everyone and a specific group",
-	username: "dalek",
-	groups:   []string{"group2", "group3"},
-	readPerm: []string{params.Everyone, "group1"},
+	about:               "everyone and a specific group",
+	username:            "dalek",
+	groups:              []string{"group2", "group3"},
+	unpublishedReadPerm: []string{params.Everyone, "group1"},
 }, {
-	about:    "specific group authorized",
-	username: "who",
-	groups:   []string{"group1", "group42", "group2"},
-	readPerm: []string{"group42"},
+	about:               "specific group authorized",
+	username:            "who",
+	groups:              []string{"group1", "group42", "group2"},
+	unpublishedReadPerm: []string{"group42"},
 }, {
-	about:    "multiple specific groups authorized",
-	username: "picard",
-	groups:   []string{"group2"},
-	readPerm: []string{"kirk", "group0", "group2"},
+	about:               "multiple specific groups authorized",
+	username:            "picard",
+	groups:              []string{"group2"},
+	unpublishedReadPerm: []string{"kirk", "group0", "group2"},
 }, {
 	about:        "no group authorized",
 	username:     "picard",
@@ -293,11 +294,11 @@ var readAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "picard"`,
 	},
 }, {
-	about:        "access denied for group",
-	username:     "kirk",
-	groups:       []string{"group1", "group2", "group3"},
-	readPerm:     []string{"picard", "sisko", "group42", "group47"},
-	expectStatus: http.StatusUnauthorized,
+	about:               "access denied for group",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
+	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
 		Message: `unauthorized: access denied for user "kirk"`,
@@ -306,14 +307,14 @@ var readAuthorizationTests = []struct {
 	about:               "access provided through development channel",
 	username:            "kirk",
 	groups:              []string{"group1", "group2", "group3"},
-	readPerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group1"},
 	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel},
 }, {
 	about:               "access provided through development channel, but charm not published",
 	username:            "kirk",
 	groups:              []string{"group1", "group2", "group3"},
-	readPerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group1"},
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -324,7 +325,7 @@ var readAuthorizationTests = []struct {
 	about:               "access provided through stable channel",
 	username:            "kirk",
 	groups:              []string{"group1", "group2", "group3"},
-	readPerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group12"},
 	stableReadPerm:      []string{"group2"},
 	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel, mongodoc.StableChannel},
@@ -332,7 +333,7 @@ var readAuthorizationTests = []struct {
 	about:               "access provided through stable channel, but charm not published",
 	username:            "kirk",
 	groups:              []string{"group1", "group2", "group3"},
-	readPerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group12"},
 	stableReadPerm:      []string{"group2"},
 	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel},
@@ -345,7 +346,7 @@ var readAuthorizationTests = []struct {
 	about:               "access provided through development channel, but charm on stable channel",
 	username:            "kirk",
 	groups:              []string{"group1", "group2", "group3"},
-	readPerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group1"},
 	stableReadPerm:      []string{"group11"},
 	channels: []mongodoc.Channel{
@@ -358,11 +359,11 @@ var readAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:          "access provided through unpublished ACL, but charm on stable channel",
-	username:       "kirk",
-	groups:         []string{"group1", "group2", "group3"},
-	readPerm:       []string{"picard", "sisko", "group42", "group1"},
-	stableReadPerm: []string{"group11"},
+	about:               "access provided through unpublished ACL, but charm on stable channel",
+	username:            "kirk",
+	groups:              []string{"group1", "group2", "group3"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group1"},
+	stableReadPerm:      []string{"group11"},
 	channels: []mongodoc.Channel{
 		mongodoc.DevelopmentChannel,
 		mongodoc.StableChannel,
@@ -376,7 +377,7 @@ var readAuthorizationTests = []struct {
 	about:               "access provided through unpublished ACL, but charm on development channel",
 	username:            "kirk",
 	groups:              []string{"group1", "group2", "group3"},
-	readPerm:            []string{"picard", "sisko", "group42", "group1"},
+	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group1"},
 	developmentReadPerm: []string{"group11"},
 	channels: []mongodoc.Channel{
 		mongodoc.DevelopmentChannel,
@@ -417,7 +418,7 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		}
 
 		// Change the ACLs for the testing charm.
-		err = s.store.SetPerms(&rurl.URL, "unpublished.read", test.readPerm...)
+		err = s.store.SetPerms(&rurl.URL, "unpublished.read", test.unpublishedReadPerm...)
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&rurl.URL, "development.read", test.developmentReadPerm...)
 		c.Assert(err, gc.IsNil)
@@ -425,7 +426,7 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 
 		// Define an helper function used to send requests and check responses.
-		makeRequest := func(path string, expectStatus int, expectBody interface{}) {
+		doRequest := func(path string, expectStatus int, expectBody interface{}) {
 			rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 				Handler: s.srv,
 				Do:      bakeryDo(nil),
@@ -441,8 +442,10 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		}
 
 		// Perform meta and id requests.
-		makeRequest("~charmers/wordpress/meta/archive-size", test.expectStatus, test.expectBody)
-		makeRequest("~charmers/wordpress/expand-id", test.expectStatus, test.expectBody)
+		// Note that we use the full URL so that we test authorization specifically
+		// on that entity without trying to look up the entity in the stable channel.
+		doRequest("~charmers/utopic/wordpress-42/meta/archive-size", test.expectStatus, test.expectBody)
+		doRequest("~charmers/utopic/wordpress-42/expand-id", test.expectStatus, test.expectBody)
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
@@ -460,7 +463,7 @@ var writeAuthorizationTests = []struct {
 	// discharger.
 	groups []string
 	// writePerm stores a list of users with write permissions.
-	writePerm []string
+	unpublishedWritePerm []string
 	// developmentWritePerm stores a list of users with write permissions on the development channel.
 	developmentWritePerm []string
 	// stableWritePerm stores a list of users with write permissions on the stable channel.
@@ -474,21 +477,21 @@ var writeAuthorizationTests = []struct {
 	// the body is not checked and the response is assumed to be ok.
 	expectBody interface{}
 }{{
-	about:        "anonymous users are not authorized",
-	writePerm:    []string{"who"},
-	expectStatus: http.StatusUnauthorized,
+	about:                "anonymous users are not authorized",
+	unpublishedWritePerm: []string{"who"},
+	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
 		Message: "unauthorized: no username declared",
 	},
 }, {
-	about:     "specific user authorized to write",
-	username:  "dalek",
-	writePerm: []string{"dalek"},
+	about:                "specific user authorized to write",
+	username:             "dalek",
+	unpublishedWritePerm: []string{"dalek"},
 }, {
-	about:     "multiple users authorized",
-	username:  "sisko",
-	writePerm: []string{"kirk", "picard", "sisko"},
+	about:                "multiple users authorized",
+	username:             "sisko",
+	unpublishedWritePerm: []string{"kirk", "picard", "sisko"},
 }, {
 	about:        "no users authorized",
 	username:     "who",
@@ -498,24 +501,24 @@ var writeAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "who"`,
 	},
 }, {
-	about:        "specific user unauthorized",
-	username:     "kirk",
-	writePerm:    []string{"picard", "sisko", "janeway"},
-	expectStatus: http.StatusUnauthorized,
+	about:                "specific user unauthorized",
+	username:             "kirk",
+	unpublishedWritePerm: []string{"picard", "sisko", "janeway"},
+	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:     "access granted for group",
-	username:  "picard",
-	groups:    []string{"group1", "group2"},
-	writePerm: []string{"group2"},
+	about:                "access granted for group",
+	username:             "picard",
+	groups:               []string{"group1", "group2"},
+	unpublishedWritePerm: []string{"group2"},
 }, {
-	about:     "multiple groups authorized",
-	username:  "picard",
-	groups:    []string{"group1", "group2"},
-	writePerm: []string{"kirk", "group0", "group1", "group2"},
+	about:                "multiple groups authorized",
+	username:             "picard",
+	groups:               []string{"group1", "group2"},
+	unpublishedWritePerm: []string{"kirk", "group0", "group1", "group2"},
 }, {
 	about:        "no group authorized",
 	username:     "picard",
@@ -526,11 +529,11 @@ var writeAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "picard"`,
 	},
 }, {
-	about:        "access denied for group",
-	username:     "kirk",
-	groups:       []string{"group1", "group2", "group3"},
-	writePerm:    []string{"picard", "sisko", "group42", "group47"},
-	expectStatus: http.StatusUnauthorized,
+	about:                "access denied for group",
+	username:             "kirk",
+	groups:               []string{"group1", "group2", "group3"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
+	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
 		Message: `unauthorized: access denied for user "kirk"`,
@@ -539,14 +542,14 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through development channel",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
 	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel},
 }, {
 	about:                "access provided through development channel, but charm not published",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -557,7 +560,7 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through stable channel",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group12"},
 	stableWritePerm:      []string{"group2"},
 	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel, mongodoc.StableChannel},
@@ -565,7 +568,7 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through stable channel, but charm not published",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group12"},
 	stableWritePerm:      []string{"group2"},
 	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel},
@@ -578,7 +581,7 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through development channel, but charm on stable channel",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group47"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
 	stableWritePerm:      []string{"group11"},
 	channels: []mongodoc.Channel{
@@ -591,11 +594,11 @@ var writeAuthorizationTests = []struct {
 		Message: `unauthorized: access denied for user "kirk"`,
 	},
 }, {
-	about:           "access provided through unpublished ACL, but charm on stable channel",
-	username:        "kirk",
-	groups:          []string{"group1", "group2", "group3"},
-	writePerm:       []string{"picard", "sisko", "group42", "group1"},
-	stableWritePerm: []string{"group11"},
+	about:                "access provided through unpublished ACL, but charm on stable channel",
+	username:             "kirk",
+	groups:               []string{"group1", "group2", "group3"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group1"},
+	stableWritePerm:      []string{"group11"},
 	channels: []mongodoc.Channel{
 		mongodoc.DevelopmentChannel,
 		mongodoc.StableChannel,
@@ -609,7 +612,7 @@ var writeAuthorizationTests = []struct {
 	about:                "access provided through unpublished ACL, but charm on development channel",
 	username:             "kirk",
 	groups:               []string{"group1", "group2", "group3"},
-	writePerm:            []string{"picard", "sisko", "group42", "group1"},
+	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group1"},
 	developmentWritePerm: []string{"group11"},
 	channels: []mongodoc.Channel{
 		mongodoc.DevelopmentChannel,
@@ -642,7 +645,7 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 		}
 
 		// Change the ACLs for the testing charm.
-		err = s.store.SetPerms(&rurl.URL, "unpublished.write", test.writePerm...)
+		err = s.store.SetPerms(&rurl.URL, "unpublished.write", test.unpublishedWritePerm...)
 		c.Assert(err, gc.IsNil)
 		err = s.store.SetPerms(&rurl.URL, "development.write", test.developmentWritePerm...)
 		c.Assert(err, gc.IsNil)
@@ -669,7 +672,9 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 		}
 
 		// Perform a meta PUT request to the URLs.
-		makeRequest("~charmers/wordpress/meta/extra-info/key", test.expectStatus, test.expectBody)
+		// Note that we use the full URL so that we test authorization specifically
+		// on that entity without trying to look up the entity in the stable channel.
+		makeRequest("~charmers/utopic/wordpress-42/meta/extra-info/key", test.expectStatus, test.expectBody)
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
@@ -906,16 +911,11 @@ func (s *authSuite) TestIsEntityCaveat(c *gc.C) {
 	}
 
 	// Add a charm to the store, used for testing.
-	err := s.store.AddCharmWithArchive(
-		newResolvedURL("~charmers/utopic/wordpress-41", 9),
-		storetesting.Charms.CharmDir("wordpress"))
-	c.Assert(err, gc.IsNil)
-	err = s.store.AddCharmWithArchive(
-		newResolvedURL("~charmers/utopic/wordpress-42", 10),
-		storetesting.Charms.CharmDir("wordpress"))
-	c.Assert(err, gc.IsNil)
-	// Change the ACLs for the testing charm.
-	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "unpublished.read", "bob")
+	s.addPublicCharm(c, storetesting.NewCharm(nil), newResolvedURL("~charmers/utopic/wordpress-41", 9))
+	s.addPublicCharm(c, storetesting.NewCharm(nil), newResolvedURL("~charmers/utopic/wordpress-42", 10))
+	// Change the ACLs for charms we've just uploaded, otherwise
+	// no authorization checking will take place.
+	err := s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")
 	c.Assert(err, gc.IsNil)
 
 	for i, test := range isEntityCaveatTests {
@@ -1000,12 +1000,15 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 	// Now check that we can use the obtained macaroon to do stuff
 	// as the declared user.
 
+	rurl := newResolvedURL("~charmers/utopic/wordpress-41", 9)
 	err = s.store.AddCharmWithArchive(
-		newResolvedURL("~charmers/utopic/wordpress-41", 9),
+		rurl,
 		storetesting.Charms.CharmDir("wordpress"))
 	c.Assert(err, gc.IsNil)
+	err = s.store.Publish(rurl, mongodoc.StableChannel)
+	c.Assert(err, gc.IsNil)
 	// Change the ACLs for the testing charm.
-	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "unpublished.read", "bob")
+	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")
 	c.Assert(err, gc.IsNil)
 
 	// First check that we require authorization to access the charm.

--- a/internal/v5/bench_test.go
+++ b/internal/v5/bench_test.go
@@ -19,7 +19,7 @@ type BenchmarkSuite struct {
 var _ = gc.Suite(&BenchmarkSuite{})
 
 func (s *BenchmarkSuite) TestBenchmarkMeta(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
 	srv := httptest.NewServer(s.srv)
 	defer srv.Close()
 	url := srv.URL + storeURL("wordpress/meta/archive-size")
@@ -35,7 +35,7 @@ func (s *BenchmarkSuite) TestBenchmarkMeta(c *gc.C) {
 }
 
 func (s *BenchmarkSuite) BenchmarkMeta(c *gc.C) {
-	s.addPublicCharm(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
+	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-23", 23))
 	srv := httptest.NewServer(s.srv)
 	defer srv.Close()
 	url := srv.URL + storeURL("wordpress/meta/archive-size")

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -210,8 +210,11 @@ func (s *commonSuite) startServer(c *gc.C) {
 	s.store = s.srv.Pool().Store()
 }
 
-func (s *commonSuite) addPublicCharm(c *gc.C, charmName string, rurl *router.ResolvedURL) (*router.ResolvedURL, charm.Charm) {
-	ch := storetesting.Charms.CharmDir(charmName)
+func (s *commonSuite) addPublicCharmFromRepo(c *gc.C, charmName string, rurl *router.ResolvedURL) (*router.ResolvedURL, charm.Charm) {
+	return s.addPublicCharm(c, storetesting.Charms.CharmDir(charmName), rurl)
+}
+
+func (s *commonSuite) addPublicCharm(c *gc.C, ch charm.Charm, rurl *router.ResolvedURL) (*router.ResolvedURL, charm.Charm) {
 	err := s.store.AddCharmWithArchive(rurl, ch)
 	c.Assert(err, gc.IsNil)
 	s.setPublic(c, rurl)
@@ -225,8 +228,11 @@ func (s *commonSuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	c.Assert(err, gc.IsNil)
 }
 
-func (s *commonSuite) addPublicBundle(c *gc.C, bundleName string, rurl *router.ResolvedURL, addRequiredCharms bool) (*router.ResolvedURL, charm.Bundle) {
-	bundle := storetesting.Charms.BundleDir(bundleName)
+func (s *commonSuite) addPublicBundleFromRepo(c *gc.C, bundleName string, rurl *router.ResolvedURL, addRequiredCharms bool) (*router.ResolvedURL, charm.Bundle) {
+	return s.addPublicBundle(c, storetesting.Charms.BundleDir(bundleName), rurl, addRequiredCharms)
+}
+
+func (s *commonSuite) addPublicBundle(c *gc.C, bundle charm.Bundle, rurl *router.ResolvedURL, addRequiredCharms bool) (*router.ResolvedURL, charm.Bundle) {
 	if addRequiredCharms {
 		s.addRequiredCharms(c, bundle)
 	}
@@ -240,20 +246,16 @@ func (s *commonSuite) addPublicBundle(c *gc.C, bundleName string, rurl *router.R
 // map key is the id of the charm.
 func (s *commonSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
 	for id, ch := range charms {
-		url := mustParseResolvedURL(id)
-		err := s.store.AddCharmWithArchive(url, storetesting.NewCharm(ch.Meta()))
-		c.Assert(err, gc.IsNil, gc.Commentf("id %q", id))
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, storetesting.NewCharm(ch.Meta()), mustParseResolvedURL(id))
 	}
 }
 
-// setPerms sets the read permissions of a set of entities.
-// The map key is the is the id of each entity; its
-// associated value is its read ACL.
+// setPerms sets the stable channel read permissions of a set of
+// entities. The map key is the is the id of each entity; its associated
+// value is its read ACL.
 func (s *commonSuite) setPerms(c *gc.C, readACLs map[string][]string) {
 	for url, acl := range readACLs {
-		err := s.store.SetPerms(charm.MustParseURL(url), "unpublished.read", acl...)
+		err := s.store.SetPerms(charm.MustParseURL(url), "stable.read", acl...)
 		c.Assert(err, gc.IsNil)
 	}
 }
@@ -264,7 +266,7 @@ func (s *commonSuite) setPerms(c *gc.C, readACLs map[string][]string) {
 func (s *commonSuite) handler(c *gc.C) *v5.ReqHandler {
 	h := v5.New(s.store.Pool(), s.srvParams, "")
 	defer h.Close()
-	rh, err := h.NewReqHandler()
+	rh, err := h.NewReqHandler(new(http.Request))
 	c.Assert(err, gc.IsNil)
 	// It would be nice if we could call s.AddCleanup here
 	// to call rh.Put when the test has completed, but
@@ -325,9 +327,7 @@ func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
 			rurl.PromulgatedRevision = -1
 		}
 		c.Logf("adding charm %v %d required by bundle to fulfil %v", &rurl.URL, rurl.PromulgatedRevision, svc.Charm)
-		err = s.store.AddCharmWithArchive(&rurl, ch)
-		c.Assert(err, gc.IsNil, gc.Commentf("url: %#v", &rurl))
-		s.setPublic(c, &rurl)
+		s.addPublicCharm(c, ch, &rurl)
 	}
 }
 

--- a/internal/v5/content_test.go
+++ b/internal/v5/content_test.go
@@ -49,9 +49,9 @@ var serveDiagramErrorsTests = []struct {
 
 func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/trusty/wordpress-42", 42)
-	s.addPublicCharm(c, "wordpress", id)
+	s.addPublicCharmFromRepo(c, "wordpress", id)
 	id = newResolvedURL("cs:~charmers/bundle/nopositionbundle-42", 42)
-	s.addPublicBundle(c, "wordpress-simple", id, true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", id, true)
 
 	for i, test := range serveDiagramErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -89,8 +89,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	s.addRequiredCharms(c, bundle)
 	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -152,8 +151,7 @@ func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 	s.addRequiredCharms(c, bundle)
 	err := s.store.AddBundleWithArchive(url, bundle)
 	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -208,10 +206,7 @@ func (s *APISuite) TestServeReadMe(c *gc.C) {
 		}
 
 		url.URL.Revision = i
-		err := s.store.AddCharmWithArchive(url, wordpress)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, wordpress, url)
 
 		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 			Handler: s.srv,
@@ -246,8 +241,7 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 	url := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
 	err := s.store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -278,6 +272,7 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 	url.URL.Revision++
 	err = s.store.AddCharmWithArchive(url, wordpress)
 	c.Assert(err, gc.IsNil)
+	s.setPublic(c, url)
 
 	// Check that we still get expected svg.
 	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -290,7 +285,7 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 }
 
 func (s *APISuite) TestServeBundleIcon(c *gc.C) {
-	s.addPublicBundle(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/something-32", 32), true)
+	s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/something-32", 32), true)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
@@ -307,10 +302,7 @@ func (s *APISuite) TestServeDefaultIcon(c *gc.C) {
 	wordpress := storetesting.Charms.ClonedDir(c.MkDir(), "wordpress")
 
 	url := newResolvedURL("cs:~charmers/precise/wordpress-0", 0)
-	err := s.store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, wordpress, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -335,10 +327,7 @@ func (s *APISuite) TestServeDefaultIconForBadXML(c *gc.C) {
 
 		url := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
 		url.URL.Revision = i
-		err := s.store.AddCharmWithArchive(url, wordpress)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, wordpress, url)
 
 		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 			Handler: s.srv,

--- a/internal/v5/list_test.go
+++ b/internal/v5/list_test.go
@@ -20,7 +20,6 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 )
@@ -57,24 +56,10 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 
 func (s *ListSuite) addCharmsToStore(c *gc.C) {
 	for name, id := range exportListTestCharms {
-		err := s.store.AddCharmWithArchive(id, getListCharm(name))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&id.URL, "unpublished.read", params.Everyone, id.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&id.URL, "stable.read", params.Everyone, id.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.Publish(id, mongodoc.StableChannel)
-		c.Assert(err, gc.IsNil)
+		s.addPublicCharm(c, getListCharm(name), id)
 	}
 	for name, id := range exportListTestBundles {
-		err := s.store.AddBundleWithArchive(id, getListBundle(name))
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&id.URL, "unpublished.read", params.Everyone, id.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&id.URL, "stable.read", params.Everyone, id.URL.User)
-		c.Assert(err, gc.IsNil)
-		err = s.store.Publish(id, mongodoc.StableChannel)
-		c.Assert(err, gc.IsNil)
+		s.addPublicBundle(c, getListBundle(name), id, false)
 	}
 }
 
@@ -405,9 +390,7 @@ func (s *ListSuite) TestSortUnsupportedListField(c *gc.C) {
 
 func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/precise/wordpress-24", 24)
-	err := s.store.AddCharmWithArchive(id, getListCharm("wordpress"))
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&id.URL, "unpublished.read", params.Everyone, id.URL.User)
+	s.addPublicCharm(c, getListCharm("wordpress"), id)
 
 	testresults := []*router.ResolvedURL{
 		exportTestBundles["wordpress-simple"],
@@ -421,7 +404,7 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 		URL:     storeURL("list"),
 	})
 	var sr params.ListResponse
-	err = json.Unmarshal(rec.Body.Bytes(), &sr)
+	err := json.Unmarshal(rec.Body.Bytes(), &sr)
 	c.Assert(err, gc.IsNil)
 	c.Assert(sr.Results, gc.HasLen, 4, gc.Commentf("expected %#v", testresults))
 	c.Logf("results: %s", rec.Body.Bytes())

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -583,17 +583,12 @@ var metaBundlesContainingTests = []struct {
 func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 	// Add the bundles used for testing to the database.
 	for id, b := range metaBundlesContainingBundles {
-		url := mustParseResolvedURL(id)
-		s.addRequiredCharms(c, b)
-		err := s.store.AddBundleWithArchive(url, b)
-		c.Assert(err, gc.IsNil)
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
+		s.addPublicBundle(c, b, mustParseResolvedURL(id), true)
 	}
 	for i, test := range metaBundlesContainingTests {
 		c.Logf("test %d: %s", i, test.about)
 		if test.addCharm != nil {
-			s.addPublicCharm(c, "wordpress", test.addCharm)
+			s.addPublicCharmFromRepo(c, "wordpress", test.addCharm)
 		}
 		// Perform the request and ensure the response is what we expect.
 		storeURL := storeURL(test.id + "/meta/bundles-containing" + test.querystring)
@@ -614,17 +609,12 @@ func (s *RelationsSuite) TestMetaBundlesContainingBundleACL(c *gc.C) {
 	// Add the bundles used for testing to the database.
 	for id, b := range metaBundlesContainingBundles {
 		url := mustParseResolvedURL(id)
-		s.addRequiredCharms(c, b)
-		err := s.store.AddBundleWithArchive(url, storetesting.NewBundle(b.Data()))
-		c.Assert(err, gc.IsNil)
+		s.addPublicBundle(c, storetesting.NewBundle(b.Data()), url, true)
 		if url.URL.Name == "useless" {
 			// The useless bundle is not available for "everyone".
-			err = s.store.SetPerms(&url.URL, "unpublished.read", url.URL.User)
+			err := s.store.SetPerms(&url.URL, "stable.read", url.URL.User)
 			c.Assert(err, gc.IsNil)
-			continue
 		}
-		err = s.store.SetPerms(&url.URL, "unpublished.read", params.Everyone, url.URL.User)
-		c.Assert(err, gc.IsNil)
 	}
 
 	// Perform the request and ensure that the useless bundle isn't listed.

--- a/internal/v5/stats_test.go
+++ b/internal/v5/stats_test.go
@@ -129,17 +129,13 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 		previousMonth: true,
 	}}
 
-	ch := storetesting.Charms.CharmDir("wordpress")
-	rurl := newResolvedURL("~charmers/precise/wordpress-23", 23)
-	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "unpublished.read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, storetesting.Charms.CharmDir("wordpress"), newResolvedURL("~charmers/precise/wordpress-23", 23))
 
 	var countsBefore, countsAfter charmstore.AggregatedCounts
 	for i, test := range tests {
 		c.Logf("test %d. %s", i, test.path)
 
+		var err error
 		_, countsBefore, err = s.store.ArchiveDownloadCounts(ref, true)
 		c.Assert(err, gc.IsNil)
 
@@ -169,12 +165,8 @@ func (s *StatsSuite) TestServerStatsArchiveDownloadOnPromulgatedEntity(c *gc.C) 
 	ref := charm.MustParseURL("~charmers/precise/wordpress-23")
 	path := "/stats/counter/archive-download:*"
 
-	ch := storetesting.Charms.CharmDir("wordpress")
 	rurl := newResolvedURL("~charmers/precise/wordpress-23", 23)
-	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "unpublished.read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, storetesting.Charms.CharmDir("wordpress"), rurl)
 	s.store.SetPromulgated(rurl, true)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -244,17 +236,13 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 		partialUpdate: true,
 	}}
 
-	ch := storetesting.Charms.CharmDir("wordpress")
-	rurl := newResolvedURL("~charmers/precise/wordpress-23", 23)
-	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "unpublished.read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, storetesting.Charms.CharmDir("wordpress"), newResolvedURL("~charmers/precise/wordpress-23", 23))
 
 	for i, test := range tests {
 		c.Logf("test %d. %s", i, test.path)
-		var countsBefore, countsAfter charmstore.AggregatedCounts
+		var countsBefore charmstore.AggregatedCounts
 		if test.partialUpdate {
+			var err error
 			_, countsBefore, err = s.store.ArchiveDownloadCounts(ref, true)
 			c.Assert(err, gc.IsNil)
 		}
@@ -272,7 +260,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 			},
 		})
 		if test.partialUpdate {
-			_, countsAfter, err = s.store.ArchiveDownloadCounts(ref, true)
+			_, countsAfter, err := s.store.ArchiveDownloadCounts(ref, true)
 			c.Assert(err, gc.IsNil)
 			c.Assert(countsAfter.Total-countsBefore.Total, gc.Equals, int64(1))
 			c.Assert(countsAfter.LastDay-countsBefore.LastDay, gc.Equals, int64(1))
@@ -315,12 +303,7 @@ func (s *StatsSuite) TestServerStatsUpdateNotPartOfStatsUpdateGroup(c *gc.C) {
 }
 
 func (s *StatsSuite) TestServerStatsUpdatePartOfStatsUpdateGroup(c *gc.C) {
-	ch := storetesting.Charms.CharmDir("wordpress")
-	rurl := newResolvedURL("~charmers/precise/wordpress-23", 23)
-	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
-	err = s.store.SetPerms(&rurl.URL, "unpublished.read", params.Everyone, rurl.URL.User)
-	c.Assert(err, gc.IsNil)
+	s.addPublicCharm(c, storetesting.Charms.CharmDir("wordpress"), newResolvedURL("~charmers/precise/wordpress-23", 23))
 
 	s.discharge = dischargeForUser("statsupdate")
 	s.idM.groups = map[string][]string{

--- a/internal/v5/status_test.go
+++ b/internal/v5/status_test.go
@@ -31,9 +31,9 @@ func (s *APISuite) TestStatus(c *gc.C) {
 		newResolvedURL("cs:~bar/bundle/wordpress-simple-4", -1),
 	} {
 		if id.URL.Series == "bundle" {
-			s.addPublicBundle(c, id.URL.Name, id, false)
+			s.addPublicBundleFromRepo(c, id.URL.Name, id, false)
 		} else {
-			s.addPublicCharm(c, id.URL.Name, id)
+			s.addPublicCharmFromRepo(c, id.URL.Name, id)
 		}
 	}
 	now := time.Now()


### PR DESCRIPTION
Many of the tests were failing because they did not use the standard addPublicCharm
helper method, so we change them all to use addPublicCharm when possible.
