### PR TITLE
internal/v5: tests for meta/perm semantics

### DIFF
--- a/internal/entitycache/cache.go
+++ b/internal/entitycache/cache.go
@@ -258,8 +258,8 @@ func (s *stash) entity(id *charm.URL, fields map[string]int) (stashEntity, error
 	e, hasEntry := s.entities[*id]
 	for {
 		if e != nil {
-			if e == notFoundEntity {
-				return nil, params.ErrNotFound
+			if e, ok := e.(*notFoundEntity); ok {
+				return nil, errgo.Mask(e.err, errgo.Is(params.ErrNotFound))
 			}
 			return e, nil
 		}
@@ -379,7 +379,7 @@ func (s *stash) fetch(url *charm.URL, fields map[string]int, version int) stashE
 			}
 			return nil
 		}
-		e = notFoundEntity
+		e = &notFoundEntity{err}
 	}
 	if s.version != version {
 		// The entity version has changed, implying the selected
@@ -407,7 +407,7 @@ func (s *stash) fetch(url *charm.URL, fields map[string]int, version int) stashE
 // Called with s.mu locked.
 func (s *stash) addEntity(e stashEntity, lookupId *charm.URL) stashEntity {
 	keys := make([]*charm.URL, 0, 3)
-	if e == notFoundEntity {
+	if _, ok := e.(*notFoundEntity); ok {
 		keys = append(keys, lookupId)
 	} else {
 		keys = append(keys, e.url())
@@ -435,20 +435,21 @@ func (s *stash) addEntity(e stashEntity, lookupId *charm.URL) stashEntity {
 	return e
 }
 
-type notFoundEntityT struct{}
+// notFoundEntity is a sentinel type that is stored
+// in the entities map when the value has been fetched
+// but was not found.
+type notFoundEntity struct {
+	// The actual not-found error encountered.
+	err error
+}
 
-func (notFoundEntityT) url() *charm.URL {
+func (*notFoundEntity) url() *charm.URL {
 	panic("url called on not-found sentinel value")
 }
 
-func (notFoundEntityT) promulgatedURL() *charm.URL {
+func (*notFoundEntity) promulgatedURL() *charm.URL {
 	panic("promulgatedURL called on not-found sentinel value")
 }
-
-// notFoundEntity is a sentinel value that is stored
-// in the entities map when the value has been fetched
-// but was not found.
-var notFoundEntity = notFoundEntityT{}
 
 // Iter returns an iterator that iterates through
 // all the entities found by the given query, which must

--- a/internal/entitycache/cache_test.go
+++ b/internal/entitycache/cache_test.go
@@ -326,13 +326,13 @@ func (*suite) TestGetEntityNotFound(c *gc.C) {
 	defer cache.Close()
 	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
 	c.Assert(e, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "not found")
+	c.Assert(err, gc.ErrorMatches, "entity: not found")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 
 	// Make sure that the not-found result has been cached.
 	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
 	c.Assert(e, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "not found")
+	c.Assert(err, gc.ErrorMatches, "entity: not found")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 
 	c.Assert(entityFetchCount, gc.Equals, 1)
@@ -340,12 +340,12 @@ func (*suite) TestGetEntityNotFound(c *gc.C) {
 	// Make sure fetching the base entity works the same way.
 	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
 	c.Assert(be, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "not found")
+	c.Assert(err, gc.ErrorMatches, "base entity: not found")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 
 	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
 	c.Assert(be, gc.IsNil)
-	c.Assert(err, gc.ErrorMatches, "not found")
+	c.Assert(err, gc.ErrorMatches, "base entity: not found")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 
 	c.Assert(baseEntityFetchCount, gc.Equals, 1)

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -138,7 +138,7 @@ func (s *APISuite) TestCharmArchiveUnresolvedURL(c *gc.C) {
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Code:    params.ErrNotFound,
-			Message: `no matching charm or bundle for "cs:wordpress"`,
+			Message: `no matching charm or bundle for cs:wordpress`,
 		},
 	})
 }

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -157,11 +157,8 @@ func (h ReqHandler) ResolveURLs(urls []*charm.URL) ([]*router.ResolvedURL, error
 // easily unit-tested.
 func resolveURL(cache *entitycache.Cache, url *charm.URL) (*router.ResolvedURL, error) {
 	entity, err := cache.Entity(url, charmstore.FieldSelector("supportedseries"))
-	if err != nil && errgo.Cause(err) != params.ErrNotFound {
-		return nil, errgo.Mask(err)
-	}
-	if errgo.Cause(err) == params.ErrNotFound {
-		return nil, noMatchingURLError(url)
+	if err != nil {
+		return nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
 	rurl := &router.ResolvedURL{
 		URL:                 *entity.URL,
@@ -197,10 +194,6 @@ func (h ReqHandler) Close() {
 // the given HTTP request.
 func StatsEnabled(req *http.Request) bool {
 	return v5.StatsEnabled(req)
-}
-
-func noMatchingURLError(url *charm.URL) error {
-	return errgo.WithCausef(nil, params.ErrNotFound, "no matching charm or bundle for %q", url)
 }
 
 // GET id/meta/charm-metadata

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -570,8 +570,8 @@ func (s *APISuite) addTestEntities(c *gc.C) []*router.ResolvedURL {
 		// Associate some extra-info data with the entity.
 		key := e.URL.Path() + "/meta/extra-info/key"
 		commonkey := e.URL.Path() + "/meta/common-info/key"
-		s.assertPut(c, key, "value "+e.URL.String())
-		s.assertPut(c, commonkey, "value "+e.URL.String())
+		s.assertPutAsAdmin(c, key, "value "+e.URL.String())
+		s.assertPutAsAdmin(c, commonkey, "value "+e.URL.String())
 	}
 	return testEntities
 }
@@ -620,13 +620,13 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		err := s.store.AddCharmWithArchive(u, storetesting.NewCharm(nil))
 		c.Assert(err, gc.IsNil)
 	}
-	s.assertGet(c, "wordpress/meta/perm?channel=unpublished", params.PermResponse{
-		Read:  []string{"charmers"},
-		Write: []string{"charmers"},
+	s.doAsUser("charmers", func() {
+		s.assertGet(c, "wordpress/meta/perm?channel=unpublished", params.PermResponse{
+			Read:  []string{"charmers"},
+			Write: []string{"charmers"},
+		})
 	})
-	e, err := s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.ChannelACLs, gc.DeepEquals, map[mongodoc.Channel]mongodoc.ACL{
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
 		mongodoc.UnpublishedChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
@@ -641,76 +641,87 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		},
 	})
 
-	// Change the read perms to only include a specific user and the
-	// published write perms to include an "admin" user.
-	// Because the entity isn't published yet, the unpublished channel ACLs
-	// will be changed.
-	s.assertPut(c, "precise/wordpress-23/meta/perm/read", []string{"bob"})
-	s.assertPut(c, "precise/wordpress-23/meta/perm/write", []string{"admin"})
+	s.doAsUser("charmers", func() {
+		// Change the read perms to only include a specific user and the
+		// published write perms to include an "admin" user.
+		// Because the entity isn't published yet, the unpublished channel ACLs
+		// will be changed.
+		s.assertPut(c, "precise/wordpress-23/meta/perm/read", []string{"bob"})
+		s.assertPut(c, "precise/wordpress-23/meta/perm/write", []string{"admin"})
+		// charmers no longer has permission.
+		s.assertGetIsUnauthorized(c, "precise/wordpress-23/meta/perm", `unauthorized: access denied for user "charmers"`)
+	})
 
 	// The permissions are only for bob now, so act as bob.
-	s.discharge = dischargeForUser("bob")
+	s.doAsUser("bob", func() {
+		// Check that the perms have changed for all revisions and series.
+		for i, u := range []string{"precise/wordpress-23", "precise/wordpress-24", "trusty/wordpress-1"} {
+			c.Logf("id %d: %q", i, u)
+			httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+				Handler: s.srv,
+				Do:      bakeryDo(nil),
+				URL:     storeURL(u + "/meta/perm"),
+				ExpectBody: params.PermResponse{
+					Read:  []string{"bob"},
+					Write: []string{"admin"},
+				},
+			})
+		}
+	})
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
+		mongodoc.UnpublishedChannel: {
+			Read:  []string{"bob"},
+			Write: []string{"admin"},
+		},
+		mongodoc.DevelopmentChannel: {
+			Read:  []string{"charmers"},
+			Write: []string{"charmers"},
+		},
+		mongodoc.StableChannel: {
+			Read:  []string{"charmers"},
+			Write: []string{"charmers"},
+		},
+	})
 
-	// Check that the perms have changed for all revisions and series.
-	for i, u := range []string{"precise/wordpress-23", "precise/wordpress-24", "trusty/wordpress-1"} {
-		c.Logf("id %d: %q", i, u)
+	// Publish one of the revisions to development, then PUT to meta/perm
+	// and check that the development ACLs have changed.
+	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), mongodoc.DevelopmentChannel)
+	c.Assert(err, gc.IsNil)
+
+	s.doAsUser("bob", func() {
+		// Check that we aren't allowed to put to the newly published entity as bob.
+		s.assertPutIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=development", []string{}, `unauthorized: access denied for user "bob"`)
+	})
+
+	s.doAsUser("charmers", func() {
+		s.discharge = dischargeForUser("charmers")
+		s.assertPut(c, "precise/wordpress-23/meta/perm/read", []string{"bob", "charlie"})
+		s.assertGetIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=development", `unauthorized: access denied for user "charmers"`)
+	})
+
+	s.doAsUser("bob", func() {
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler: s.srv,
 			Do:      bakeryDo(nil),
-			URL:     storeURL(u + "/meta/perm"),
+			URL:     storeURL("precise/wordpress-23/meta/perm"),
+			ExpectBody: params.PermResponse{
+				Read:  []string{"bob", "charlie"},
+				Write: []string{"charmers"},
+			},
+		})
+		// The other revisions should still see the old ACLs.
+		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+			Handler: s.srv,
+			Do:      bakeryDo(nil),
+			URL:     storeURL("precise/wordpress-24/meta/perm"),
 			ExpectBody: params.PermResponse{
 				Read:  []string{"bob"},
 				Write: []string{"admin"},
 			},
 		})
-	}
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.ChannelACLs, gc.DeepEquals, map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
-			Read:  []string{"bob"},
-			Write: []string{"admin"},
-		},
-		mongodoc.DevelopmentChannel: {
-			Read:  []string{"charmers"},
-			Write: []string{"charmers"},
-		},
-		mongodoc.StableChannel: {
-			Read:  []string{"charmers"},
-			Write: []string{"charmers"},
-		},
 	})
 
