### PR TITLE
internal/v5: use request channel to determine ACLs

### DIFF
--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -502,6 +502,19 @@ func (s *Store) FindBestEntity(url *charm.URL, channel mongodoc.Channel, fields 
 		} else if err != nil {
 			return nil, errgo.Mask(err)
 		}
+		// If a channel was specified make sure the entity is in that channel.
+		// This is crucial because if we don't do this, then the user could choose
+		// to use any chosen set of ACLs against any entity.
+		switch channel {
+		case mongodoc.StableChannel:
+			if !entity.Stable {
+				return nil, errgo.WithCausef(nil, params.ErrNotFound, "%s not found in stable channel", url)
+			}
+		case mongodoc.DevelopmentChannel:
+			if !entity.Development {
+				return nil, errgo.WithCausef(nil, params.ErrNotFound, "%s not found in development channel", url)
+			}
+		}
 		return entity, nil
 	}
 

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -1537,13 +1537,15 @@ var findBestEntityTests = []struct {
 	channel:  mongodoc.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
-	url:      "~charmers/trusty/wordpress-3",
-	channel:  mongodoc.DevelopmentChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
+	url:              "~charmers/trusty/wordpress-3",
+	channel:          mongodoc.DevelopmentChannel,
+	expectError:      "cs:~charmers/trusty/wordpress-3 not found in development channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
-	url:      "~charmers/trusty/wordpress-2",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-2", 2),
+	url:              "~charmers/trusty/wordpress-2",
+	channel:          mongodoc.StableChannel,
+	expectError:      "cs:~charmers/trusty/wordpress-2 not found in stable channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "trusty/wordpress-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-0", 0),
@@ -1567,13 +1569,15 @@ var findBestEntityTests = []struct {
 	channel:  mongodoc.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
-	url:      "trusty/wordpress-3",
-	channel:  mongodoc.DevelopmentChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
+	url:              "trusty/wordpress-3",
+	channel:          mongodoc.DevelopmentChannel,
+	expectError:      "cs:trusty/wordpress-3 not found in development channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
-	url:      "trusty/wordpress-2",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-2", 2),
+	url:              "trusty/wordpress-2",
+	channel:          mongodoc.StableChannel,
+	expectError:      "cs:trusty/wordpress-2 not found in stable channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "~charmers/trusty/wordpress",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-1", 1),
@@ -1691,13 +1695,15 @@ var findBestEntityTests = []struct {
 	channel:  mongodoc.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
-	url:      "~charmers/mysql-3",
-	channel:  mongodoc.DevelopmentChannel,
-	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
+	url:              "~charmers/mysql-3",
+	channel:          mongodoc.DevelopmentChannel,
+	expectError:      "cs:~charmers/mysql-3 not found in development channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
-	url:      "~charmers/mysql-2",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/mysql-2", 2),
+	url:              "~charmers/mysql-2",
+	channel:          mongodoc.StableChannel,
+	expectError:      "cs:~charmers/mysql-2 not found in stable channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "mysql-0",
 	expectID: findBestEntityCharms[8].id,
@@ -1721,13 +1727,15 @@ var findBestEntityTests = []struct {
 	channel:  mongodoc.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
-	url:      "mysql-3",
-	channel:  mongodoc.DevelopmentChannel,
-	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
+	url:              "mysql-3",
+	channel:          mongodoc.DevelopmentChannel,
+	expectError:      "cs:mysql-3 not found in development channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
-	url:      "mysql-2",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/mysql-2", 2),
+	url:              "mysql-2",
+	channel:          mongodoc.StableChannel,
+	expectError:      "cs:mysql-2 not found in stable channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "~charmers/mysql",
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
@@ -1841,13 +1849,15 @@ var findBestEntityTests = []struct {
 	channel:  mongodoc.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-3", -1),
 }, {
-	url:      "~charmers/trusty/mongodb-3",
-	channel:  mongodoc.DevelopmentChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-3", -1),
+	url:              "~charmers/trusty/mongodb-3",
+	channel:          mongodoc.DevelopmentChannel,
+	expectError:      "cs:~charmers/trusty/mongodb-3 not found in development channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
-	url:      "~charmers/trusty/mongodb-2",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-2", -1),
+	url:              "~charmers/trusty/mongodb-2",
+	channel:          mongodoc.StableChannel,
+	expectError:      "cs:~charmers/trusty/mongodb-2 not found in stable channel",
+	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/mongodb-0",
 	expectError:      "no matching charm or bundle for cs:trusty/mongodb-0",
@@ -1941,9 +1951,9 @@ var findBestEntityTests = []struct {
 	url:      "~charmers/trusty/apache-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
-	url:      "~charmers/trusty/apache-0",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
+	url:         "~charmers/trusty/apache-0",
+	channel:     mongodoc.StableChannel,
+	expectError: "cs:~charmers/trusty/apache-0 not found in stable channel",
 }, {
 	url:      "~charmers/trusty/apache-0",
 	channel:  mongodoc.DevelopmentChannel,
@@ -1973,9 +1983,9 @@ var findBestEntityTests = []struct {
 	url:      "trusty/apache-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
-	url:      "trusty/apache-0",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
+	url:         "trusty/apache-0",
+	channel:     mongodoc.StableChannel,
+	expectError: "cs:trusty/apache-0 not found in stable channel",
 }, {
 	url:      "trusty/apache-0",
 	channel:  mongodoc.DevelopmentChannel,
@@ -2006,13 +2016,13 @@ var findBestEntityTests = []struct {
 	url:      "~charmers/trusty/nginx-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
 }, {
-	url:      "~charmers/trusty/nginx-0",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
+	url:         "~charmers/trusty/nginx-0",
+	channel:     mongodoc.StableChannel,
+	expectError: "cs:~charmers/trusty/nginx-0 not found in stable channel",
 }, {
-	url:      "~charmers/trusty/nginx-0",
-	channel:  mongodoc.DevelopmentChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
+	url:         "~charmers/trusty/nginx-0",
+	channel:     mongodoc.DevelopmentChannel,
+	expectError: "cs:~charmers/trusty/nginx-0 not found in development channel",
 }, {
 	url:      "~charmers/trusty/nginx-0",
 	channel:  mongodoc.UnpublishedChannel,
@@ -2039,13 +2049,13 @@ var findBestEntityTests = []struct {
 	url:      "trusty/nginx-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
 }, {
-	url:      "trusty/nginx-0",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
+	url:         "trusty/nginx-0",
+	channel:     mongodoc.StableChannel,
+	expectError: "cs:trusty/nginx-0 not found in stable channel",
 }, {
-	url:      "trusty/nginx-0",
-	channel:  mongodoc.DevelopmentChannel,
-	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
+	url:         "trusty/nginx-0",
+	channel:     mongodoc.DevelopmentChannel,
+	expectError: "cs:trusty/nginx-0 not found in development channel",
 }, {
 	url:      "trusty/nginx-0",
 	channel:  mongodoc.UnpublishedChannel,
@@ -2073,13 +2083,13 @@ var findBestEntityTests = []struct {
 	channel:  mongodoc.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
-	url:      "~charmers/bundle/wordpress-simple-3",
-	channel:  mongodoc.DevelopmentChannel,
-	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
+	url:         "~charmers/bundle/wordpress-simple-3",
+	channel:     mongodoc.DevelopmentChannel,
+	expectError: "cs:~charmers/bundle/wordpress-simple-3 not found in development channel",
 }, {
-	url:      "~charmers/bundle/wordpress-simple-2",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 2),
+	url:         "~charmers/bundle/wordpress-simple-3",
+	channel:     mongodoc.StableChannel,
+	expectError: "cs:~charmers/bundle/wordpress-simple-3 not found in stable channel",
 }, {
 	url:      "bundle/wordpress-simple-0",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
@@ -2103,13 +2113,13 @@ var findBestEntityTests = []struct {
 	channel:  mongodoc.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
-	url:      "bundle/wordpress-simple-3",
-	channel:  mongodoc.DevelopmentChannel,
-	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
+	url:         "bundle/wordpress-simple-3",
+	channel:     mongodoc.DevelopmentChannel,
+	expectError: "cs:bundle/wordpress-simple-3 not found in development channel",
 }, {
-	url:      "bundle/wordpress-simple-2",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 2),
+	url:         "bundle/wordpress-simple-2",
+	channel:     mongodoc.StableChannel,
+	expectError: "cs:bundle/wordpress-simple-2 not found in stable channel",
 }, {
 	url:      "~charmers/bundle/wordpress-simple",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
@@ -2393,9 +2403,9 @@ var findBestEntityTests = []struct {
 	url:      "~openstack-charmers/trusty/ceph-0",
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
-	url:      "~openstack-charmers/trusty/ceph-0",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
+	url:         "~openstack-charmers/trusty/ceph-0",
+	channel:     mongodoc.StableChannel,
+	expectError: "cs:~openstack-charmers/trusty/ceph-0 not found in stable channel",
 }, {
 	url:      "~openstack-charmers/trusty/ceph-0",
 	channel:  mongodoc.DevelopmentChannel,
@@ -2440,9 +2450,9 @@ var findBestEntityTests = []struct {
 	url:      "trusty/ceph-1",
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
-	url:      "trusty/ceph-1",
-	channel:  mongodoc.StableChannel,
-	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
+	url:         "trusty/ceph-1",
+	channel:     mongodoc.StableChannel,
+	expectError: "cs:trusty/ceph-1 not found in stable channel",
 }, {
 	url:      "trusty/ceph-1",
 	channel:  mongodoc.DevelopmentChannel,

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -2497,9 +2497,13 @@ var urlChannelResolvingTests = []struct {
 	channel:   mongodoc.StableChannel,
 	expectURL: "cs:~charmers/precise/wordpress-0",
 }, {
-	url:       "~charmers/precise/wordpress-2",
-	channel:   mongodoc.StableChannel,
-	expectURL: "cs:~charmers/precise/wordpress-2",
+	url:          "~charmers/precise/wordpress-2",
+	channel:      mongodoc.StableChannel,
+	expectStatus: http.StatusNotFound,
+	expectError: params.Error{
+		Message: `no matching charm or bundle for "cs:~charmers/precise/wordpress-2"`,
+		Code:    params.ErrNotFound,
+	},
 }, {
 	url:          "mysql",
 	expectStatus: http.StatusNotFound,

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -377,11 +377,11 @@ func resolveURL(cache *entitycache.Cache, url *charm.URL) (*router.ResolvedURL, 
 	// We've added promulgated-url as a required field, so
 	// we'll always get it from the Entity result.
 	entity, err := cache.Entity(url, nil)
-	if err != nil && errgo.Cause(err) != params.ErrNotFound {
+	if err != nil {
+		if errgo.Cause(err) == params.ErrNotFound {
+			return nil, noMatchingURLError(url)
+		}
 		return nil, errgo.Mask(err)
-	}
-	if errgo.Cause(err) == params.ErrNotFound {
-		return nil, noMatchingURLError(url)
 	}
 	rurl := &router.ResolvedURL{
 		URL:                 *entity.URL,
@@ -1009,7 +1009,6 @@ func checkExtraInfoKey(key string, field string) error {
 // GET id/meta/perm
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetaperm
 func (h *ReqHandler) metaPerm(entity *mongodoc.BaseEntity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
-	// TODO select channel based on channel parameter if specified.
 	ch, err := h.entityChannel(id)
 	if err != nil {
 		return nil, errgo.Mask(err)
@@ -1024,7 +1023,6 @@ func (h *ReqHandler) metaPerm(entity *mongodoc.BaseEntity, id *router.ResolvedUR
 // PUT id/meta/perm
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#put-idmeta
 func (h *ReqHandler) putMetaPerm(id *router.ResolvedURL, path string, val *json.RawMessage, updater *router.FieldUpdater, req *http.Request) error {
-	// TODO select channel based on channel parameter if specified.
 	var perms params.PermRequest
 	if err := json.Unmarshal(*val, &perms); err != nil {
 		return errgo.Mask(err)
@@ -1063,7 +1061,6 @@ func (h *ReqHandler) metaPromulgated(entity *mongodoc.BaseEntity, id *router.Res
 // GET id/meta/perm/key
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-idmetapermkey
 func (h *ReqHandler) metaPermWithKey(entity *mongodoc.BaseEntity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
-	// TODO select channel based on channel parameter if specified.
 	ch, err := h.entityChannel(id)
 	if err != nil {
 		return nil, errgo.Mask(err)
@@ -1081,7 +1078,6 @@ func (h *ReqHandler) metaPermWithKey(entity *mongodoc.BaseEntity, id *router.Res
 // PUT id/meta/perm/key
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#put-idmetapermkey
 func (h *ReqHandler) putMetaPermWithKey(id *router.ResolvedURL, path string, val *json.RawMessage, updater *router.FieldUpdater, req *http.Request) error {
-	// TODO select channel based on channel parameter if specified.
 	ch, err := h.entityChannel(id)
 	if err != nil {
 		return errgo.Mask(err)

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -2607,9 +2607,13 @@ var urlChannelResolvingTests = []struct {
 	channel:   mongodoc.StableChannel,
 	expectURL: "cs:~charmers/precise/wordpress-0",
 }, {
-	url:       "~charmers/precise/wordpress-2",
-	channel:   mongodoc.StableChannel,
-	expectURL: "cs:~charmers/precise/wordpress-2",
+	url:          "~charmers/precise/wordpress-2",
+	channel:      mongodoc.StableChannel,
+	expectStatus: http.StatusNotFound,
+	expectError: params.Error{
+		Message: `no matching charm or bundle for "cs:~charmers/precise/wordpress-2"`,
+		Code:    params.ErrNotFound,
+	},
 }, {
 	url:          "mysql",
 	expectStatus: http.StatusNotFound,

--- a/internal/v5/auth.go
+++ b/internal/v5/auth.go
@@ -303,6 +303,9 @@ func (h *ReqHandler) AuthorizeEntity(id *router.ResolvedURL, req *http.Request) 
 }
 
 func (h *ReqHandler) entityChannel(id *router.ResolvedURL) (mongodoc.Channel, error) {
+	if h.Store.Channel != mongodoc.NoChannel {
+		return h.Store.Channel, nil
+	}
 	entity, err := h.Cache.Entity(&id.URL, charmstore.FieldSelector("development", "stable"))
 	if err != nil {
 		if errgo.Cause(err) == params.ErrNotFound {


### PR DESCRIPTION
This changes it from using an ACL calculated from the entity itself.
Clients can now iterate through channels to find one that might work
for them.
