### PR TITLE
Add docs and a collection for resources.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -9,7 +9,7 @@ github.com/juju/httprequest	git	273244b6479b0c06c7bcf342eccefc55f3760653	2015-11
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/names	git	e287fe4ae0dbda220cace3ed0e35cda4796c1aa3	2015-10-22T17:21:35Z
-github.com/juju/schema	git	afe1151cb49d1d7ed3c75592dfc6f38703f2e988	2015-08-07T07:58:08Z
+github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
 github.com/juju/testing	git	ee18040b46bb1f8c93438383bd51ec77eb8c02ab	2016-01-12T21:04:04Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/utils	git	0cac78a34dd1c42d2f2dc718c345fd13e3a264fc	2016-01-29T15:50:19Z
@@ -20,7 +20,7 @@ golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:0
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/juju/charm.v6-unstable	git	ba541b945799430ccfcbab02453d898bfa714f27	2015-11-24T15:06:54Z
+gopkg.in/juju/charm.v6-unstable	git	8edb23ed1f704181179c7af9eb2a0cdddb75686b	2016-03-01T14:35:53Z
 gopkg.in/juju/charmrepo.v2-unstable	git	f03e1b601c98ff4a97baeedac856a7a030e021f4	2016-01-11T16:59:27Z
 gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T20:24:49Z
 gopkg.in/macaroon-bakery.v1	git	a165ebf9a2ce170e430ee2360dab11c70c22062c	2016-01-19T15:40:20Z

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -441,6 +441,7 @@ func (s *AddEntitySuite) checkAddCharm(c *gc.C, ch charm.Charm, addToES bool, ur
 		PromulgatedURL:          url.DocPromulgatedURL(),
 		SupportedSeries:         ch.Meta().Series,
 		Development:             url.Development,
+		Resources:               map[string]int{},
 	}))
 
 	// The charm archive has been properly added to the blob store.
@@ -525,6 +526,7 @@ func (s *AddEntitySuite) checkAddBundle(c *gc.C, bundle charm.Bundle, addToES bo
 		BundleUnitCount:    newInt(2),
 		PromulgatedURL:     url.DocPromulgatedURL(),
 		Development:        url.Development,
+		Resources:          map[string]int{},
 	}))
 
 	// The bundle archive has been properly added to the blob store.

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -949,6 +949,12 @@ func (s StoreDatabase) BaseEntities() *mgo.Collection {
 	return s.C("base_entities")
 }
 