-	// Publish one of the revisions to development and check that the development ACLs
-	// have changed.
-	err = s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), mongodoc.DevelopmentChannel)
-	c.Assert(err, gc.IsNil)
-	s.assertPut(c, "precise/wordpress-23/meta/perm/read", []string{"bob", "charlie"})
-
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Do:      bakeryDo(nil),
-		URL:     storeURL("precise/wordpress-23/meta/perm"),
-		ExpectBody: params.PermResponse{
-			Read:  []string{"bob", "charlie"},
-			Write: []string{"charmers"},
-		},
-	})
-
-	// The other revisions should still see the old ACLs.
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Do:      bakeryDo(nil),
-		URL:     storeURL("precise/wordpress-24/meta/perm"),
-		ExpectBody: params.PermResponse{
-			Read:  []string{"bob"},
-			Write: []string{"admin"},
-		},
-	})
-
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("precise/wordpress-23"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.ChannelACLs, gc.DeepEquals, map[mongodoc.Channel]mongodoc.ACL{
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
 		mongodoc.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
@@ -724,53 +735,51 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Write: []string{"charmers"},
 		},
 	})
-
-	// The stable permissions only allow charmers currently, so act as
-	// charmers again.
-	s.discharge = dischargeForUser("charmers")
-
-	// Publish one of the revisions to stable and check that the stable ACLs
+	// Publish wordpress-1 to stable and check that the stable ACLs
 	// have changed.
 	err = s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), mongodoc.StableChannel)
 	c.Assert(err, gc.IsNil)