+// Resources returns the mongo collection where resources are stored.
+func (s StoreDatabase) Resources() *mgo.Collection {
+	// TODO(ericsnow) Re-use the Entities collection?
+	return s.C("resources")
+}
+
 // Logs returns the Mongo collection where charm store logs are stored.
 func (s StoreDatabase) Logs() *mgo.Collection {
 	return s.C("logs")
@@ -972,6 +978,7 @@ var allCollections = []func(StoreDatabase) *mgo.Collection{
 	StoreDatabase.StatTokens,
 	StoreDatabase.Entities,
 	StoreDatabase.BaseEntities,
+	StoreDatabase.Resources,
 	StoreDatabase.Logs,
 	StoreDatabase.Migrations,
 }

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -399,6 +399,12 @@ func (s *Store) ensureIndexes() error {
 		s.DB.BaseEntities(),
 		mgo.Index{Key: []string{"name"}},
 	}, {
+		s.DB.Resources(),
+		mgo.Index{Key: []string{"charm-url", "name"}},
+	}, {
+		s.DB.Resources(),
+		mgo.Index{Key: []string{"charm-url", "name", "revision"}},
+	}, {
 		// TODO this index should be created by the mgo gridfs code.
 		s.DB.C("entitystore.files"),
 		mgo.Index{Key: []string{"filename"}},

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -2487,6 +2487,7 @@ func entity(url, purl string) *mongodoc.Entity {
 	e := &mongodoc.Entity{
 		URL:            id,
 		PromulgatedURL: pid,
+		Resources:      map[string]int{},
 	}
 	denormalizeEntity(e)
 	return e

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -138,6 +138,10 @@ type Entity struct {
 	// A development entity can only be referred to using URLs including the
 	// "development" channel.
 	Development bool
+
+	// Resources maps the charm's resources to the resource revisions
+	// tied to this charm revision.
+	Resources map[string]int
 }
 
 // PreferredURL returns the preferred way to refer to this entity. If

--- a/internal/mongodoc/doc_test.go
+++ b/internal/mongodoc/doc_test.go
@@ -4,8 +4,6 @@
 package mongodoc_test // import "gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 
 import (
-	"testing"
-
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
@@ -13,10 +11,6 @@ import (
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 )
-
-func TestPackage(t *testing.T) {
-	gc.TestingT(t)
-}
 
 type DocSuite struct{}
 

--- a/internal/mongodoc/package_test.go
+++ b/internal/mongodoc/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongodoc_test // import "gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/internal/mongodoc/resource.go
+++ b/internal/mongodoc/resource.go
@@ -22,10 +22,10 @@ type Resource struct {
 	DocID    string    `bson:"_id"`
 	CharmURL charm.URL `bson:"charm-url"`
 
-	Name    string `bson:"name"`
-	Type    string `bson:"type"`
-	Path    string `bson:"path"`
-	Comment string `bson:"comment"`
+	Name        string `bson:"name"`
+	Type        string `bson:"type"`
+	Path        string `bson:"path"`
+	Description string `bson:"comment"`
 
 	Origin      string `bson:"origin"`
 	Revision    int    `bson:"revision"`
@@ -45,10 +45,10 @@ func Resource2Doc(curl charm.URL, res resource.Resource) *Resource {
 		DocID:    id,
 		CharmURL: curl,
 
-		Name:    res.Name,
-		Type:    res.Type.String(),
-		Path:    res.Path,
-		Comment: res.Comment,
+		Name:        res.Name,
+		Type:        res.Type.String(),
+		Path:        res.Path,
+		Description: res.Description,
 
 		Origin:      res.Origin.String(),
 		Revision:    res.Revision,
@@ -78,10 +78,10 @@ func Doc2Resource(doc Resource) (resource.Resource, error) {
 
 	res = resource.Resource{
 		Meta: resource.Meta{
-			Name:    doc.Name,
-			Type:    resType,
-			Path:    doc.Path,
-			Comment: doc.Comment,
+			Name:        doc.Name,
+			Type:        resType,
+			Path:        doc.Path,
+			Description: doc.Description,
 		},
 		Origin:      origin,
 		Revision:    doc.Revision,

--- a/internal/mongodoc/resource.go
+++ b/internal/mongodoc/resource.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongodoc // import "gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+
+import (
+	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6-unstable/resource"
+)
+
+// Resource holds the in-database representation of a charm resource
+// at a particular revision.
+type Resource struct {
+	DocID    string    `bson:"_id"`
+	CharmURL charm.URL `bson:"charm-url"`
+
+	Name    string `bson:"name"`
+	Type    string `bson:"type"`
+	Path    string `bson:"path"`
+	Comment string `bson:"comment"`
+
+	Origin      string `bson:"origin"`
+	Revision    int    `bson:"revision"`
+	Fingerprint []byte `bson:"fingerprint"`
+	Size        int64  `bson:"size"`
+}
+
+// Resource2Doc converts the resource into a DB doc.
+func Resource2Doc(id string, curl charm.URL, res resource.Resource) *Resource {
+	return &Resource{
+		DocID:    id,
+		CharmURL: curl,
+
+		Name:    res.Name,
+		Type:    res.Type.String(),
+		Path:    res.Path,
+		Comment: res.Comment,
+
+		Origin:      res.Origin.String(),
+		Revision:    res.Revision,
+		Fingerprint: res.Fingerprint.Bytes(),
+		Size:        res.Size,
+	}
+}
+
+// Doc2Resource returns the resource.Resource represented by the doc.
+func Doc2Resource(doc Resource) (resource.Resource, error) {
+	var res resource.Resource
+
+	resType, err := resource.ParseType(doc.Type)
+	if err != nil {
+		return res, errgo.Notef(err, "got invalid data from DB")
+	}
+
+	origin, err := resource.ParseOrigin(doc.Origin)
+	if err != nil {
+		return res, errgo.Notef(err, "got invalid data from DB")
+	}
+
+	fp, err := resource.NewFingerprint(doc.Fingerprint)
+	if err != nil {
+		return res, errgo.Notef(err, "got invalid data from DB")
+	}
+
+	res = resource.Resource{
+		Meta: resource.Meta{
+			Name:    doc.Name,
+			Type:    resType,
+			Path:    doc.Path,
+			Comment: doc.Comment,
+		},
+		Origin:      origin,
+		Revision:    doc.Revision,
+		Fingerprint: fp,
+		Size:        doc.Size,
+	}
+	if err := res.Validate(); err != nil {
+		return res, errgo.Notef(err, "got invalid data from DB")
+	}
+	return res, nil
+}

--- a/internal/mongodoc/resource.go
+++ b/internal/mongodoc/resource.go
@@ -4,10 +4,17 @@
 package mongodoc // import "gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 
 import (
+	"fmt"
+
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charm.v6-unstable/resource"
 )
+
+// NewResourceID generates the doc ID corresponding to the given info.
+func NewResourceID(curl charm.URL, res resource.Resource) string {
+	return fmt.Sprintf("resource#%s#%s#%d", curl, res.Name, res.Revision)
+}
 
 // Resource holds the in-database representation of a charm resource
 // at a particular revision.
@@ -27,7 +34,10 @@ type Resource struct {
 }
 
 // Resource2Doc converts the resource into a DB doc.
-func Resource2Doc(id string, curl charm.URL, res resource.Resource) *Resource {
+func Resource2Doc(curl charm.URL, res resource.Resource) *Resource {
+	// TODO(ericsnow) Ignore the series?
+	id := NewResourceID(curl, res)
+
 	return &Resource{
 		DocID:    id,
 		CharmURL: curl,

--- a/internal/mongodoc/resource.go
+++ b/internal/mongodoc/resource.go
@@ -11,16 +11,78 @@ import (
 	"gopkg.in/juju/charm.v6-unstable/resource"
 )
 
+// CheckResourceCharm ensures that the given entity is okay
+// to associate with a revisioned resource.
+func CheckResourceCharm(entity Entity) error {
+	if entity.URL.Series == "bundle" {
+		return errgo.Newf("bundles do not have resources")
+	}
+	if entity.URL.Revision < 0 {
+		return errgo.Newf("unrevisioned charms do not have specific resources")
+	}
+	return nil
+}
+
+func charmHasResource(meta *charm.Meta, resName string) bool {
+	for name := range meta.Resources {
+		if resName == name {
+			return true
+		}
+	}
+	return false
+}
+
+// NewLatestResourceID generates the doc ID corresponding to the given info.
+func NewLatestResourceID(curl *charm.URL, resName string, revision int) string {
+	return fmt.Sprintf("latest-resource#%s#%s#%d", curl, resName, revision)
+}
+
+// LatestResource links a revisioned charm to a revisioned resource.
+type LatestResource struct {
+	DocID    string     `bson:"_id"`
+	CharmURL *charm.URL `bson:"charm-url"`
+	Resource string     `bson:"name"` // matches Resource
+	Revision int        `bson:"revision"`
+}
+
+// NewLatestResource packs the provided data into a LatestResource. The
+// entity must not be a bundle nor unrevisioned. The charmmetadata must
+// have the resource name. The revision must be non-negative.
+func NewLatestResource(entity Entity, resName string, revision int) (*LatestResource, error) {
+	if err := CheckResourceCharm(entity); err != nil {
+		return nil, err
+	}
+	if !charmHasResource(entity.CharmMeta, resName) {
+		return nil, errgo.Newf("charm does not have resource %q", resName)
+	}
+	if revision < 0 {
+		return nil, errgo.Newf("missing resource revision")
+	}
+
+	id := NewLatestResourceID(entity.URL, resName, revision)
+	latest := &LatestResource{
+		DocID:    id,
+		CharmURL: entity.URL,
+		Resource: resName,
+		Revision: revision,
+	}
+	return latest, nil
+}
+
 // NewResourceID generates the doc ID corresponding to the given info.
-func NewResourceID(curl charm.URL, res resource.Resource) string {
-	return fmt.Sprintf("resource#%s#%s#%d", curl, res.Name, res.Revision)
+func NewResourceID(curl *charm.URL, resName string, revision int) string {
+	// We ignore the series and revision because resources are specific
+	// to the charm rather than to any particular variation of it.
+	curl = curl.WithRevision(-1)
+	curl.Series = ""
+	return fmt.Sprintf("resource#%s#%s#%d", curl, resName, revision)
 }
 
 // Resource holds the in-database representation of a charm resource
 // at a particular revision.
 type Resource struct {
-	DocID    string    `bson:"_id"`
-	CharmURL charm.URL `bson:"charm-url"`
+	DocID    string     `bson:"_id"`
+	CharmURL *charm.URL `bson:"charm-url"`
 
 	Name        string `bson:"name"`
 	Type        string `bson:"type"`
@@ -34,14 +96,18 @@ type Resource struct {
 }
 
 // Resource2Doc converts the resource into a DB doc.
-func Resource2Doc(curl charm.URL, res resource.Resource) *Resource {
+func Resource2Doc(curl *charm.URL, res resource.Resource) (*Resource, error) {
+	if curl.Series == "bundle" {
+		return nil, errgo.Newf("bundles do not have resources")
+	}
+
 	// We ignore the series and revision because resources are specific
 	// to the charm rather than to any particular variation of it.
+	curl = curl.WithRevision(-1)
 	curl.Series = ""
-	curl.Revision = -1
 
-	id := NewResourceID(curl, res)
-	return &Resource{
+	id := NewResourceID(curl, res.Name, res.Revision)
+	doc := &Resource{
 		DocID:    id,
 		CharmURL: curl,
 
@@ -55,6 +121,7 @@ func Resource2Doc(curl charm.URL, res resource.Resource) *Resource {
 		Fingerprint: res.Fingerprint.Bytes(),
 		Size:        res.Size,
 	}
+	return doc, nil
 }
 
 // Doc2Resource returns the resource.Resource represented by the doc.

--- a/internal/mongodoc/resource.go
+++ b/internal/mongodoc/resource.go
@@ -13,7 +13,7 @@ import (
 
 // CheckResourceCharm ensures that the given entity is okay
 // to associate with a revisioned resource.
-func CheckResourceCharm(entity Entity) error {
+func CheckResourceCharm(entity *Entity) error {
 	if entity.URL.Series == "bundle" {
 		return errgo.Newf("bundles do not have resources")
 	}
@@ -48,7 +48,7 @@ type LatestResource struct {
 // NewLatestResource packs the provided data into a LatestResource. The
 // entity must not be a bundle nor unrevisioned. The charmmetadata must
 // have the resource name. The revision must be non-negative.
-func NewLatestResource(entity Entity, resName string, revision int) (*LatestResource, error) {
+func NewLatestResource(entity *Entity, resName string, revision int) (*LatestResource, error) {
 	if err := CheckResourceCharm(entity); err != nil {
 		return nil, err
 	}

--- a/internal/mongodoc/resource.go
+++ b/internal/mongodoc/resource.go
@@ -35,9 +35,12 @@ type Resource struct {
 
 // Resource2Doc converts the resource into a DB doc.
 func Resource2Doc(curl charm.URL, res resource.Resource) *Resource {
-	// TODO(ericsnow) Ignore the series?
-	id := NewResourceID(curl, res)
+	// We ignore the series and revision because resources are specific
+	// to the charm rather than to any particular variation of it.
+	curl.Series = ""
+	curl.Revision = -1
 
+	id := NewResourceID(curl, res)
 	return &Resource{
 		DocID:    id,
 		CharmURL: curl,

--- a/internal/mongodoc/resource_test.go
+++ b/internal/mongodoc/resource_test.go
@@ -23,42 +23,21 @@ func (s *ResourceSuite) TestCheckResourceCharm(c *gc.C) {
 	curl := charm.MustParseURL("cs:spam-2")
 	entity := &mongodoc.Entity{
 		URL: curl,
-	}
-
-	err := mongodoc.CheckResourceCharm(entity)
-
-	c.Check(err, jc.ErrorIsNil)
-}
-
-func (s *ResourceSuite) TestNewLatestResourceID(c *gc.C) {
-	curl := charm.MustParseURL("cs:trust/spam-2")
-
-	id := mongodoc.NewLatestResourceID(curl, "eggs", 3)
-
-	c.Check(id, gc.Equals, "latest-resource#cs:trust/spam-2#eggs#3")
-}
-
-func (s *ResourceSuite) TestNewLatestResource(c *gc.C) {
-	curl := charm.MustParseURL("cs:spam-2")
-	entity := &mongodoc.Entity{
-		URL: curl,
 		CharmMeta: &charm.Meta{
 			Resources: map[string]resource.Meta{
-				"ham":  resource.Meta{Name: "ham"},
-				"eggs": resource.Meta{Name: "eggs"},
+				"eggs": resource.Meta{
+					Name: "eggs",
+					Type: resource.TypeFile,
+					Path: "eggs.tgz",
+				},
 			},
 		},
 	}
+	res, _ := newResource(c, curl, "eggs", "<some data>")
 
-	doc, err := mongodoc.NewLatestResource(entity, "eggs", 3)
-	c.Assert(err, jc.ErrorIsNil)
+	err := mongodoc.CheckCharmResource(entity, res)
 
-	c.Check(doc, jc.DeepEquals, &mongodoc.LatestResource{
-		DocID:    "latest-resource#cs:spam-2#eggs#3",
-		CharmURL: curl,
-		Resource: "eggs",
-		Revision: 3,
-	})
+	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *ResourceSuite) TestNewResourceID(c *gc.C) {

--- a/internal/mongodoc/resource_test.go
+++ b/internal/mongodoc/resource_test.go
@@ -38,6 +38,9 @@ func (s *ResourceSuite) TestDoc2Resource(c *gc.C) {
 }
 
 func newResource(c *gc.C, curl charm.URL, name, data string) (resource.Resource, mongodoc.Resource) {
+	curl.Series = ""
+	curl.Revision = -1
+
 	path := name + ".tgz"
 	comment := "you really need this!!!"
 	revision := 1

--- a/internal/mongodoc/resource_test.go
+++ b/internal/mongodoc/resource_test.go
@@ -1,0 +1,82 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongodoc_test // import "gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+
+import (
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6-unstable/resource"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+)
+
+type ResourceSuite struct{}
+
+var _ = gc.Suite(&ResourceSuite{})
+
+func (s *ResourceSuite) TestResource2Doc(c *gc.C) {
+	var curl charm.URL
+	res, expected := newResource(c, curl, "spam", "spamspamspam")
+	id := expected.DocID
+
+	doc := mongodoc.Resource2Doc(id, curl, res)
+
+	c.Check(doc, jc.DeepEquals, &expected)
+}
+
+func (s *ResourceSuite) TestDoc2Resource(c *gc.C) {
+	var curl charm.URL
+	expected, doc := newResource(c, curl, "spam", "spamspamspam")
+
+	res, err := mongodoc.Doc2Resource(doc)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(res, jc.DeepEquals, expected)
+}
+
+func newResource(c *gc.C, curl charm.URL, name, data string) (resource.Resource, mongodoc.Resource) {
+	path := name + ".tgz"
+	comment := "you really need this!!!"
+	revision := 1
+
+	fp, err := resource.GenerateFingerprint([]byte(data))
+	c.Assert(err, jc.ErrorIsNil)
+	size := int64(len(data))
+
+	res := resource.Resource{
+		Meta: resource.Meta{
+			Name:    name,
+			Type:    resource.TypeFile,
+			Path:    path,
+			Comment: comment,
+		},
+		Origin:      resource.OriginStore,
+		Revision:    revision,
+		Fingerprint: fp,
+		Size:        size,
+	}
+	err = res.Validate()
+	c.Assert(err, jc.ErrorIsNil)
+
+	id := fmt.Sprintf("resource#%s#%s#%d", curl, name, revision)
+	doc := mongodoc.Resource{
+		DocID:    id,
+		CharmURL: curl,
+
+		Name:    name,
+		Type:    "file",
+		Path:    path,
+		Comment: comment,
+
+		Origin:      "store",
+		Revision:    revision,
+		Fingerprint: fp.Bytes(),
+		Size:        size,
+	}
+
+	return res, doc
+}

--- a/internal/mongodoc/resource_test.go
+++ b/internal/mongodoc/resource_test.go
@@ -21,9 +21,8 @@ var _ = gc.Suite(&ResourceSuite{})
 func (s *ResourceSuite) TestResource2Doc(c *gc.C) {
 	var curl charm.URL
 	res, expected := newResource(c, curl, "spam", "spamspamspam")
-	id := expected.DocID
 
-	doc := mongodoc.Resource2Doc(id, curl, res)
+	doc := mongodoc.Resource2Doc(curl, res)
 
 	c.Check(doc, jc.DeepEquals, &expected)
 }

--- a/internal/mongodoc/resource_test.go
+++ b/internal/mongodoc/resource_test.go
@@ -21,7 +21,7 @@ var _ = gc.Suite(&ResourceSuite{})
 
 func (s *ResourceSuite) TestCheckResourceCharm(c *gc.C) {
 	curl := charm.MustParseURL("cs:spam-2")
-	entity := mongodoc.Entity{
+	entity := &mongodoc.Entity{
 		URL: curl,
 	}
 
@@ -40,7 +40,7 @@ func (s *ResourceSuite) TestNewLatestResourceID(c *gc.C) {
 
 func (s *ResourceSuite) TestNewLatestResource(c *gc.C) {
 	curl := charm.MustParseURL("cs:spam-2")
-	entity := mongodoc.Entity{
+	entity := &mongodoc.Entity{
 		URL: curl,
 		CharmMeta: &charm.Meta{
 			Resources: map[string]resource.Meta{

--- a/internal/mongodoc/resource_test.go
+++ b/internal/mongodoc/resource_test.go
@@ -4,6 +4,7 @@
 package mongodoc_test // import "gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 
 import (
+	"bytes"
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
@@ -45,16 +46,16 @@ func newResource(c *gc.C, curl charm.URL, name, data string) (resource.Resource,
 	comment := "you really need this!!!"
 	revision := 1
 
-	fp, err := resource.GenerateFingerprint([]byte(data))
+	fp, err := resource.GenerateFingerprint(bytes.NewReader([]byte(data)))
 	c.Assert(err, jc.ErrorIsNil)
 	size := int64(len(data))
 
 	res := resource.Resource{
 		Meta: resource.Meta{
-			Name:    name,
-			Type:    resource.TypeFile,
-			Path:    path,
-			Comment: comment,
+			Name:        name,
+			Type:        resource.TypeFile,
+			Path:        path,
+			Description: comment,
 		},
 		Origin:      resource.OriginStore,
 		Revision:    revision,
@@ -69,10 +70,10 @@ func newResource(c *gc.C, curl charm.URL, name, data string) (resource.Resource,
 		DocID:    id,
 		CharmURL: curl,
 
-		Name:    name,
-		Type:    "file",
-		Path:    path,
-		Comment: comment,
+		Name:        name,
+		Type:        "file",
+		Path:        path,
+		Description: comment,
 
 		Origin:      "store",
 		Revision:    revision,

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -31,6 +31,7 @@ func NewEntity(url string) EntityBuilder {
 			User:                URL.User,
 			BaseURL:             mongodoc.BaseURL(URL),
 			PromulgatedRevision: -1,
+			Resources:           map[string]int{},
 		},
 	}
 }


### PR DESCRIPTION
In order to add functionality to the charm store we must have support in mongo.  This patch achieves that.  Later patches will add Store methods for listing and adding resources.