-	s.assertPut(c, "trusty/wordpress-1/meta/perm/write", []string{"doris"})
 
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Do:      bakeryDo(nil),
-		URL:     storeURL("~charmers/trusty/wordpress-1/meta/perm"),
-		ExpectBody: params.PermResponse{
-			Read:  []string{"charmers"},
-			Write: []string{"doris"},
-		},
+	// The stable permissions only allow charmers currently, so act as
+	// charmers again.
+	s.doAsUser("charmers", func() {
+		s.assertPut(c, "trusty/wordpress-1/meta/perm/write", []string{"doris"})
+		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+			Handler: s.srv,
+			Do:      bakeryDo(nil),
+			URL:     storeURL("~charmers/trusty/wordpress-1/meta/perm"),
+			ExpectBody: params.PermResponse{
+				Read:  []string{"charmers"},
+				Write: []string{"doris"},
+			},
+		})
 	})
 
 	// The other revisions should still see the old ACLs.
-	s.discharge = dischargeForUser("bob")
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Do:      bakeryDo(nil),
-		URL:     storeURL("precise/wordpress-24/meta/perm"),
-		ExpectBody: params.PermResponse{
-			Read:  []string{"bob"},
-			Write: []string{"admin"},
-		},
+	s.doAsUser("bob", func() {
+		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+			Handler: s.srv,
+			Do:      bakeryDo(nil),
+			URL:     storeURL("precise/wordpress-24/meta/perm"),
+			ExpectBody: params.PermResponse{
+				Read:  []string{"bob"},
+				Write: []string{"admin"},
+			},
+		})
+
+		// The development-channel entity should still see the development ACLS.
+		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+			Handler: s.srv,
+			Do:      bakeryDo(nil),
+			URL:     storeURL("precise/wordpress-23/meta/perm"),
+			ExpectBody: params.PermResponse{
+				Read:  []string{"bob", "charlie"},
+				Write: []string{"charmers"},
+			},
+		})
 	})
 
-	// The development-channel entity should still see the development ACLS.
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Do:      bakeryDo(nil),
-		URL:     storeURL("precise/wordpress-23/meta/perm"),
-		ExpectBody: params.PermResponse{
-			Read:  []string{"bob", "charlie"},
-			Write: []string{"charmers"},
-		},
-	})
-
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("trusty/wordpress-1"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.ChannelACLs, jc.DeepEquals, map[mongodoc.Channel]mongodoc.ACL{
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
 		mongodoc.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
@@ -785,18 +794,36 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		},
 	})
 
-	// Try restoring everyone's read permission on the charm.
-	// Note: wordpress resolves to trusty/wordpress-1 here because
-	// trusty is a later LTS series than precise.
-	s.assertPut(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
-	s.assertGet(c, "wordpress/meta/perm", params.PermResponse{
-		Read:  []string{"bob", params.Everyone},
-		Write: []string{"doris"},
+	s.doAsUser("doris", func() {
+		// Try restoring everyone's read permission on the charm.
+		// Note: wordpress resolves to trusty/wordpress-1 here because
+		// trusty is a later LTS series than precise.
+		s.assertPut(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
 	})
-	s.assertGet(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("trusty/wordpress-1"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.ChannelACLs, jc.DeepEquals, map[mongodoc.Channel]mongodoc.ACL{
+
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
+		mongodoc.UnpublishedChannel: {
+			Read:  []string{"bob"},
+			Write: []string{"admin"},
+		},
+		mongodoc.DevelopmentChannel: {
+			Read:  []string{"bob", "charlie"},
+			Write: []string{"charmers"},
+		},
+		mongodoc.StableChannel: {
+			Read:  []string{"bob", params.Everyone},
+			Write: []string{"doris"},
+		},
+	})
+
+	s.doAsUser("bob", func() {
+		s.assertGet(c, "wordpress/meta/perm", params.PermResponse{
+			Read:  []string{"bob", params.Everyone},
+			Write: []string{"doris"},
+		})
+		s.assertGet(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
+	})
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
 		mongodoc.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
@@ -812,22 +839,29 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	})
 
 	// Try deleting all permissions.
-	s.assertPut(c, "wordpress/meta/perm/read", []string{})
-	s.assertPut(c, "wordpress/meta/perm/write", []string{})
-
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler:      s.srv,
-		Do:           bakeryDo(nil),
-		URL:          storeURL("wordpress/meta/perm"),
-		ExpectStatus: http.StatusUnauthorized,
-		ExpectBody: params.Error{
-			Code:    params.ErrUnauthorized,
-			Message: `unauthorized: access denied for user "bob"`,
-		},
+	s.doAsUser("doris", func() {
+		s.assertPut(c, "wordpress/meta/perm/read", []string{})
+		s.assertPut(c, "wordpress/meta/perm/write", []string{})
+		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+			Handler:      s.srv,
+			Do:           bakeryDo(nil),
+			URL:          storeURL("wordpress/meta/perm"),
+			ExpectStatus: http.StatusUnauthorized,
+			ExpectBody: params.Error{
+				Code:    params.ErrUnauthorized,
+				Message: `unauthorized: access denied for user "doris"`,
+			},
+		})
 	})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("trusty/wordpress-1"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.ChannelACLs, gc.DeepEquals, map[mongodoc.Channel]mongodoc.ACL{
+	// Now no-one except admin can do anything with trusty/wordpress-1.
+	for _, user := range []string{"charmers", "bob", "charlie", "doris", "admin"} {
+		s.doAsUser(user, func() {
+			s.assertGetIsUnauthorized(c, "wordpress/meta/perm", fmt.Sprintf("unauthorized: access denied for user %q", user))
+			s.assertPutIsUnauthorized(c, "wordpress/meta/perm", []string{}, fmt.Sprintf("unauthorized: access denied for user %q", user))
+		})
+	}
+
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
 		mongodoc.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
@@ -842,14 +876,12 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		},
 	})
 
-	// Try setting all permissions in one request.
-	s.assertPut(c, "wordpress/meta/perm", params.PermRequest{
+	// Try setting all permissions in one request. We need to be admin here.
+	s.assertPutAsAdmin(c, "wordpress/meta/perm", params.PermRequest{
 		Read:  []string{"bob"},
 		Write: []string{"admin"},
 	})
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("trusty/wordpress-1"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.ChannelACLs, jc.DeepEquals, map[mongodoc.Channel]mongodoc.ACL{
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
 		mongodoc.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
@@ -865,13 +897,13 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	})
 
 	// Try putting only read permissions.
-	readRequest := struct {
-		Read []string
-	}{Read: []string{"joe"}}
-	s.assertPut(c, "wordpress/meta/perm", readRequest)
-	e, err = s.store.FindBaseEntity(charm.MustParseURL("trusty/wordpress-1"), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(e.ChannelACLs, jc.DeepEquals, map[mongodoc.Channel]mongodoc.ACL{
+	s.doAsUser("admin", func() {
+		readRequest := struct {
+			Read []string
+		}{Read: []string{"joe"}}
+		s.assertPut(c, "wordpress/meta/perm", readRequest)
+	})
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
 		mongodoc.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
@@ -885,6 +917,85 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Write: []string{},
 		},
 	})
+
+	// Restore some write rights to the stable channel.
+	s.assertPutAsAdmin(c, "trusty/wordpress-1/meta/perm/write", []string{"bob"})
+
+	// ~charmers/trusty/wordpress-1 has been published only to the
+	// stable channel. If we specify a different channel in a perm PUT
+	// request, we'll get an error because the channel isn't valid for
+	// that entity.
+	s.doAsUser("charmers", func() {
+		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+			Handler: s.srv,
+			Do:      bakeryDo(nil),
+			Method:  "PUT",
+			JSONBody: params.PermRequest{
+				Read:  []string{"foo"},
+				Write: []string{"bar"},
+			},
+			URL:          storeURL("trusty/wordpress-1/meta/perm?channel=development"),
+			ExpectStatus: http.StatusNotFound,
+			ExpectBody: params.Error{
+				Code:    params.ErrNotFound,
+				Message: `cs:trusty/wordpress-1 not found in development channel`,
+			},
+		})
+	})
+
+	// Similarly, we should be able to specify a channel on read
+	// to read a different channel.
+	s.doAsUser("bob", func() {
+		s.assertGet(c, "trusty/wordpress/meta/perm?channel=unpublished", params.PermResponse{
+			Read:  []string{"bob"},
+			Write: []string{"admin"},
+		})
+		s.assertGet(c, "wordpress/meta/perm?channel=development", params.PermResponse{
+			Read:  []string{"bob", "charlie"},
+			Write: []string{"charmers"},
+		})
+	})
+
+	// We can't write to a channel that the charm's not in.
+	s.doAsUser("charmers", func() {
+		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+			Handler:      s.srv,
+			Do:           bakeryDo(nil),
+			Method:       "PUT",
+			JSONBody:     []string{"arble"},
+			URL:          storeURL("trusty/wordpress-1/meta/perm/read?channel=development"),
+			ExpectStatus: http.StatusNotFound,
+			ExpectBody: params.Error{
+				Code:    params.ErrNotFound,
+				Message: `cs:trusty/wordpress-1 not found in development channel`,
+			},
+		})
+	})
+	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
+		mongodoc.UnpublishedChannel: {
+			Read:  []string{"bob"},
+			Write: []string{"admin"},
+		},
+		mongodoc.DevelopmentChannel: {
+			Read:  []string{"bob", "charlie"},
+			Write: []string{"charmers"},
+		},
+		mongodoc.StableChannel: {
+			Read:  []string{"joe"},
+			Write: []string{"bob"},
+		},
+	})
+	s.doAsUser("bob", func() {
+		s.assertGet(c, "trusty/wordpress/meta/perm/read?channel=unpublished", []string{"bob"})
+	})
+}
+
+// assertChannelACLs asserts that the ChannelACLs field of the base entity with the
+// given URL are as given.
+func (s *APISuite) assertChannelACLs(c *gc.C, url string, acls map[mongodoc.Channel]mongodoc.ACL) {
+	e, err := s.store.FindBaseEntity(charm.MustParseURL(url), nil)
+	c.Assert(err, gc.IsNil)
+	c.Assert(e.ChannelACLs, jc.DeepEquals, acls)
 }
 
 func (s *APISuite) TestMetaPermPutUnauthorized(c *gc.C) {
@@ -915,14 +1026,14 @@ func (s *APISuite) TestExtraInfo(c *gc.C) {
 
 func (s *APISuite) checkInfo(c *gc.C, path string, id string) {
 	// Add one value and check that it's there.
-	s.assertPut(c, id+"/meta/"+path+"/foo", "fooval")
+	s.assertPutAsAdmin(c, id+"/meta/"+path+"/foo", "fooval")
 	s.assertGet(c, id+"/meta/"+path+"/foo", "fooval")
 	s.assertGet(c, id+"/meta/"+path, map[string]string{
 		"foo": "fooval",
 	})
 
 	// Add another value and check that both values are there.
-	s.assertPut(c, id+"/meta/"+path+"/bar", "barval")
+	s.assertPutAsAdmin(c, id+"/meta/"+path+"/bar", "barval")
 	s.assertGet(c, id+"/meta/"+path+"/bar", "barval")
 	s.assertGet(c, id+"/meta/"+path, map[string]string{
 		"foo": "fooval",
@@ -930,7 +1041,7 @@ func (s *APISuite) checkInfo(c *gc.C, path string, id string) {
 	})
 
 	// Overwrite a value and check that it's changed.
-	s.assertPut(c, id+"/meta/"+path+"/foo", "fooval2")
+	s.assertPutAsAdmin(c, id+"/meta/"+path+"/foo", "fooval2")
 	s.assertGet(c, id+"/meta/"+path+"/foo", "fooval2")
 	s.assertGet(c, id+"/meta/"+path+"", map[string]string{
 		"foo": "fooval2",
@@ -938,7 +1049,7 @@ func (s *APISuite) checkInfo(c *gc.C, path string, id string) {
 	})
 
 	// Write several values at once.
-	s.assertPut(c, id+"/meta/any", params.MetaAnyResponse{
+	s.assertPutAsAdmin(c, id+"/meta/any", params.MetaAnyResponse{
 		Meta: map[string]interface{}{
 			path: map[string]string{
 				"foo": "fooval3",
@@ -955,7 +1066,7 @@ func (s *APISuite) checkInfo(c *gc.C, path string, id string) {
 	})
 
 	// Delete a single value.
-	s.assertPut(c, id+"/meta/"+path+"/foo", nil)
+	s.assertPutAsAdmin(c, id+"/meta/"+path+"/foo", nil)
 	s.assertGet(c, id+"/meta/"+path, map[string]interface{}{
 		"baz":  "bazval",
 		"bar":  "barval",
@@ -963,7 +1074,7 @@ func (s *APISuite) checkInfo(c *gc.C, path string, id string) {
 	})
 
 	// Delete a value and add some values at the same time.
-	s.assertPut(c, id+"/meta/any", params.MetaAnyResponse{
+	s.assertPutAsAdmin(c, id+"/meta/any", params.MetaAnyResponse{
 		Meta: map[string]interface{}{
 			path: map[string]interface{}{
 				"baz":    nil,
@@ -1168,7 +1279,7 @@ func (s *APISuite) TestCommonInfo(c *gc.C) {
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/precise/wordpress-24", 24))
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/trusty/wordpress-1", 1))
 
-	s.assertPut(c, "wordpress/meta/common-info/key", "something")
+	s.assertPutAsAdmin(c, "wordpress/meta/common-info/key", "something")
 
 	s.assertGet(c, "wordpress/meta/common-info", map[string]string{
 		"key": "something",
@@ -1243,7 +1354,7 @@ func (s *APISuite) TestMetaAnyWithNoIncludesAndNoEntity(c *gc.C) {
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Code:    params.ErrNotFound,
-			Message: `no matching charm or bundle for "cs:precise/wordpress-1"`,
+			Message: `no matching charm or bundle for cs:precise/wordpress-1`,
 		},
 	})
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -1451,7 +1562,7 @@ func (s *APISuite) TestMetaCharmNotFound(c *gc.C) {
 	for i, ep := range metaEndpoints {
 		c.Logf("test %d: %s", i, ep.name)
 		expected := params.Error{
-			Message: `no matching charm or bundle for "cs:precise/wordpress-23"`,
+			Message: `no matching charm or bundle for cs:precise/wordpress-23`,
 			Code:    params.ErrNotFound,
 		}
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -1460,7 +1571,7 @@ func (s *APISuite) TestMetaCharmNotFound(c *gc.C) {
 			ExpectStatus: http.StatusNotFound,
 			ExpectBody:   expected,
 		})
-		expected.Message = `no matching charm or bundle for "cs:wordpress"`
+		expected.Message = `no matching charm or bundle for cs:wordpress`
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler:      s.srv,
 			URL:          storeURL("wordpress/meta/" + ep.name),
@@ -1577,7 +1688,7 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 		}), url)
 		if test.notFound {
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
-			c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for ".*"`)
+			c.Assert(err, gc.ErrorMatches, `no matching charm or bundle for .*`)
 			c.Assert(rurl, gc.IsNil)
 			continue
 		}
@@ -1643,11 +1754,11 @@ var serveExpandIdTests = []struct {
 }, {
 	about: "fully qualified URL with no entities found",
 	url:   "~charmers/precise/no-such-42",
-	err:   `no matching charm or bundle for "cs:~charmers/precise/no-such-42"`,
+	err:   `no matching charm or bundle for cs:~charmers/precise/no-such-42`,
 }, {
 	about: "partial URL with no entities found",
 	url:   "no-such",
-	err:   `no matching charm or bundle for "cs:no-such"`,
+	err:   `no matching charm or bundle for cs:no-such`,
 }}
 
 func (s *APISuite) TestServeExpandId(c *gc.C) {
@@ -1824,7 +1935,7 @@ var serveMetaRevisionInfoTests = []struct {
 }, {
 	about: "no entities found",
 	url:   "precise/no-such-33",
-	err:   `no matching charm or bundle for "cs:precise/no-such-33"`,
+	err:   `no matching charm or bundle for cs:precise/no-such-33`,
 }}
 
 func (s *APISuite) TestServeMetaRevisionInfo(c *gc.C) {
@@ -2501,14 +2612,14 @@ var urlChannelResolvingTests = []struct {
 	channel:      mongodoc.StableChannel,
 	expectStatus: http.StatusNotFound,
 	expectError: params.Error{
-		Message: `no matching charm or bundle for "cs:~charmers/precise/wordpress-2"`,
+		Message: `cs:~charmers/precise/wordpress-2 not found in stable channel`,
 		Code:    params.ErrNotFound,
 	},
 }, {
 	url:          "mysql",
 	expectStatus: http.StatusNotFound,
 	expectError: params.Error{
-		Message: `no matching charm or bundle for "cs:mysql"`,
+		Message: `no matching charm or bundle for cs:mysql`,
 		Code:    params.ErrNotFound,
 	},
 }, {
@@ -2824,7 +2935,7 @@ var promulgateTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: `no matching charm or bundle for "cs:~charmers/mysql"`,
+		Message: `no matching charm or bundle for cs:~charmers/mysql`,
 	},
 	expectEntities: []*mongodoc.Entity{
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
@@ -2847,7 +2958,7 @@ var promulgateTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: `no matching charm or bundle for "cs:~charmers/mysql"`,
+		Message: `no matching charm or bundle for cs:~charmers/mysql`,
 	},
 	expectEntities: []*mongodoc.Entity{
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").Build(),

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -998,7 +998,7 @@ var archiveFileErrorsTests = []struct {
 	about:         "entity not found",
 	path:          "~charmers/trusty/no-such-42/archive/icon.svg",
 	expectStatus:  http.StatusNotFound,
-	expectMessage: `no matching charm or bundle for "cs:~charmers/trusty/no-such-42"`,
+	expectMessage: `no matching charm or bundle for cs:~charmers/trusty/no-such-42`,
 	expectCode:    params.ErrNotFound,
 }, {
 	about:         "directory listing",
@@ -1174,7 +1174,7 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 		Password:     testPassword,
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
-			Message: `no matching charm or bundle for "cs:~charmers/utopic/no-such-0"`,
+			Message: `no matching charm or bundle for cs:~charmers/utopic/no-such-0`,
 			Code:    params.ErrNotFound,
 		},
 	})

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -1,6 +1,7 @@
 package v4_test // import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/juju/loggo"
 	jujutesting "github.com/juju/testing"
+	"github.com/juju/testing/httptesting"
 	"github.com/julienschmidt/httprouter"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
@@ -289,6 +291,93 @@ func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
 		c.Logf("adding charm %v %d required by bundle to fulfil %v", &rurl.URL, rurl.PromulgatedRevision, svc.Charm)
 		s.addPublicCharm(c, ch, &rurl)
 	}
+}
+
+func (s *commonSuite) assertPut(c *gc.C, url string, val interface{}) {
+	s.assertPut0(c, url, val, false)
+}
+
+func (s *commonSuite) assertPutAsAdmin(c *gc.C, url string, val interface{}) {
+	s.assertPut0(c, url, val, true)
+}
+
+func (s *commonSuite) assertPut0(c *gc.C, url string, val interface{}, asAdmin bool) {
+	body, err := json.Marshal(val)
+	c.Assert(err, gc.IsNil)
+	p := httptesting.JSONCallParams{
+		Handler: s.srv,
+		URL:     storeURL(url),
+		Method:  "PUT",
+		Do:      bakeryDo(nil),
+		Header: http.Header{
+			"Content-Type": {"application/json"},
+		},
+		Body: bytes.NewReader(body),
+	}
+	if asAdmin {
+		p.Username = testUsername
+		p.Password = testPassword
+	}
+	httptesting.AssertJSONCall(c, p)
+}
+
+func (s *commonSuite) assertGet(c *gc.C, url string, expectVal interface{}) {
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:    s.srv,
+		Do:         bakeryDo(nil),
+		URL:        storeURL(url),
+		ExpectBody: expectVal,
+	})
+}
+
+// assertGetIsUnauthorized asserts that a GET to the given URL results
+// in an ErrUnauthorized response with the given error message.
+func (s *commonSuite) assertGetIsUnauthorized(c *gc.C, url, expectMessage string) {
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Do:           bakeryDo(nil),
+		Method:       "GET",
+		URL:          storeURL(url),
+		ExpectStatus: http.StatusUnauthorized,
+		ExpectBody: params.Error{
+			Code:    params.ErrUnauthorized,
+			Message: expectMessage,
+		},
+	})
+}
+
+// assertGetIsUnauthorized asserts that a PUT to the given URL with the
+// given body value results in an ErrUnauthorized response with the given
+// error message.
+func (s *commonSuite) assertPutIsUnauthorized(c *gc.C, url string, val interface{}, expectMessage string) {
+	body, err := json.Marshal(val)
+	c.Assert(err, gc.IsNil)
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler: s.srv,
+		URL:     storeURL(url),
+		Method:  "PUT",
+		Do:      bakeryDo(nil),
+		Header: http.Header{
+			"Content-Type": {"application/json"},
+		},
+		Body:         bytes.NewReader(body),
+		ExpectStatus: http.StatusUnauthorized,
+		ExpectBody: params.Error{
+			Code:    params.ErrUnauthorized,
+			Message: expectMessage,
+		},
+	})
+}
+
+// doAsUser calls the given function, discharging any authorization
+// request as the given user name.
+func (s *commonSuite) doAsUser(user string, f func()) {
+	old := s.discharge
+	s.discharge = dischargeForUser(user)
+	defer func() {
+		s.discharge = old
+	}()
+	f()
 }
 
 func bakeryDo(client *http.Client) func(*http.Request) (*http.Response, error) {

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -34,7 +34,7 @@ var serveDiagramErrorsTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: `no matching charm or bundle for "cs:~charmers/bundle/foo-23"`,
+		Message: `no matching charm or bundle for cs:~charmers/bundle/foo-23`,
 	},
 }, {
 	about:        "diagram for a charm",

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -4,7 +4,6 @@
 package v4_test // import "gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/http"
 	"sort"
@@ -629,28 +628,10 @@ func (s *SearchSuite) TestLegacyStatsUpdatesSearch(c *gc.C) {
 	doc, err := s.store.ES.GetSearchDocument(charm.MustParseURL("~openstack-charmers/trusty/mysql-7"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(doc.TotalDownloads, gc.Equals, int64(0))
-	s.assertPut(c, "~openstack-charmers/trusty/mysql-7/meta/extra-info/"+params.LegacyDownloadStats, 57)
+	s.assertPutAsAdmin(c, "~openstack-charmers/trusty/mysql-7/meta/extra-info/"+params.LegacyDownloadStats, 57)
 	doc, err = s.store.ES.GetSearchDocument(charm.MustParseURL("~openstack-charmers/trusty/mysql-7"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(doc.TotalDownloads, gc.Equals, int64(57))
-}
-
-func (s *SearchSuite) assertPut(c *gc.C, url string, val interface{}) {
-	body, err := json.Marshal(val)
-	c.Assert(err, gc.IsNil)
-	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     storeURL(url),
-		Method:  "PUT",
-		Header: http.Header{
-			"Content-Type": {"application/json"},
-		},
-		Username: testUsername,
-		Password: testPassword,
-		Body:     bytes.NewReader(body),
-	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("headers: %v, body: %s", rec.HeaderMap, rec.Body.String()))
-	c.Assert(rec.Body.String(), gc.HasLen, 0)
 }
 
 func (s *SearchSuite) TestSearchWithAdminCredentials(c *gc.C) {

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -214,7 +214,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 				CharmReference: charm.MustParseURL("~charmers/precise/unknown-23"),
 			}},
 		},
-		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for "cs:~charmers/precise/unknown-23"`,
+		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for cs:~charmers/precise/unknown-23`,
 	}, {
 		path:   "stats/update",
 		status: http.StatusInternalServerError,
@@ -227,7 +227,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 				CharmReference: charm.MustParseURL("~charmers/precise/wordpress-23"),
 			}},
 		},
-		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for "cs:~charmers/precise/unknown-23"`,
+		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for cs:~charmers/precise/unknown-23`,
 		partialUpdate: true,
 	}}
 

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -378,10 +378,7 @@ func resolveURL(cache *entitycache.Cache, url *charm.URL) (*router.ResolvedURL, 
 	// we'll always get it from the Entity result.
 	entity, err := cache.Entity(url, nil)
 	if err != nil {
-		if errgo.Cause(err) == params.ErrNotFound {
-			return nil, noMatchingURLError(url)
-		}
-		return nil, errgo.Mask(err)
+		return nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
 	rurl := &router.ResolvedURL{
 		URL:                 *entity.URL,
@@ -398,10 +395,6 @@ func resolveURL(cache *entitycache.Cache, url *charm.URL) (*router.ResolvedURL, 
 	// the result.
 	cache.BaseEntity(entity.BaseURL, nil)
 	return rurl, nil
-}
-
-func noMatchingURLError(url *charm.URL) error {
-	return errgo.WithCausef(nil, params.ErrNotFound, "no matching charm or bundle for %q", url)
 }
 
 type EntityHandlerFunc func(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error)

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -991,7 +991,7 @@ var archiveFileErrorsTests = []struct {
 	about:         "entity not found",
 	path:          "~charmers/trusty/no-such-42/archive/icon.svg",
 	expectStatus:  http.StatusNotFound,
-	expectMessage: `no matching charm or bundle for "cs:~charmers/trusty/no-such-42"`,
+	expectMessage: `no matching charm or bundle for cs:~charmers/trusty/no-such-42`,
 	expectCode:    params.ErrNotFound,
 }, {
 	about:         "directory listing",
@@ -1148,7 +1148,7 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 		Password:     testPassword,
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
-			Message: `no matching charm or bundle for "cs:~charmers/utopic/no-such-0"`,
+			Message: `no matching charm or bundle for cs:~charmers/utopic/no-such-0`,
 			Code:    params.ErrNotFound,
 		},
 	})

--- a/internal/v5/content_test.go
+++ b/internal/v5/content_test.go
@@ -35,7 +35,7 @@ var serveDiagramErrorsTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: `no matching charm or bundle for "cs:~charmers/bundle/foo-23"`,
+		Message: `no matching charm or bundle for cs:~charmers/bundle/foo-23`,
 	},
 }, {
 	about:        "diagram for a charm",

--- a/internal/v5/search_test.go
+++ b/internal/v5/search_test.go
@@ -4,7 +4,6 @@
 package v5_test // import "gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -730,28 +729,10 @@ func (s *SearchSuite) TestLegacyStatsUpdatesSearch(c *gc.C) {
 	doc, err := s.store.ES.GetSearchDocument(charm.MustParseURL("~openstack-charmers/trusty/mysql-7"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(doc.TotalDownloads, gc.Equals, int64(0))
-	s.assertPut(c, "~openstack-charmers/trusty/mysql-7/meta/extra-info/"+params.LegacyDownloadStats, 57)
+	s.assertPutAsAdmin(c, "~openstack-charmers/trusty/mysql-7/meta/extra-info/"+params.LegacyDownloadStats, 57)
 	doc, err = s.store.ES.GetSearchDocument(charm.MustParseURL("~openstack-charmers/trusty/mysql-7"))
 	c.Assert(err, gc.IsNil)
 	c.Assert(doc.TotalDownloads, gc.Equals, int64(57))
-}
-
-func (s *SearchSuite) assertPut(c *gc.C, url string, val interface{}) {
-	body, err := json.Marshal(val)
-	c.Assert(err, gc.IsNil)
-	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-		Handler: s.srv,
-		URL:     storeURL(url),
-		Method:  "PUT",
-		Header: http.Header{
-			"Content-Type": {"application/json"},
-		},
-		Username: testUsername,
-		Password: testPassword,
-		Body:     bytes.NewReader(body),
-	})
-	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("headers: %v, body: %s", rec.HeaderMap, rec.Body.String()))
-	c.Assert(rec.Body.String(), gc.HasLen, 0)
 }
 
 func (s *SearchSuite) TestSearchWithAdminCredentials(c *gc.C) {

--- a/internal/v5/stats_test.go
+++ b/internal/v5/stats_test.go
@@ -219,7 +219,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 				CharmReference: charm.MustParseURL("~charmers/precise/unknown-23"),
 			}},
 		},
-		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for "cs:~charmers/precise/unknown-23"`,
+		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for cs:~charmers/precise/unknown-23`,
 	}, {
 		path:   "stats/update",
 		status: http.StatusInternalServerError,
@@ -232,7 +232,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 				CharmReference: charm.MustParseURL("~charmers/precise/wordpress-23"),
 			}},
 		},
-		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for "cs:~charmers/precise/unknown-23"`,
+		expectMessage: `cannot find entity for url cs:~charmers/precise/unknown-23: no matching charm or bundle for cs:~charmers/precise/unknown-23`,
 		partialUpdate: true,
 	}}
 


### PR DESCRIPTION
Also update entitycache so that it correctly passes back
the not-found error that it was given and make internal/v[45]
avoid throwing away the original error too.

Also, in internal/v[45], align assertPut with assertGet, making
put-with-admin-privileges the special case rather than the default.
