### PR TITLE
all: use params.Channel

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -21,8 +21,8 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	ba541b945799430ccfcbab02453d898bfa714f27	2015-11-24T15:06:54Z
-gopkg.in/juju/charmrepo.v2-unstable	git	f03e1b601c98ff4a97baeedac856a7a030e021f4	2016-01-11T16:59:27Z
-gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T20:24:49Z
+gopkg.in/juju/charmrepo.v2-unstable	git	a746d18ef9ecc39354bf9d338478c539f43e9138	2016-03-03T09:59:06Z
+gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z
 gopkg.in/macaroon-bakery.v1	git	a165ebf9a2ce170e430ee2360dab11c70c22062c	2016-01-19T15:40:20Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z

--- a/internal/charmstore/addentity.go
+++ b/internal/charmstore/addentity.go
@@ -516,10 +516,10 @@ func (s *Store) addEntity(entity *mongodoc.Entity) (err error) {
 		URL:  entity.BaseURL,
 		User: entity.User,
 		Name: entity.Name,
-		ChannelACLs: map[mongodoc.Channel]mongodoc.ACL{
-			mongodoc.UnpublishedChannel: acls,
-			mongodoc.DevelopmentChannel: acls,
-			mongodoc.StableChannel:      acls,
+		ChannelACLs: map[params.Channel]mongodoc.ACL{
+			params.UnpublishedChannel: acls,
+			params.DevelopmentChannel: acls,
+			params.StableChannel:      acls,
 		},
 		Promulgated: entity.PromulgatedURL != nil,
 	}
@@ -602,7 +602,7 @@ func (s *Store) bundleCharms(ids []string) (map[string]charm.Charm, error) {
 			// be returned to the user along with other bundle errors.
 			continue
 		}
-		e, err := s.FindBestEntity(url, mongodoc.NoChannel, map[string]int{})
+		e, err := s.FindBestEntity(url, params.NoChannel, map[string]int{})
 		if err != nil {
 			if errgo.Cause(err) == params.ErrNotFound {
 				// Ignore this error too, for the same reasons

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -103,16 +103,16 @@ func (s *AddEntitySuite) TestAddCharmWithMultiSeries(c *gc.C) {
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), "multi-series")
 	s.checkAddCharm(c, ch, router.MustNewResolvedURL("~charmers/multi-series-1", 1))
 	// Make sure it can be accessed with a number of names
-	e, err := store.FindBestEntity(charm.MustParseURL("~charmers/multi-series-1"), mongodoc.UnpublishedChannel, nil)
+	e, err := store.FindBestEntity(charm.MustParseURL("~charmers/multi-series-1"), params.UnpublishedChannel, nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.URL.String(), gc.Equals, "cs:~charmers/multi-series-1")
-	e, err = store.FindBestEntity(charm.MustParseURL("~charmers/trusty/multi-series-1"), mongodoc.UnpublishedChannel, nil)
+	e, err = store.FindBestEntity(charm.MustParseURL("~charmers/trusty/multi-series-1"), params.UnpublishedChannel, nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.URL.String(), gc.Equals, "cs:~charmers/multi-series-1")
-	e, err = store.FindBestEntity(charm.MustParseURL("~charmers/wily/multi-series-1"), mongodoc.UnpublishedChannel, nil)
+	e, err = store.FindBestEntity(charm.MustParseURL("~charmers/wily/multi-series-1"), params.UnpublishedChannel, nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.URL.String(), gc.Equals, "cs:~charmers/multi-series-1")
-	_, err = store.FindBestEntity(charm.MustParseURL("~charmers/precise/multi-series-1"), mongodoc.UnpublishedChannel, nil)
+	_, err = store.FindBestEntity(charm.MustParseURL("~charmers/precise/multi-series-1"), params.UnpublishedChannel, nil)
 	c.Assert(err, gc.ErrorMatches, "no matching charm or bundle for cs:~charmers/precise/multi-series-1")
 	c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 }
@@ -486,10 +486,10 @@ func assertBaseEntity(c *gc.C, store *Store, url *charm.URL, promulgated bool) {
 		Read:  []string{url.User},
 		Write: []string{url.User},
 	}
-	expectACLs := map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.StableChannel:      acls,
-		mongodoc.DevelopmentChannel: acls,
-		mongodoc.UnpublishedChannel: acls,
+	expectACLs := map[params.Channel]mongodoc.ACL{
+		params.StableChannel:      acls,
+		params.DevelopmentChannel: acls,
+		params.UnpublishedChannel: acls,
 	}
 	c.Assert(storetesting.NormalizeBaseEntity(baseEntity), jc.DeepEquals, storetesting.NormalizeBaseEntity(&mongodoc.BaseEntity{
 		URL:         url,

--- a/internal/charmstore/common_test.go
+++ b/internal/charmstore/common_test.go
@@ -6,9 +6,9 @@ package charmstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/char
 import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 
-	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 )
@@ -25,7 +25,7 @@ func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
 	defer store.Close()
 	for _, svc := range bundle.Data().Services {
 		u := charm.MustParseURL(svc.Charm)
-		if _, err := store.FindBestEntity(u, mongodoc.NoChannel, nil); err == nil {
+		if _, err := store.FindBestEntity(u, params.NoChannel, nil); err == nil {
 			continue
 		}
 		if u.Revision == -1 {
@@ -45,7 +45,7 @@ func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
 		}
 		err := store.AddCharmWithArchive(&rurl, ch)
 		c.Assert(err, gc.IsNil)
-		err = store.Publish(&rurl, mongodoc.StableChannel)
+		err = store.Publish(&rurl, params.StableChannel)
 		c.Assert(err, gc.IsNil)
 	}
 }

--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -5,6 +5,7 @@ package charmstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/char
 
 import (
 	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
@@ -180,7 +181,7 @@ func addDevelopmentACLs(db StoreDatabase) error {
 	defer iter.Close()
 	for iter.Next(&baseEntity) {
 		if err := baseEntities.UpdateId(baseEntity.URL, bson.D{{
-			"$set", bson.D{{"channelacls.development", baseEntity.ChannelACLs[mongodoc.DevelopmentChannel]}},
+			"$set", bson.D{{"channelacls.development", baseEntity.ChannelACLs[params.DevelopmentChannel]}},
 		}}); err != nil {
 			return errgo.Notef(err, "cannot add development ACLs to base entity id %s", baseEntity.URL)
 		}

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -417,8 +418,8 @@ func (s *migrationsSuite) TestMigrateAddDevelopment(c *gc.C) {
 //	entities := []*mongodoc.BaseEntity{{
 //		URL:  charm.MustParseURL("~charmers/django"),
 //		Name: "django",
-//		ChannelACLs: map[mongodoc.Channel] mongodoc.ACL{
-//			mongodoc.UnpublishedChannel: {
+//		ChannelACLs: map[params.Channel] mongodoc.ACL{
+//			params.UnpublishedChannel: {
 //				Read:  []string{"user", "group"},
 //				Write: []string{"user"},
 //			},
@@ -426,8 +427,8 @@ func (s *migrationsSuite) TestMigrateAddDevelopment(c *gc.C) {
 //	}, {
 //		URL:  charm.MustParseURL("~who/rails"),
 //		Name: "rails",
-//		ChannelACLs: map[mongodoc.Channel] mongodoc.ACL{
-//			mongodoc.UnpublishedChannel: {
+//		ChannelACLs: map[params.Channel] mongodoc.ACL{
+//			params.UnpublishedChannel: {
 //				Read:  []string{"everyone"},
 //				Write: []string{},
 //			},
@@ -435,8 +436,8 @@ func (s *migrationsSuite) TestMigrateAddDevelopment(c *gc.C) {
 //	}, {
 //		URL:  charm.MustParseURL("~who/mediawiki-scalable"),
 //		Name: "mediawiki-scalable",
-//		ChannelACLs: map[mongodoc.Channel] mongodoc.ACL{
-//			mongodoc.UnpublishedChannel: {
+//		ChannelACLs: map[params.Channel] mongodoc.ACL{
+//			params.UnpublishedChannel: {
 //				Read:  []string{"who"},
 //				Write: []string{"dalek"},
 //			},
@@ -509,7 +510,7 @@ func (s *migrationsSuite) TestAddPreV5CompatBlob(c *gc.C) {
 	} {
 		err := store.AddCharmWithArchive(rurl, ch)
 		c.Assert(err, gc.IsNil)
-		err = store.Publish(rurl, mongodoc.StableChannel)
+		err = store.Publish(rurl, params.StableChannel)
 		c.Assert(err, gc.IsNil)
 	}
 	err = store.AddBundleWithArchive(MustParseResolvedURL("~charmers/bundle/of-fun-1"), storetesting.NewBundle(&charm.BundleData{

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -97,7 +97,7 @@ func (s *Store) UpdateSearch(r *router.ResolvedURL) error {
 		return errgo.NoteMask(err, fmt.Sprintf("cannot update search record for %q", &r.URL), errgo.Is(params.ErrNotFound))
 	}
 	series := r.URL.Series
-	entityURL := baseEntity.ChannelEntities[mongodoc.StableChannel][series]
+	entityURL := baseEntity.ChannelEntities[params.StableChannel][series]
 	if entityURL == nil {
 		// There is no stable version of the entity to index.
 		return nil
@@ -123,7 +123,7 @@ func (s *Store) UpdateSearchBaseURL(baseURL *charm.URL) error {
 	if err != nil {
 		return errgo.NoteMask(err, fmt.Sprintf("cannot index %s", baseURL), errgo.Is(params.ErrNotFound))
 	}
-	stableEntities := baseEntity.ChannelEntities[mongodoc.StableChannel]
+	stableEntities := baseEntity.ChannelEntities[params.StableChannel]
 	updated := make(map[string]bool, len(stableEntities))
 	for urlSeries, url := range stableEntities {
 		if !series.Series[urlSeries].SearchIndex {
@@ -182,7 +182,7 @@ func (s *Store) UpdateSearchFields(r *router.ResolvedURL, fields map[string]inte
 // for indexing.
 func (s *Store) searchDocFromEntity(e *mongodoc.Entity, be *mongodoc.BaseEntity) (*SearchDoc, error) {
 	doc := SearchDoc{Entity: e}
-	doc.ReadACLs = be.ChannelACLs[mongodoc.StableChannel].Read
+	doc.ReadACLs = be.ChannelACLs[params.StableChannel].Read
 	// There should only be one record for the promulgated entity, which
 	// should be the latest promulgated revision. In the case that the base
 	// entity is not promulgated assume that there is a later promulgated

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -980,14 +980,14 @@ func (s *StoreSearchSuite) TestOnlyIndexStableCharms(c *gc.C) {
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(&id.URL), &actual)
 	c.Assert(err, gc.ErrorMatches, "elasticsearch document not found")
 
-	err = s.store.Publish(id, mongodoc.DevelopmentChannel)
+	err = s.store.Publish(id, params.DevelopmentChannel)
 	c.Assert(err, gc.IsNil)
 	err = s.store.UpdateSearch(id)
 	c.Assert(err, gc.IsNil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(&id.URL), &actual)
 	c.Assert(err, gc.ErrorMatches, "elasticsearch document not found")
 
-	err = s.store.Publish(id, mongodoc.StableChannel)
+	err = s.store.Publish(id, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 	err = s.store.UpdateSearch(id)
 	c.Assert(err, gc.IsNil)
@@ -1018,7 +1018,7 @@ func addCharmForSearch(c *gc.C, s *Store, id *router.ResolvedURL, ch charm.Charm
 	}
 	err = s.SetPerms(&id.URL, "stable.read", acl...)
 	c.Assert(err, gc.IsNil)
-	err = s.Publish(id, mongodoc.StableChannel)
+	err = s.Publish(id, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -1034,6 +1034,6 @@ func addBundleForSearch(c *gc.C, s *Store, id *router.ResolvedURL, b charm.Bundl
 	}
 	err = s.SetPerms(&id.URL, "stable.read", acl...)
 	c.Assert(err, gc.IsNil)
-	err = s.Publish(id, mongodoc.StableChannel)
+	err = s.Publish(id, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 }

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -475,8 +475,8 @@ func (s *Store) FindEntities(url *charm.URL, fields map[string]int) ([]*mongodoc
 //
 // If the URL does not contain a revision then the channel is searched
 // for the best match, here NoChannel will be treated as
-// mongodoc.StableChannel.
-func (s *Store) FindBestEntity(url *charm.URL, channel mongodoc.Channel, fields map[string]int) (*mongodoc.Entity, error) {
+// params.StableChannel.
+func (s *Store) FindBestEntity(url *charm.URL, channel params.Channel, fields map[string]int) (*mongodoc.Entity, error) {
 	if fields != nil {
 		// Make sure we have all the fields we need to make a decision.
 		// TODO this would be more efficient if we used bitmasks for field selection.
@@ -506,11 +506,11 @@ func (s *Store) FindBestEntity(url *charm.URL, channel mongodoc.Channel, fields 
 		// This is crucial because if we don't do this, then the user could choose
 		// to use any chosen set of ACLs against any entity.
 		switch channel {
-		case mongodoc.StableChannel:
+		case params.StableChannel:
 			if !entity.Stable {
 				return nil, errgo.WithCausef(nil, params.ErrNotFound, "%s not found in stable channel", url)
 			}
-		case mongodoc.DevelopmentChannel:
+		case params.DevelopmentChannel:
 			if !entity.Development {
 				return nil, errgo.WithCausef(nil, params.ErrNotFound, "%s not found in development channel", url)
 			}
@@ -519,10 +519,10 @@ func (s *Store) FindBestEntity(url *charm.URL, channel mongodoc.Channel, fields 
 	}
 
 	switch channel {
-	case mongodoc.UnpublishedChannel:
+	case params.UnpublishedChannel:
 		return s.findUnpublishedEntity(url, fields)
-	case mongodoc.NoChannel:
-		channel = mongodoc.StableChannel
+	case params.NoChannel:
+		channel = params.StableChannel
 		fallthrough
 	default:
 		return s.findEntityInChannel(url, channel, fields)
@@ -551,7 +551,7 @@ func (s *Store) findSingleEntity(url *charm.URL, fields map[string]int) (*mongod
 // findEntityInChannel attempts to find an entity on the given channel. The
 // base entity for URL is retrieved and the series with the best match to
 // URL.Series is used as the resolved entity.
-func (s *Store) findEntityInChannel(url *charm.URL, ch mongodoc.Channel, fields map[string]int) (*mongodoc.Entity, error) {
+func (s *Store) findEntityInChannel(url *charm.URL, ch params.Channel, fields map[string]int) (*mongodoc.Entity, error) {
 	baseEntity, err := s.FindBaseEntity(url, map[string]int{
 		"_id":             1,
 		"channelentities": 1,
@@ -729,16 +729,16 @@ func (s *Store) UpdateBaseEntity(url *router.ResolvedURL, update interface{}) er
 // Publish assigns channels to the entity corresponding to the given URL.
 // An error is returned if no channels are provided. For the time being,
 // the only supported channels are "development" and "stable".
-func (s *Store) Publish(url *router.ResolvedURL, channels ...mongodoc.Channel) error {
+func (s *Store) Publish(url *router.ResolvedURL, channels ...params.Channel) error {
 	var updateSearch bool
 	// Validate channels.
-	actual := make([]mongodoc.Channel, 0, len(channels))
+	actual := make([]params.Channel, 0, len(channels))
 	for _, c := range channels {
 		switch c {
-		case mongodoc.StableChannel:
+		case params.StableChannel:
 			updateSearch = true
 			fallthrough
-		case mongodoc.DevelopmentChannel:
+		case params.DevelopmentChannel:
 			actual = append(actual, c)
 		}
 	}

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -350,16 +350,16 @@ var findBaseEntityTests = []struct {
 		User:        "charmers",
 		Name:        "mysql",
 		Promulgated: true,
-		ChannelACLs: map[mongodoc.Channel]mongodoc.ACL{
-			mongodoc.UnpublishedChannel: {
+		ChannelACLs: map[params.Channel]mongodoc.ACL{
+			params.UnpublishedChannel: {
 				Read:  []string{"charmers"},
 				Write: []string{"charmers"},
 			},
-			mongodoc.DevelopmentChannel: {
+			params.DevelopmentChannel: {
 				Read:  []string{"charmers"},
 				Write: []string{"charmers"},
 			},
-			mongodoc.StableChannel: {
+			params.StableChannel: {
 				Read:  []string{"charmers"},
 				Write: []string{"charmers"},
 			},
@@ -381,16 +381,16 @@ var findBaseEntityTests = []struct {
 	fields: []string{"channelacls"},
 	expect: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/mysql"),
-		ChannelACLs: map[mongodoc.Channel]mongodoc.ACL{
-			mongodoc.UnpublishedChannel: {
+		ChannelACLs: map[params.Channel]mongodoc.ACL{
+			params.UnpublishedChannel: {
 				Read:  []string{"who"},
 				Write: []string{"who"},
 			},
-			mongodoc.DevelopmentChannel: {
+			params.DevelopmentChannel: {
 				Read:  []string{"who"},
 				Write: []string{"who"},
 			},
-			mongodoc.StableChannel: {
+			params.StableChannel: {
 				Read:  []string{"who"},
 				Write: []string{"who"},
 			},
@@ -1510,7 +1510,7 @@ var findBestEntityBundles = []struct {
 
 var findBestEntityTests = []struct {
 	url              string
-	channel          mongodoc.Channel
+	channel          params.Channel
 	expectID         *router.ResolvedURL
 	expectError      string
 	expectErrorCause error
@@ -1519,31 +1519,31 @@ var findBestEntityTests = []struct {
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-0", 0),
 }, {
 	url:      "~charmers/trusty/wordpress-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-0", 0),
 }, {
 	url:      "~charmers/trusty/wordpress-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-0", 0),
 }, {
 	url:      "~charmers/trusty/wordpress-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-0", 0),
 }, {
 	url:      "~charmers/trusty/wordpress-3",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
 	url:      "~charmers/trusty/wordpress-3",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
 	url:              "~charmers/trusty/wordpress-3",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "cs:~charmers/trusty/wordpress-3 not found in development channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~charmers/trusty/wordpress-2",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "cs:~charmers/trusty/wordpress-2 not found in stable channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -1551,31 +1551,31 @@ var findBestEntityTests = []struct {
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-0", 0),
 }, {
 	url:      "trusty/wordpress-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-0", 0),
 }, {
 	url:      "trusty/wordpress-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-0", 0),
 }, {
 	url:      "trusty/wordpress-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-0", 0),
 }, {
 	url:      "trusty/wordpress-3",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
 	url:      "trusty/wordpress-3",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
 	url:              "trusty/wordpress-3",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "cs:trusty/wordpress-3 not found in development channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/wordpress-2",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "cs:trusty/wordpress-2 not found in stable channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -1583,75 +1583,75 @@ var findBestEntityTests = []struct {
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-1", 1),
 }, {
 	url:      "~charmers/trusty/wordpress",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-1", 1),
 }, {
 	url:      "~charmers/trusty/wordpress",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-2", 2),
 }, {
 	url:      "~charmers/trusty/wordpress",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
 	url:      "trusty/wordpress",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-1", 1),
 }, {
 	url:      "trusty/wordpress",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-1", 1),
 }, {
 	url:      "trusty/wordpress",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-2", 2),
 }, {
 	url:      "trusty/wordpress",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
 	url:      "precise/wordpress",
 	expectID: router.MustNewResolvedURL("~charmers/precise/wordpress-5", 5),
 }, {
 	url:      "precise/wordpress",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/precise/wordpress-5", 5),
 }, {
 	url:      "precise/wordpress",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/precise/wordpress-6", 6),
 }, {
 	url:      "precise/wordpress",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/precise/wordpress-7", 7),
 }, {
 	url:      "wordpress",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-1", 1),
 }, {
 	url:      "wordpress",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-1", 1),
 }, {
 	url:      "wordpress",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-2", 2),
 }, {
 	url:      "wordpress",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
 	url:      "~charmers/wordpress",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-1", 1),
 }, {
 	url:      "~charmers/wordpress",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-1", 1),
 }, {
 	url:      "~charmers/wordpress",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-2", 2),
 }, {
 	url:      "~charmers/wordpress",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/wordpress-3", 3),
 }, {
 	url:              "~charmers/wordpress-0",
@@ -1659,17 +1659,17 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~charmers/wordpress-0",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:~charmers/wordpress-0",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~charmers/wordpress-0",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "no matching charm or bundle for cs:~charmers/wordpress-0",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~charmers/wordpress-0",
-	channel:          mongodoc.UnpublishedChannel,
+	channel:          params.UnpublishedChannel,
 	expectError:      "no matching charm or bundle for cs:~charmers/wordpress-0",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -1677,31 +1677,31 @@ var findBestEntityTests = []struct {
 	expectID: router.MustNewResolvedURL("~charmers/mysql-0", 0),
 }, {
 	url:      "~charmers/mysql-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-0", 0),
 }, {
 	url:      "~charmers/mysql-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-0", 0),
 }, {
 	url:      "~charmers/mysql-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-0", 0),
 }, {
 	url:      "~charmers/mysql-3",
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:      "~charmers/mysql-3",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:              "~charmers/mysql-3",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "cs:~charmers/mysql-3 not found in development channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~charmers/mysql-2",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "cs:~charmers/mysql-2 not found in stable channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -1709,31 +1709,31 @@ var findBestEntityTests = []struct {
 	expectID: findBestEntityCharms[8].id,
 }, {
 	url:      "mysql-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-0", 0),
 }, {
 	url:      "mysql-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-0", 0),
 }, {
 	url:      "mysql-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-0", 0),
 }, {
 	url:      "mysql-3",
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:      "mysql-3",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:              "mysql-3",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "cs:mysql-3 not found in development channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "mysql-2",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "cs:mysql-2 not found in stable channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -1741,121 +1741,121 @@ var findBestEntityTests = []struct {
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "~charmers/mysql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "~charmers/mysql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-2", 2),
 }, {
 	url:      "~charmers/mysql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:      "mysql",
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "mysql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "mysql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-2", 2),
 }, {
 	url:      "mysql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:      "~charmers/precise/mysql",
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "~charmers/precise/mysql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "~charmers/precise/mysql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-2", 2),
 }, {
 	url:      "~charmers/precise/mysql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:      "precise/mysql",
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "precise/mysql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "precise/mysql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-2", 2),
 }, {
 	url:      "precise/mysql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:      "~charmers/trusty/mysql",
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "~charmers/trusty/mysql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "~charmers/trusty/mysql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-2", 2),
 }, {
 	url:      "~charmers/trusty/mysql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:      "trusty/mysql",
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "trusty/mysql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-1", 1),
 }, {
 	url:      "trusty/mysql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-2", 2),
 }, {
 	url:      "trusty/mysql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/mysql-3", 3),
 }, {
 	url:      "~charmers/trusty/mongodb-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-0", -1),
 }, {
 	url:      "~charmers/trusty/mongodb-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-0", -1),
 }, {
 	url:      "~charmers/trusty/mongodb-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-0", -1),
 }, {
 	url:      "~charmers/trusty/mongodb-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-0", -1),
 }, {
 	url:      "~charmers/trusty/mongodb-3",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-3", -1),
 }, {
 	url:      "~charmers/trusty/mongodb-3",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-3", -1),
 }, {
 	url:              "~charmers/trusty/mongodb-3",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "cs:~charmers/trusty/mongodb-3 not found in development channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~charmers/trusty/mongodb-2",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "cs:~charmers/trusty/mongodb-2 not found in stable channel",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -1864,17 +1864,17 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/mongodb-0",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/mongodb-0",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/mongodb-0",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/mongodb-0",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/mongodb-0",
-	channel:          mongodoc.UnpublishedChannel,
+	channel:          params.UnpublishedChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/mongodb-0",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -1882,15 +1882,15 @@ var findBestEntityTests = []struct {
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-1", -1),
 }, {
 	url:      "~charmers/trusty/mongodb",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-1", -1),
 }, {
 	url:      "~charmers/trusty/mongodb",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-2", -1),
 }, {
 	url:      "~charmers/trusty/mongodb",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/mongodb-3", -1),
 }, {
 	url:              "trusty/mongodb",
@@ -1898,17 +1898,17 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/mongodb",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/mongodb",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/mongodb",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/mongodb",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/mongodb",
-	channel:          mongodoc.UnpublishedChannel,
+	channel:          params.UnpublishedChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/mongodb",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -1917,17 +1917,17 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "mongodb",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:mongodb",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "mongodb",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "no matching charm or bundle for cs:mongodb",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "mongodb",
-	channel:          mongodoc.UnpublishedChannel,
+	channel:          params.UnpublishedChannel,
 	expectError:      "no matching charm or bundle for cs:mongodb",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -1936,31 +1936,31 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~charmers/trusty/apache",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:~charmers/trusty/apache",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "~charmers/trusty/apache",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:      "~charmers/trusty/apache",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:      "~charmers/trusty/apache-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:         "~charmers/trusty/apache-0",
-	channel:     mongodoc.StableChannel,
+	channel:     params.StableChannel,
 	expectError: "cs:~charmers/trusty/apache-0 not found in stable channel",
 }, {
 	url:      "~charmers/trusty/apache-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:      "~charmers/trusty/apache-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:              "trusty/apache",
@@ -1968,31 +1968,31 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/apache",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/apache",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "trusty/apache",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:      "trusty/apache",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:      "trusty/apache-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:         "trusty/apache-0",
-	channel:     mongodoc.StableChannel,
+	channel:     params.StableChannel,
 	expectError: "cs:trusty/apache-0 not found in stable channel",
 }, {
 	url:      "trusty/apache-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:      "trusty/apache-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/apache-0", 0),
 }, {
 	url:              "~charmers/trusty/nginx",
@@ -2000,32 +2000,32 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~charmers/trusty/nginx",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:~charmers/trusty/nginx",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~charmers/trusty/nginx",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "no matching charm or bundle for cs:~charmers/trusty/nginx",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "~charmers/trusty/nginx",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
 }, {
 	url:      "~charmers/trusty/nginx-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
 }, {
 	url:         "~charmers/trusty/nginx-0",
-	channel:     mongodoc.StableChannel,
+	channel:     params.StableChannel,
 	expectError: "cs:~charmers/trusty/nginx-0 not found in stable channel",
 }, {
 	url:         "~charmers/trusty/nginx-0",
-	channel:     mongodoc.DevelopmentChannel,
+	channel:     params.DevelopmentChannel,
 	expectError: "cs:~charmers/trusty/nginx-0 not found in development channel",
 }, {
 	url:      "~charmers/trusty/nginx-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
 }, {
 	url:              "trusty/nginx",
@@ -2033,167 +2033,167 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/nginx",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/nginx",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/nginx",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/nginx",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "trusty/nginx",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
 }, {
 	url:      "trusty/nginx-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
 }, {
 	url:         "trusty/nginx-0",
-	channel:     mongodoc.StableChannel,
+	channel:     params.StableChannel,
 	expectError: "cs:trusty/nginx-0 not found in stable channel",
 }, {
 	url:         "trusty/nginx-0",
-	channel:     mongodoc.DevelopmentChannel,
+	channel:     params.DevelopmentChannel,
 	expectError: "cs:trusty/nginx-0 not found in development channel",
 }, {
 	url:      "trusty/nginx-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/nginx-0", 0),
 }, {
 	url:      "~charmers/bundle/wordpress-simple-0",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "~charmers/bundle/wordpress-simple-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "~charmers/bundle/wordpress-simple-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "~charmers/bundle/wordpress-simple-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "~charmers/bundle/wordpress-simple-3",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
 	url:      "~charmers/bundle/wordpress-simple-3",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
 	url:         "~charmers/bundle/wordpress-simple-3",
-	channel:     mongodoc.DevelopmentChannel,
+	channel:     params.DevelopmentChannel,
 	expectError: "cs:~charmers/bundle/wordpress-simple-3 not found in development channel",
 }, {
 	url:         "~charmers/bundle/wordpress-simple-3",
-	channel:     mongodoc.StableChannel,
+	channel:     params.StableChannel,
 	expectError: "cs:~charmers/bundle/wordpress-simple-3 not found in stable channel",
 }, {
 	url:      "bundle/wordpress-simple-0",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "bundle/wordpress-simple-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "bundle/wordpress-simple-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "bundle/wordpress-simple-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "bundle/wordpress-simple-3",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
 	url:      "bundle/wordpress-simple-3",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
 	url:         "bundle/wordpress-simple-3",
-	channel:     mongodoc.DevelopmentChannel,
+	channel:     params.DevelopmentChannel,
 	expectError: "cs:bundle/wordpress-simple-3 not found in development channel",
 }, {
 	url:         "bundle/wordpress-simple-2",
-	channel:     mongodoc.StableChannel,
+	channel:     params.StableChannel,
 	expectError: "cs:bundle/wordpress-simple-2 not found in stable channel",
 }, {
 	url:      "~charmers/bundle/wordpress-simple",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 }, {
 	url:      "~charmers/bundle/wordpress-simple",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 }, {
 	url:      "~charmers/bundle/wordpress-simple",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 2),
 }, {
 	url:      "~charmers/bundle/wordpress-simple",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
 	url:      "bundle/wordpress-simple",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 }, {
 	url:      "bundle/wordpress-simple",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 }, {
 	url:      "bundle/wordpress-simple",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 2),
 }, {
 	url:      "bundle/wordpress-simple",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
 	url:      "wordpress-simple",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 }, {
 	url:      "wordpress-simple",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 }, {
 	url:      "wordpress-simple",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 2),
 }, {
 	url:      "wordpress-simple",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
 	url:      "~charmers/wordpress-simple",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 }, {
 	url:      "~charmers/wordpress-simple",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 }, {
 	url:      "~charmers/wordpress-simple",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 2),
 }, {
 	url:      "~charmers/wordpress-simple",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 }, {
 	url:      "~charmers/wordpress-simple-0",
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "~charmers/wordpress-simple-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "~charmers/wordpress-simple-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:      "~charmers/wordpress-simple-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 }, {
 	url:              "~charmers/trusty/wordpress",
@@ -2205,150 +2205,150 @@ var findBestEntityTests = []struct {
 	expectID: router.MustNewResolvedURL("~charmers/trusty/postgresql-0", 0),
 }, {
 	url:      "~charmers/trusty/postgresql-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/postgresql-0", 0),
 }, {
 	url:      "~charmers/trusty/postgresql-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/postgresql-0", 0),
 }, {
 	url:      "~charmers/trusty/postgresql-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/postgresql-0", 0),
 }, {
 	url:      "~charmers/precise/postgresql-0",
 	expectID: router.MustNewResolvedURL("~charmers/precise/postgresql-0", 0),
 }, {
 	url:      "~charmers/precise/postgresql-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/precise/postgresql-0", 0),
 }, {
 	url:      "~charmers/precise/postgresql-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/precise/postgresql-0", 0),
 }, {
 	url:      "~charmers/precise/postgresql-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/precise/postgresql-0", 0),
 }, {
 	url:      "~charmers/trusty/postgresql-1",
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/trusty/postgresql-1",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/trusty/postgresql-1",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/trusty/postgresql-1",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/precise/postgresql-1",
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/precise/postgresql-1",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/precise/postgresql-1",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/precise/postgresql-1",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/trusty/postgresql",
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/trusty/postgresql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/trusty/postgresql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/trusty/postgresql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/precise/postgresql",
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/precise/postgresql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/precise/postgresql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "~charmers/precise/postgresql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "trusty/postgresql",
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "trusty/postgresql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "trusty/postgresql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "trusty/postgresql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "precise/postgresql",
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "precise/postgresql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "precise/postgresql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "precise/postgresql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "postgresql",
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "postgresql",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "postgresql",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "postgresql",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "postgresql-1",
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "postgresql-1",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "postgresql-1",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:      "postgresql-1",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/postgresql-1", 1),
 }, {
 	url:              "postgresql-0",
@@ -2356,17 +2356,17 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "postgresql-0",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:postgresql-0",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "postgresql-0",
-	channel:          mongodoc.DevelopmentChannel,
+	channel:          params.DevelopmentChannel,
 	expectError:      "no matching charm or bundle for cs:postgresql-0",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "postgresql-0",
-	channel:          mongodoc.UnpublishedChannel,
+	channel:          params.UnpublishedChannel,
 	expectError:      "no matching charm or bundle for cs:postgresql-0",
 	expectErrorCause: params.ErrNotFound,
 }, {
@@ -2374,45 +2374,45 @@ var findBestEntityTests = []struct {
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "~charmers/trusty/ceph-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "~charmers/trusty/ceph-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "~charmers/trusty/ceph-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "~charmers/trusty/ceph",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "~charmers/trusty/ceph",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "~charmers/trusty/ceph",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "~charmers/trusty/ceph",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "~openstack-charmers/trusty/ceph-0",
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:         "~openstack-charmers/trusty/ceph-0",
-	channel:     mongodoc.StableChannel,
+	channel:     params.StableChannel,
 	expectError: "cs:~openstack-charmers/trusty/ceph-0 not found in stable channel",
 }, {
 	url:      "~openstack-charmers/trusty/ceph-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:      "~openstack-charmers/trusty/ceph-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:              "~openstack-charmers/trusty/ceph",
@@ -2420,46 +2420,46 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "~openstack-charmers/trusty/ceph",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:~openstack-charmers/trusty/ceph",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "~openstack-charmers/trusty/ceph",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:      "~openstack-charmers/trusty/ceph",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:      "trusty/ceph-0",
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "trusty/ceph-0",
-	channel:  mongodoc.StableChannel,
+	channel:  params.StableChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "trusty/ceph-0",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "trusty/ceph-0",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~charmers/trusty/ceph-0", 0),
 }, {
 	url:      "trusty/ceph-1",
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:         "trusty/ceph-1",
-	channel:     mongodoc.StableChannel,
+	channel:     params.StableChannel,
 	expectError: "cs:trusty/ceph-1 not found in stable channel",
 }, {
 	url:      "trusty/ceph-1",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:      "trusty/ceph-1",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:              "trusty/ceph",
@@ -2467,16 +2467,16 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "trusty/ceph",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:trusty/ceph",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "trusty/ceph",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:      "trusty/ceph",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:              "ceph",
@@ -2484,16 +2484,16 @@ var findBestEntityTests = []struct {
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:              "ceph",
-	channel:          mongodoc.StableChannel,
+	channel:          params.StableChannel,
 	expectError:      "no matching charm or bundle for cs:ceph",
 	expectErrorCause: params.ErrNotFound,
 }, {
 	url:      "ceph",
-	channel:  mongodoc.DevelopmentChannel,
+	channel:  params.DevelopmentChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }, {
 	url:      "ceph",
-	channel:  mongodoc.UnpublishedChannel,
+	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
 }}
 
@@ -2506,11 +2506,11 @@ func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
 		err = store.SetPromulgated(ch.id, ch.id.PromulgatedRevision != -1)
 		c.Assert(err, gc.IsNil)
 		if ch.development {
-			err := store.Publish(ch.id, mongodoc.DevelopmentChannel)
+			err := store.Publish(ch.id, params.DevelopmentChannel)
 			c.Assert(err, gc.IsNil)
 		}
 		if ch.stable {
-			err := store.Publish(ch.id, mongodoc.StableChannel)
+			err := store.Publish(ch.id, params.StableChannel)
 			c.Assert(err, gc.IsNil)
 		}
 	}
@@ -2521,11 +2521,11 @@ func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
 		err = store.SetPromulgated(b.id, b.id.PromulgatedRevision != -1)
 		c.Assert(err, gc.IsNil)
 		if b.development {
-			err := store.Publish(b.id, mongodoc.DevelopmentChannel)
+			err := store.Publish(b.id, params.DevelopmentChannel)
 			c.Assert(err, gc.IsNil)
 		}
 		if b.stable {
-			err := store.Publish(b.id, mongodoc.StableChannel)
+			err := store.Publish(b.id, params.StableChannel)
 			c.Assert(err, gc.IsNil)
 		}
 	}
@@ -2679,7 +2679,7 @@ func (s *StoreSuite) TestUpdateBaseEntity(c *gc.C) {
 			c.Assert(err, gc.IsNil)
 			baseEntity, err := store.FindBaseEntity(&url.URL, nil)
 			c.Assert(err, gc.IsNil)
-			c.Assert(baseEntity.ChannelACLs[mongodoc.UnpublishedChannel].Read, jc.DeepEquals, []string{"test"})
+			c.Assert(baseEntity.ChannelACLs[params.UnpublishedChannel].Read, jc.DeepEquals, []string{"test"})
 		}
 	}
 }
@@ -3215,19 +3215,19 @@ func (s *StoreSuite) TestBundleCharms(c *gc.C) {
 	rurl := router.MustNewResolvedURL("cs:~charmers/saucy/mysql-0", 0)
 	err := store.AddCharmWithArchive(rurl, mysql)
 	c.Assert(err, gc.IsNil)
-	err = store.Publish(rurl, mongodoc.StableChannel)
+	err = store.Publish(rurl, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 	riak := storetesting.Charms.CharmArchive(c.MkDir(), "riak")
 	rurl = router.MustNewResolvedURL("cs:~charmers/trusty/riak-42", 42)
 	err = store.AddCharmWithArchive(rurl, riak)
 	c.Assert(err, gc.IsNil)
-	err = store.Publish(rurl, mongodoc.StableChannel)
+	err = store.Publish(rurl, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 	wordpress := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	rurl = router.MustNewResolvedURL("cs:~charmers/utopic/wordpress-47", 47)
 	err = store.AddCharmWithArchive(rurl, wordpress)
 	c.Assert(err, gc.IsNil)
-	err = store.Publish(rurl, mongodoc.StableChannel)
+	err = store.Publish(rurl, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 
 	tests := []struct {
@@ -3305,7 +3305,7 @@ func (s *StoreSuite) TestBundleCharms(c *gc.C) {
 var publishTests = []struct {
 	about              string
 	url                *router.ResolvedURL
-	channels           []mongodoc.Channel
+	channels           []params.Channel
 	initialEntity      *mongodoc.Entity
 	initialBaseEntity  *mongodoc.BaseEntity
 	expectedEntity     *mongodoc.Entity
@@ -3314,7 +3314,7 @@ var publishTests = []struct {
 }{{
 	about:    "unpublished, single series, publish development",
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
-	channels: []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels: []params.Channel{params.DevelopmentChannel},
 	initialEntity: &mongodoc.Entity{
 		URL: charm.MustParseURL("~who/trusty/django-42"),
 	},
@@ -3327,8 +3327,8 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-42"),
 			},
 		},
@@ -3336,15 +3336,15 @@ var publishTests = []struct {
 }, {
 	about:    "development, single series, publish development",
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
-	channels: []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels: []params.Channel{params.DevelopmentChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:         charm.MustParseURL("~who/trusty/django-42"),
 		Development: true,
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-41"),
 			},
 		},
@@ -3355,8 +3355,8 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-42"),
 			},
 		},
@@ -3364,15 +3364,15 @@ var publishTests = []struct {
 }, {
 	about:    "stable, single series, publish development",
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
-	channels: []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels: []params.Channel{params.DevelopmentChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:    charm.MustParseURL("~who/trusty/django-42"),
 		Stable: true,
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-42"),
 			},
 		},
@@ -3384,11 +3384,11 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-42"),
 			},
-			mongodoc.DevelopmentChannel: {
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-42"),
 			},
 		},
@@ -3396,7 +3396,7 @@ var publishTests = []struct {
 }, {
 	about:    "unpublished, single series, publish stable",
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
-	channels: []mongodoc.Channel{mongodoc.StableChannel},
+	channels: []params.Channel{params.StableChannel},
 	initialEntity: &mongodoc.Entity{
 		URL: charm.MustParseURL("~who/trusty/django-42"),
 	},
@@ -3409,8 +3409,8 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-42"),
 			},
 		},
@@ -3418,15 +3418,15 @@ var publishTests = []struct {
 }, {
 	about:    "development, single series, publish stable",
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
-	channels: []mongodoc.Channel{mongodoc.StableChannel},
+	channels: []params.Channel{params.StableChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:         charm.MustParseURL("~who/trusty/django-42"),
 		Development: true,
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-41"),
 			},
 		},
@@ -3438,11 +3438,11 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-41"),
 			},
-			mongodoc.StableChannel: {
+			params.StableChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-42"),
 			},
 		},
@@ -3450,15 +3450,15 @@ var publishTests = []struct {
 }, {
 	about:    "stable, single series, publish stable",
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
-	channels: []mongodoc.Channel{mongodoc.StableChannel},
+	channels: []params.Channel{params.StableChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:    charm.MustParseURL("~who/trusty/django-42"),
 		Stable: true,
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-40"),
 			},
 		},
@@ -3469,8 +3469,8 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"trusty": charm.MustParseURL("~who/trusty/django-42"),
 			},
 		},
@@ -3478,7 +3478,7 @@ var publishTests = []struct {
 }, {
 	about:    "unpublished, multi series, publish development",
 	url:      MustParseResolvedURL("~who/django-42"),
-	channels: []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels: []params.Channel{params.DevelopmentChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"trusty", "wily"},
@@ -3493,8 +3493,8 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/django-42"),
 				"wily":   charm.MustParseURL("~who/django-42"),
 			},
@@ -3503,7 +3503,7 @@ var publishTests = []struct {
 }, {
 	about:    "development, multi series, publish development",
 	url:      MustParseResolvedURL("~who/django-42"),
-	channels: []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels: []params.Channel{params.DevelopmentChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		Development:     true,
@@ -3511,8 +3511,8 @@ var publishTests = []struct {
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"precise": charm.MustParseURL("~who/django-0"),
 				"trusty":  charm.MustParseURL("~who/trusty/django-0"),
 			},
@@ -3525,8 +3525,8 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"precise": charm.MustParseURL("~who/django-0"),
 				"trusty":  charm.MustParseURL("~who/django-42"),
 				"wily":    charm.MustParseURL("~who/django-42"),
@@ -3536,7 +3536,7 @@ var publishTests = []struct {
 }, {
 	about:    "stable, multi series, publish development",
 	url:      MustParseResolvedURL("~who/django-47"),
-	channels: []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels: []params.Channel{params.DevelopmentChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-47"),
 		SupportedSeries: []string{"trusty", "wily", "precise"},
@@ -3544,8 +3544,8 @@ var publishTests = []struct {
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"trusty": charm.MustParseURL("~who/django-47"),
 			},
 		},
@@ -3558,11 +3558,11 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"trusty": charm.MustParseURL("~who/django-47"),
 			},
-			mongodoc.DevelopmentChannel: {
+			params.DevelopmentChannel: {
 				"trusty":  charm.MustParseURL("~who/django-47"),
 				"wily":    charm.MustParseURL("~who/django-47"),
 				"precise": charm.MustParseURL("~who/django-47"),
@@ -3572,7 +3572,7 @@ var publishTests = []struct {
 }, {
 	about:    "unpublished, multi series, publish stable",
 	url:      MustParseResolvedURL("~who/django-42"),
-	channels: []mongodoc.Channel{mongodoc.StableChannel},
+	channels: []params.Channel{params.StableChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"trusty", "wily", "precise"},
@@ -3587,8 +3587,8 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"trusty":  charm.MustParseURL("~who/django-42"),
 				"wily":    charm.MustParseURL("~who/django-42"),
 				"precise": charm.MustParseURL("~who/django-42"),
@@ -3598,7 +3598,7 @@ var publishTests = []struct {
 }, {
 	about:    "development, multi series, publish stable",
 	url:      MustParseResolvedURL("~who/django-42"),
-	channels: []mongodoc.Channel{mongodoc.StableChannel},
+	channels: []params.Channel{params.StableChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"wily"},
@@ -3606,8 +3606,8 @@ var publishTests = []struct {
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/django-0"),
 			},
 		},
@@ -3620,11 +3620,11 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"wily": charm.MustParseURL("~who/django-42"),
 			},
-			mongodoc.DevelopmentChannel: {
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/django-0"),
 			},
 		},
@@ -3632,7 +3632,7 @@ var publishTests = []struct {
 }, {
 	about:    "stable, multi series, publish stable",
 	url:      MustParseResolvedURL("~who/django-42"),
-	channels: []mongodoc.Channel{mongodoc.StableChannel},
+	channels: []params.Channel{params.StableChannel},
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"trusty", "wily", "precise"},
@@ -3640,8 +3640,8 @@ var publishTests = []struct {
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"precise": charm.MustParseURL("~who/django-1"),
 				"quantal": charm.MustParseURL("~who/django-2"),
 				"saucy":   charm.MustParseURL("~who/django-3"),
@@ -3656,8 +3656,8 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"precise": charm.MustParseURL("~who/django-42"),
 				"quantal": charm.MustParseURL("~who/django-2"),
 				"saucy":   charm.MustParseURL("~who/django-3"),
@@ -3669,7 +3669,7 @@ var publishTests = []struct {
 }, {
 	about:    "bundle",
 	url:      MustParseResolvedURL("~who/bundle/django-42"),
-	channels: []mongodoc.Channel{mongodoc.StableChannel},
+	channels: []params.Channel{params.StableChannel},
 	initialEntity: &mongodoc.Entity{
 		URL: charm.MustParseURL("~who/bundle/django-42"),
 	},
@@ -3682,8 +3682,8 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"bundle": charm.MustParseURL("~who/bundle/django-42"),
 			},
 		},
@@ -3691,19 +3691,19 @@ var publishTests = []struct {
 }, {
 	about:    "unpublished, multi series, publish multiple channels",
 	url:      MustParseResolvedURL("~who/django-42"),
-	channels: []mongodoc.Channel{mongodoc.DevelopmentChannel, mongodoc.StableChannel, mongodoc.Channel("no-such")},
+	channels: []params.Channel{params.DevelopmentChannel, params.StableChannel, params.Channel("no-such")},
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"trusty", "wily"},
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.StableChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.StableChannel: {
 				"quantal": charm.MustParseURL("~who/django-1"),
 				"trusty":  charm.MustParseURL("~who/django-4"),
 			},
-			mongodoc.DevelopmentChannel: {
+			params.DevelopmentChannel: {
 				"wily": charm.MustParseURL("~who/django-10"),
 			},
 		},
@@ -3716,12 +3716,12 @@ var publishTests = []struct {
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
-		ChannelEntities: map[mongodoc.Channel]map[string]*charm.URL{
-			mongodoc.DevelopmentChannel: {
+		ChannelEntities: map[params.Channel]map[string]*charm.URL{
+			params.DevelopmentChannel: {
 				"trusty": charm.MustParseURL("~who/django-42"),
 				"wily":   charm.MustParseURL("~who/django-42"),
 			},
-			mongodoc.StableChannel: {
+			params.StableChannel: {
 				"quantal": charm.MustParseURL("~who/django-1"),
 				"trusty":  charm.MustParseURL("~who/django-42"),
 				"wily":    charm.MustParseURL("~who/django-42"),
@@ -3731,7 +3731,7 @@ var publishTests = []struct {
 }, {
 	about:    "not found",
 	url:      MustParseResolvedURL("~who/trusty/no-such-42"),
-	channels: []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels: []params.Channel{params.DevelopmentChannel},
 	initialEntity: &mongodoc.Entity{
 		URL: charm.MustParseURL("~who/trusty/django-42"),
 	},
@@ -3742,7 +3742,7 @@ var publishTests = []struct {
 }, {
 	about:    "no valid channels provided",
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
-	channels: []mongodoc.Channel{mongodoc.Channel("not-valid")},
+	channels: []params.Channel{params.Channel("not-valid")},
 	initialEntity: &mongodoc.Entity{
 		URL: charm.MustParseURL("~who/trusty/django-42"),
 	},
@@ -3801,7 +3801,7 @@ func (s *StoreSuite) TestPublishWithFailedESInsert(c *gc.C) {
 	url := router.MustNewResolvedURL("~charmers/precise/wordpress-12", -1)
 	err := store.AddCharmWithArchive(url, storetesting.Charms.CharmDir("wordpress"))
 	c.Assert(err, gc.IsNil)
-	err = store.Publish(url, mongodoc.StableChannel)
+	err = store.Publish(url, params.StableChannel)
 	c.Assert(err, gc.ErrorMatches, "cannot index cs:~charmers/precise/wordpress-12 to ElasticSearch: .*")
 }
 
@@ -3826,7 +3826,7 @@ func baseEntity(url string, promulgated bool) *mongodoc.BaseEntity {
 		Name:            id.Name,
 		User:            id.User,
 		Promulgated:     mongodoc.IntBool(promulgated),
-		ChannelEntities: make(map[mongodoc.Channel]map[string]*charm.URL),
+		ChannelEntities: make(map[params.Channel]map[string]*charm.URL),
 	}
 }
 

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -188,7 +188,7 @@ func (h *reqHandler) serveCharmInfo(_ http.Header, req *http.Request) (interface
 		}
 		var entity *mongodoc.Entity
 		if err == nil {
-			entity, err = h.store.FindBestEntity(curl, mongodoc.UnpublishedChannel, nil)
+			entity, err = h.store.FindBestEntity(curl, params.UnpublishedChannel, nil)
 			if errgo.Cause(err) == params.ErrNotFound {
 				// The old API actually returned "entry not found"
 				// on *any* error, but it seems reasonable to be
@@ -257,7 +257,7 @@ func (h *reqHandler) serveCharmEvent(_ http.Header, req *http.Request) (interfac
 		}
 
 		// Retrieve the charm.
-		entity, err := h.store.FindBestEntity(id, mongodoc.UnpublishedChannel, charmstore.FieldSelector("_id", "uploadtime", "extrainfo"))
+		entity, err := h.store.FindBestEntity(id, params.UnpublishedChannel, charmstore.FieldSelector("_id", "uploadtime", "extrainfo"))
 		if err != nil {
 			if errgo.Cause(err) == params.ErrNotFound {
 				// The old API actually returned "entry not found"

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -26,7 +26,6 @@ import (
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/legacy"
-	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting/stats"
@@ -410,7 +409,7 @@ func (s *APISuite) addPublicCharm(c *gc.C, charmName, curl string) (*router.Reso
 func (s *APISuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	err := s.store.SetPerms(&rurl.URL, "stable.read", params.Everyone)
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(rurl, mongodoc.StableChannel)
+	err = s.store.Publish(rurl, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 }
 

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -8,6 +8,7 @@ import (
 
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -185,12 +186,12 @@ type BaseEntity struct {
 	// ChannelACLs holds a map from an entity channel to the ACLs
 	// that apply to entities that use this base entity that are associated
 	// with the given channel.
-	ChannelACLs map[Channel]ACL
+	ChannelACLs map[params.Channel]ACL
 
 	// ChannelEntities holds a set of channels, each containing a set
 	// of series holding the currently published entity revision for
 	// that channel and series.
-	ChannelEntities map[Channel]map[string]*charm.URL
+	ChannelEntities map[params.Channel]map[string]*charm.URL
 }
 
 // ACL holds lists of users and groups that are
@@ -314,23 +315,6 @@ func (b *IntBool) SetBSON(raw bson.Raw) error {
 	}
 	return nil
 }
-
-// Channel is the name of a channel in which an entity may be published.
-type Channel string
-
-const (
-	// DevelopmentChannel is the channel used for charms or bundles under development.
-	DevelopmentChannel Channel = "development"
-
-	// StableChannel is the channel used for stable charms or bundles.
-	StableChannel Channel = "stable"
-
-	// UnpublishedChannel is the default channel to which charms are uploaded.
-	UnpublishedChannel Channel = "unpublished"
-
-	// NoChannel represents where no channel has been specifically requested.
-	NoChannel Channel = ""
-)
 
 // BaseURL returns the "base" version of url. If
 // url represents an entity, then the returned URL

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -7,6 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
@@ -111,10 +112,10 @@ func (b BaseEntityBuilder) WithPromulgated(promulgated bool) BaseEntityBuilder {
 }
 
 // WithACLs sets the ACLs field on the BaseEntity.
-func (b BaseEntityBuilder) WithACLs(channel mongodoc.Channel, acls mongodoc.ACL) BaseEntityBuilder {
+func (b BaseEntityBuilder) WithACLs(channel params.Channel, acls mongodoc.ACL) BaseEntityBuilder {
 	b = b.copy()
 	if b.baseEntity.ChannelACLs == nil {
-		b.baseEntity.ChannelACLs = make(map[mongodoc.Channel]mongodoc.ACL)
+		b.baseEntity.ChannelACLs = make(map[params.Channel]mongodoc.ACL)
 	}
 	b.baseEntity.ChannelACLs[channel] = acls
 	return b

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -88,7 +88,7 @@ var requiredEntityFields = func() map[string]int {
 // a charmstore.ErrTooManySessions cause.
 func (h *Handler) NewReqHandler(req *http.Request) (ReqHandler, error) {
 	req.ParseForm()
-	ch := mongodoc.Channel(req.Form.Get("channel"))
+	ch := params.Channel(req.Form.Get("channel"))
 	if !v5.ValidChannels[ch] {
 		return ReqHandler{}, badRequestf(nil, "invalid channel %q specified in request", ch)
 	}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -626,16 +626,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Write: []string{"charmers"},
 		})
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
@@ -668,16 +668,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			})
 		}
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
@@ -685,7 +685,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 	// Publish one of the revisions to development, then PUT to meta/perm
 	// and check that the development ACLs have changed.
-	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), mongodoc.DevelopmentChannel)
+	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), params.DevelopmentChannel)
 	c.Assert(err, gc.IsNil)
 
 	s.doAsUser("bob", func() {
@@ -721,23 +721,23 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		})
 	})
 
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
 	})
 	// Publish wordpress-1 to stable and check that the stable ACLs
 	// have changed.
-	err = s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), mongodoc.StableChannel)
+	err = s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), params.StableChannel)
 	c.Assert(err, gc.IsNil)
 
 	// The stable permissions only allow charmers currently, so act as
@@ -779,16 +779,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		})
 	})
 
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"doris"},
 		},
@@ -801,16 +801,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		s.assertPut(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
 	})
 
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"bob", params.Everyone},
 			Write: []string{"doris"},
 		},
@@ -823,16 +823,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		})
 		s.assertGet(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"bob", params.Everyone},
 			Write: []string{"doris"},
 		},
@@ -861,16 +861,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		})
 	}
 
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{},
 			Write: []string{},
 		},
@@ -881,16 +881,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read:  []string{"bob"},
 		Write: []string{"admin"},
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
@@ -903,16 +903,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		}{Read: []string{"joe"}}
 		s.assertPut(c, "wordpress/meta/perm", readRequest)
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"joe"},
 			Write: []string{},
 		},
@@ -971,16 +971,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			},
 		})
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"joe"},
 			Write: []string{"bob"},
 		},
@@ -992,7 +992,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 // assertChannelACLs asserts that the ChannelACLs field of the base entity with the
 // given URL are as given.
-func (s *APISuite) assertChannelACLs(c *gc.C, url string, acls map[mongodoc.Channel]mongodoc.ACL) {
+func (s *APISuite) assertChannelACLs(c *gc.C, url string, acls map[params.Channel]mongodoc.ACL) {
 	e, err := s.store.FindBaseEntity(charm.MustParseURL(url), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.ChannelACLs, jc.DeepEquals, acls)
@@ -1684,7 +1684,7 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 		url := charm.MustParseURL(test.url)
 		rurl, err := v4.ResolveURL(entitycache.New(&v5.StoreWithChannel{
 			Store:   s.store,
-			Channel: mongodoc.UnpublishedChannel,
+			Channel: params.UnpublishedChannel,
 		}), url)
 		if test.notFound {
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
@@ -1769,7 +1769,7 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
 	err := s.store.AddCharmWithArchive(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), storetesting.NewCharm(nil))
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), mongodoc.DevelopmentChannel)
+	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), params.DevelopmentChannel)
 	c.Assert(err, gc.IsNil)
 	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
 
@@ -2567,24 +2567,24 @@ func (s *APISuite) TestHash256Laziness(c *gc.C) {
 
 var urlChannelResolvingEntities = []struct {
 	id      *router.ResolvedURL
-	channel mongodoc.Channel
+	channel params.Channel
 }{{
 	id:      newResolvedURL("~charmers/precise/wordpress-0", 0),
-	channel: mongodoc.StableChannel,
+	channel: params.StableChannel,
 }, {
 	id:      newResolvedURL("~charmers/precise/wordpress-1", 1),
-	channel: mongodoc.DevelopmentChannel,
+	channel: params.DevelopmentChannel,
 }, {
 	id:      newResolvedURL("~charmers/precise/wordpress-2", 2),
-	channel: mongodoc.UnpublishedChannel,
+	channel: params.UnpublishedChannel,
 }, {
 	id:      newResolvedURL("~charmers/trusty/mysql-0", 0),
-	channel: mongodoc.UnpublishedChannel,
+	channel: params.UnpublishedChannel,
 }}
 
 var urlChannelResolvingTests = []struct {
 	url          string
-	channel      mongodoc.Channel
+	channel      params.Channel
 	expectURL    string
 	expectStatus int
 	expectError  params.Error
@@ -2593,23 +2593,23 @@ var urlChannelResolvingTests = []struct {
 	expectURL: "cs:precise/wordpress-0",
 }, {
 	url:       "wordpress",
-	channel:   mongodoc.StableChannel,
+	channel:   params.StableChannel,
 	expectURL: "cs:precise/wordpress-0",
 }, {
 	url:       "wordpress",
-	channel:   mongodoc.DevelopmentChannel,
+	channel:   params.DevelopmentChannel,
 	expectURL: "cs:precise/wordpress-1",
 }, {
 	url:       "wordpress",
-	channel:   mongodoc.UnpublishedChannel,
+	channel:   params.UnpublishedChannel,
 	expectURL: "cs:precise/wordpress-2",
 }, {
 	url:       "~charmers/precise/wordpress",
-	channel:   mongodoc.StableChannel,
+	channel:   params.StableChannel,
 	expectURL: "cs:~charmers/precise/wordpress-0",
 }, {
 	url:          "~charmers/precise/wordpress-2",
-	channel:      mongodoc.StableChannel,
+	channel:      params.StableChannel,
 	expectStatus: http.StatusNotFound,
 	expectError: params.Error{
 		Message: `cs:~charmers/precise/wordpress-2 not found in stable channel`,
@@ -2637,7 +2637,7 @@ func (s *APISuite) TestURLChannelResolving(c *gc.C) {
 	for _, add := range urlChannelResolvingEntities {
 		err := s.store.AddCharmWithArchive(add.id, storetesting.NewCharm(nil))
 		c.Assert(err, gc.IsNil)
-		if add.channel != mongodoc.UnpublishedChannel {
+		if add.channel != params.UnpublishedChannel {
 			err = s.store.Publish(add.id, add.channel)
 			c.Assert(err, gc.IsNil)
 		}
@@ -2914,7 +2914,7 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.StableChannel, mongodoc.ACL{
+		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(params.StableChannel, mongodoc.ACL{
 			Write: []string{v4.PromulgatorsGroup},
 		}).WithPromulgated(true).Build(),
 	},
@@ -3052,7 +3052,7 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.StableChannel, mongodoc.ACL{
+		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(params.StableChannel, mongodoc.ACL{
 			Write: []string{v4.PromulgatorsGroup},
 		}).WithPromulgated(true).Build(),
 	},
@@ -3079,7 +3079,7 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.StableChannel, mongodoc.ACL{
+		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(params.StableChannel, mongodoc.ACL{
 			Write: []string{v4.PromulgatorsGroup},
 		}).WithPromulgated(true).Build(),
 	},
@@ -3325,11 +3325,11 @@ func entityACLs(store *charmstore.Store, url *router.ResolvedURL) (mongodoc.ACL,
 	if err != nil {
 		return mongodoc.ACL{}, err
 	}
-	ch := mongodoc.UnpublishedChannel
+	ch := params.UnpublishedChannel
 	if e.Stable {
-		ch = mongodoc.StableChannel
+		ch = params.StableChannel
 	} else if e.Development {
-		ch = mongodoc.DevelopmentChannel
+		ch = params.DevelopmentChannel
 	}
 	return be.ChannelACLs[ch], nil
 }

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -563,7 +563,7 @@ func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 	} {
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmArchive(c.MkDir(), rurl.URL.Name))
 		c.Assert(err, gc.IsNil)
-		err = s.store.Publish(rurl, mongodoc.StableChannel)
+		err = s.store.Publish(rurl, params.StableChannel)
 		c.Assert(err, gc.IsNil)
 	}
 

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -25,7 +25,6 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v4"
 )
@@ -221,7 +220,7 @@ var readAuthorizationTests = []struct {
 	// stableReadPerm stores a list of users with read permissions on the stable channel.
 	stableReadPerm []string
 	// channels contains a list of channels, to which the entity belongs.
-	channels []mongodoc.Channel
+	channels []params.Channel
 	// expectStatus is the expected HTTP response status.
 	// Defaults to 200 status OK.
 	expectStatus int
@@ -309,7 +308,7 @@ var readAuthorizationTests = []struct {
 	groups:              []string{"group1", "group2", "group3"},
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group1"},
-	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels:            []params.Channel{params.DevelopmentChannel},
 }, {
 	about:               "access provided through development channel, but charm not published",
 	username:            "kirk",
@@ -328,7 +327,7 @@ var readAuthorizationTests = []struct {
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group12"},
 	stableReadPerm:      []string{"group2"},
-	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel, mongodoc.StableChannel},
+	channels:            []params.Channel{params.DevelopmentChannel, params.StableChannel},
 }, {
 	about:               "access provided through stable channel, but charm not published",
 	username:            "kirk",
@@ -336,7 +335,7 @@ var readAuthorizationTests = []struct {
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group12"},
 	stableReadPerm:      []string{"group2"},
-	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels:            []params.Channel{params.DevelopmentChannel},
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
@@ -349,9 +348,9 @@ var readAuthorizationTests = []struct {
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group1"},
 	stableReadPerm:      []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
-		mongodoc.StableChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
+		params.StableChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -364,9 +363,9 @@ var readAuthorizationTests = []struct {
 	groups:              []string{"group1", "group2", "group3"},
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group1"},
 	stableReadPerm:      []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
-		mongodoc.StableChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
+		params.StableChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -379,8 +378,8 @@ var readAuthorizationTests = []struct {
 	groups:              []string{"group1", "group2", "group3"},
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group1"},
 	developmentReadPerm: []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -469,7 +468,7 @@ var writeAuthorizationTests = []struct {
 	// stableWritePerm stores a list of users with write permissions on the stable channel.
 	stableWritePerm []string
 	// channels contains a list of channels, to which the entity belongs.
-	channels []mongodoc.Channel
+	channels []params.Channel
 	// expectStatus is the expected HTTP response status.
 	// Defaults to 200 status OK.
 	expectStatus int
@@ -544,7 +543,7 @@ var writeAuthorizationTests = []struct {
 	groups:               []string{"group1", "group2", "group3"},
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
-	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels:             []params.Channel{params.DevelopmentChannel},
 }, {
 	about:                "access provided through development channel, but charm not published",
 	username:             "kirk",
@@ -563,7 +562,7 @@ var writeAuthorizationTests = []struct {
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group12"},
 	stableWritePerm:      []string{"group2"},
-	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel, mongodoc.StableChannel},
+	channels:             []params.Channel{params.DevelopmentChannel, params.StableChannel},
 }, {
 	about:                "access provided through stable channel, but charm not published",
 	username:             "kirk",
@@ -571,7 +570,7 @@ var writeAuthorizationTests = []struct {
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group12"},
 	stableWritePerm:      []string{"group2"},
-	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels:             []params.Channel{params.DevelopmentChannel},
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
@@ -584,9 +583,9 @@ var writeAuthorizationTests = []struct {
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
 	stableWritePerm:      []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
-		mongodoc.StableChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
+		params.StableChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -599,9 +598,9 @@ var writeAuthorizationTests = []struct {
 	groups:               []string{"group1", "group2", "group3"},
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group1"},
 	stableWritePerm:      []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
-		mongodoc.StableChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
+		params.StableChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -614,8 +613,8 @@ var writeAuthorizationTests = []struct {
 	groups:               []string{"group1", "group2", "group3"},
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group1"},
 	developmentWritePerm: []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -1005,7 +1004,7 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 		rurl,
 		storetesting.Charms.CharmDir("wordpress"))
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(rurl, mongodoc.StableChannel)
+	err = s.store.Publish(rurl, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 	// Change the ACLs for the testing charm.
 	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -23,7 +23,6 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
-	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v4"
@@ -205,7 +204,7 @@ func (s *commonSuite) addPublicCharm(c *gc.C, ch charm.Charm, rurl *router.Resol
 func (s *commonSuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	err := s.store.SetPerms(&rurl.URL, "stable.read", params.Everyone)
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(rurl, mongodoc.StableChannel)
+	err = s.store.Publish(rurl, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -265,7 +264,7 @@ func storeURL(path string) string {
 func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
 	for _, svc := range bundle.Data().Services {
 		u := charm.MustParseURL(svc.Charm)
-		if _, err := s.store.FindBestEntity(u, mongodoc.StableChannel, nil); err == nil {
+		if _, err := s.store.FindBestEntity(u, params.StableChannel, nil); err == nil {
 			continue
 		}
 		if u.Revision == -1 {

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -138,7 +138,7 @@ var (
 // to resolve any channel-ambiguous requests.
 type StoreWithChannel struct {
 	*charmstore.Store
-	Channel mongodoc.Channel
+	Channel params.Channel
 }
 
 func (s *StoreWithChannel) FindBestEntity(url *charm.URL, fields map[string]int) (*mongodoc.Entity, error) {
@@ -150,11 +150,11 @@ func (s *StoreWithChannel) FindBaseEntity(url *charm.URL, fields map[string]int)
 }
 
 // ValidChannels holds the set of all allowed channels.
-var ValidChannels = map[mongodoc.Channel]bool{
-	mongodoc.UnpublishedChannel: true,
-	mongodoc.DevelopmentChannel: true,
-	mongodoc.StableChannel:      true,
-	mongodoc.NoChannel:          true,
+var ValidChannels = map[params.Channel]bool{
+	params.UnpublishedChannel: true,
+	params.DevelopmentChannel: true,
+	params.StableChannel:      true,
+	params.NoChannel:          true,
 }
 
 // NewReqHandler returns an instance of a *ReqHandler
@@ -165,7 +165,7 @@ var ValidChannels = map[mongodoc.Channel]bool{
 // a charmstore.ErrTooManySessions cause.
 func (h *Handler) NewReqHandler(req *http.Request) (*ReqHandler, error) {
 	req.ParseForm()
-	ch := mongodoc.Channel(req.Form.Get("channel"))
+	ch := params.Channel(req.Form.Get("channel"))
 	if !ValidChannels[ch] {
 		return nil, badRequestf(nil, "invalid channel %q specified in request", ch)
 	}

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -714,16 +714,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Write: []string{"charmers"},
 		})
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
@@ -756,16 +756,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			})
 		}
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
@@ -773,7 +773,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 	// Publish one of the revisions to development, then PUT to meta/perm
 	// and check that the development ACLs have changed.
-	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), mongodoc.DevelopmentChannel)
+	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), params.DevelopmentChannel)
 	c.Assert(err, gc.IsNil)
 
 	s.doAsUser("bob", func() {
@@ -809,23 +809,23 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		})
 	})
 
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"charmers"},
 		},
 	})
 	// Publish wordpress-1 to stable and check that the stable ACLs
 	// have changed.
-	err = s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), mongodoc.StableChannel)
+	err = s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), params.StableChannel)
 	c.Assert(err, gc.IsNil)
 
 	// The stable permissions only allow charmers currently, so act as
@@ -867,16 +867,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		})
 	})
 
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"charmers"},
 			Write: []string{"doris"},
 		},
@@ -889,16 +889,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		s.assertPut(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
 	})
 
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"bob", params.Everyone},
 			Write: []string{"doris"},
 		},
@@ -911,16 +911,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		})
 		s.assertGet(c, "wordpress/meta/perm/read", []string{"bob", params.Everyone})
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"bob", params.Everyone},
 			Write: []string{"doris"},
 		},
@@ -949,16 +949,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		})
 	}
 
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{},
 			Write: []string{},
 		},
@@ -969,16 +969,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		Read:  []string{"bob"},
 		Write: []string{"admin"},
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
@@ -991,16 +991,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		}{Read: []string{"joe"}}
 		s.assertPut(c, "wordpress/meta/perm", readRequest)
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"joe"},
 			Write: []string{},
 		},
@@ -1059,16 +1059,16 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			},
 		})
 	})
-	s.assertChannelACLs(c, "precise/wordpress-23", map[mongodoc.Channel]mongodoc.ACL{
-		mongodoc.UnpublishedChannel: {
+	s.assertChannelACLs(c, "precise/wordpress-23", map[params.Channel]mongodoc.ACL{
+		params.UnpublishedChannel: {
 			Read:  []string{"bob"},
 			Write: []string{"admin"},
 		},
-		mongodoc.DevelopmentChannel: {
+		params.DevelopmentChannel: {
 			Read:  []string{"bob", "charlie"},
 			Write: []string{"charmers"},
 		},
-		mongodoc.StableChannel: {
+		params.StableChannel: {
 			Read:  []string{"joe"},
 			Write: []string{"bob"},
 		},
@@ -1080,7 +1080,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 // assertChannelACLs asserts that the ChannelACLs field of the base entity with the
 // given URL are as given.
-func (s *APISuite) assertChannelACLs(c *gc.C, url string, acls map[mongodoc.Channel]mongodoc.ACL) {
+func (s *APISuite) assertChannelACLs(c *gc.C, url string, acls map[params.Channel]mongodoc.ACL) {
 	e, err := s.store.FindBaseEntity(charm.MustParseURL(url), nil)
 	c.Assert(err, gc.IsNil)
 	c.Assert(e.ChannelACLs, jc.DeepEquals, acls)
@@ -1800,7 +1800,7 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 		url := charm.MustParseURL(test.url)
 		rurl, err := v5.ResolveURL(entitycache.New(&v5.StoreWithChannel{
 			Store:   s.store,
-			Channel: mongodoc.UnpublishedChannel,
+			Channel: params.UnpublishedChannel,
 		}), url)
 		if test.notFound {
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
@@ -1877,7 +1877,7 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
 	err := s.store.AddCharmWithArchive(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), storetesting.NewCharm(nil))
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), mongodoc.DevelopmentChannel)
+	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), params.DevelopmentChannel)
 	c.Assert(err, gc.IsNil)
 	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
 
@@ -2675,24 +2675,24 @@ func (s *APISuite) TestHash256Laziness(c *gc.C) {
 
 var urlChannelResolvingEntities = []struct {
 	id      *router.ResolvedURL
-	channel mongodoc.Channel
+	channel params.Channel
 }{{
 	id:      newResolvedURL("~charmers/precise/wordpress-0", 0),
-	channel: mongodoc.StableChannel,
+	channel: params.StableChannel,
 }, {
 	id:      newResolvedURL("~charmers/precise/wordpress-1", 1),
-	channel: mongodoc.DevelopmentChannel,
+	channel: params.DevelopmentChannel,
 }, {
 	id:      newResolvedURL("~charmers/precise/wordpress-2", 2),
-	channel: mongodoc.UnpublishedChannel,
+	channel: params.UnpublishedChannel,
 }, {
 	id:      newResolvedURL("~charmers/trusty/mysql-0", 0),
-	channel: mongodoc.UnpublishedChannel,
+	channel: params.UnpublishedChannel,
 }}
 
 var urlChannelResolvingTests = []struct {
 	url          string
-	channel      mongodoc.Channel
+	channel      params.Channel
 	expectURL    string
 	expectStatus int
 	expectError  params.Error
@@ -2701,23 +2701,23 @@ var urlChannelResolvingTests = []struct {
 	expectURL: "cs:precise/wordpress-0",
 }, {
 	url:       "wordpress",
-	channel:   mongodoc.StableChannel,
+	channel:   params.StableChannel,
 	expectURL: "cs:precise/wordpress-0",
 }, {
 	url:       "wordpress",
-	channel:   mongodoc.DevelopmentChannel,
+	channel:   params.DevelopmentChannel,
 	expectURL: "cs:precise/wordpress-1",
 }, {
 	url:       "wordpress",
-	channel:   mongodoc.UnpublishedChannel,
+	channel:   params.UnpublishedChannel,
 	expectURL: "cs:precise/wordpress-2",
 }, {
 	url:       "~charmers/precise/wordpress",
-	channel:   mongodoc.StableChannel,
+	channel:   params.StableChannel,
 	expectURL: "cs:~charmers/precise/wordpress-0",
 }, {
 	url:          "~charmers/precise/wordpress-2",
-	channel:      mongodoc.StableChannel,
+	channel:      params.StableChannel,
 	expectStatus: http.StatusNotFound,
 	expectError: params.Error{
 		Message: `cs:~charmers/precise/wordpress-2 not found in stable channel`,
@@ -2745,7 +2745,7 @@ func (s *APISuite) TestURLChannelResolving(c *gc.C) {
 	for _, add := range urlChannelResolvingEntities {
 		err := s.store.AddCharmWithArchive(add.id, storetesting.NewCharm(nil))
 		c.Assert(err, gc.IsNil)
-		if add.channel != mongodoc.UnpublishedChannel {
+		if add.channel != params.UnpublishedChannel {
 			err = s.store.Publish(add.id, add.channel)
 			c.Assert(err, gc.IsNil)
 		}
@@ -2983,7 +2983,7 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.StableChannel, mongodoc.ACL{
+		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(params.StableChannel, mongodoc.ACL{
 			Write: []string{v5.PromulgatorsGroup},
 		}).WithPromulgated(true).Build(),
 	},
@@ -3121,7 +3121,7 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.StableChannel, mongodoc.ACL{
+		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(params.StableChannel, mongodoc.ACL{
 			Write: []string{v5.PromulgatorsGroup},
 		}).WithPromulgated(true).Build(),
 	},
@@ -3148,7 +3148,7 @@ var promulgateTests = []struct {
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
 	},
 	expectBaseEntities: []*mongodoc.BaseEntity{
-		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(mongodoc.StableChannel, mongodoc.ACL{
+		storetesting.NewBaseEntity("~charmers/wordpress").WithACLs(params.StableChannel, mongodoc.ACL{
 			Write: []string{v5.PromulgatorsGroup},
 		}).WithPromulgated(true).Build(),
 	},
@@ -3418,11 +3418,11 @@ func entityACLs(store *charmstore.Store, url *router.ResolvedURL) (mongodoc.ACL,
 	if err != nil {
 		return mongodoc.ACL{}, err
 	}
-	ch := mongodoc.UnpublishedChannel
+	ch := params.UnpublishedChannel
 	if e.Stable {
-		ch = mongodoc.StableChannel
+		ch = params.StableChannel
 	} else if e.Development {
-		ch = mongodoc.DevelopmentChannel
+		ch = params.DevelopmentChannel
 	}
 	return be.ChannelACLs[ch], nil
 }

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -79,7 +79,7 @@ func (h *ReqHandler) authorizeUpload(id *charm.URL, req *http.Request) error {
 	// is-entity first-party caveats to be allowed when uploading
 	// at which point we will need to rethink this a little.
 	if err == nil {
-		acls := baseEntity.ChannelACLs[mongodoc.UnpublishedChannel]
+		acls := baseEntity.ChannelACLs[params.UnpublishedChannel]
 		if err := h.authorizeWithPerms(req, acls.Read, acls.Write, nil); err != nil {
 			return errgo.Mask(err, errgo.Any)
 		}

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -560,7 +560,7 @@ func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 	} {
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmArchive(c.MkDir(), rurl.URL.Name))
 		c.Assert(err, gc.IsNil)
-		err = s.store.Publish(rurl, mongodoc.StableChannel)
+		err = s.store.Publish(rurl, params.StableChannel)
 		c.Assert(err, gc.IsNil)
 	}
 

--- a/internal/v5/auth.go
+++ b/internal/v5/auth.go
@@ -302,25 +302,25 @@ func (h *ReqHandler) AuthorizeEntity(id *router.ResolvedURL, req *http.Request) 
 	return h.authorizeWithPerms(req, acls.Read, acls.Write, id)
 }
 
-func (h *ReqHandler) entityChannel(id *router.ResolvedURL) (mongodoc.Channel, error) {
-	if h.Store.Channel != mongodoc.NoChannel {
+func (h *ReqHandler) entityChannel(id *router.ResolvedURL) (params.Channel, error) {
+	if h.Store.Channel != params.NoChannel {
 		return h.Store.Channel, nil
 	}
 	entity, err := h.Cache.Entity(&id.URL, charmstore.FieldSelector("development", "stable"))
 	if err != nil {
 		if errgo.Cause(err) == params.ErrNotFound {
-			return mongodoc.NoChannel, errgo.WithCausef(nil, params.ErrNotFound, "entity %q not found", id)
+			return params.NoChannel, errgo.WithCausef(nil, params.ErrNotFound, "entity %q not found", id)
 		}
-		return mongodoc.NoChannel, errgo.Notef(err, "cannot retrieve entity %q for authorization", id)
+		return params.NoChannel, errgo.Notef(err, "cannot retrieve entity %q for authorization", id)
 	}
-	var ch mongodoc.Channel
+	var ch params.Channel
 	switch {
 	case entity.Stable:
-		ch = mongodoc.StableChannel
+		ch = params.StableChannel
 	case entity.Development:
-		ch = mongodoc.DevelopmentChannel
+		ch = params.DevelopmentChannel
 	default:
-		ch = mongodoc.UnpublishedChannel
+		ch = params.UnpublishedChannel
 	}
 	return ch, nil
 }

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -25,7 +25,6 @@ import (
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
 	"gopkg.in/macaroon.v1"
 
-	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 )
@@ -221,7 +220,7 @@ var readAuthorizationTests = []struct {
 	// stableReadPerm stores a list of users with read permissions on the stable channel.
 	stableReadPerm []string
 	// channels contains a list of channels, to which the entity belongs.
-	channels []mongodoc.Channel
+	channels []params.Channel
 	// expectStatus is the expected HTTP response status.
 	// Defaults to 200 status OK.
 	expectStatus int
@@ -309,7 +308,7 @@ var readAuthorizationTests = []struct {
 	groups:              []string{"group1", "group2", "group3"},
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group1"},
-	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels:            []params.Channel{params.DevelopmentChannel},
 }, {
 	about:               "access provided through development channel, but charm not published",
 	username:            "kirk",
@@ -328,7 +327,7 @@ var readAuthorizationTests = []struct {
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group12"},
 	stableReadPerm:      []string{"group2"},
-	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel, mongodoc.StableChannel},
+	channels:            []params.Channel{params.DevelopmentChannel, params.StableChannel},
 }, {
 	about:               "access provided through stable channel, but charm not published",
 	username:            "kirk",
@@ -336,7 +335,7 @@ var readAuthorizationTests = []struct {
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group12"},
 	stableReadPerm:      []string{"group2"},
-	channels:            []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels:            []params.Channel{params.DevelopmentChannel},
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
@@ -349,9 +348,9 @@ var readAuthorizationTests = []struct {
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentReadPerm: []string{"group1"},
 	stableReadPerm:      []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
-		mongodoc.StableChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
+		params.StableChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -364,9 +363,9 @@ var readAuthorizationTests = []struct {
 	groups:              []string{"group1", "group2", "group3"},
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group1"},
 	stableReadPerm:      []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
-		mongodoc.StableChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
+		params.StableChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -379,8 +378,8 @@ var readAuthorizationTests = []struct {
 	groups:              []string{"group1", "group2", "group3"},
 	unpublishedReadPerm: []string{"picard", "sisko", "group42", "group1"},
 	developmentReadPerm: []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -469,7 +468,7 @@ var writeAuthorizationTests = []struct {
 	// stableWritePerm stores a list of users with write permissions on the stable channel.
 	stableWritePerm []string
 	// channels contains a list of channels, to which the entity belongs.
-	channels []mongodoc.Channel
+	channels []params.Channel
 	// expectStatus is the expected HTTP response status.
 	// Defaults to 200 status OK.
 	expectStatus int
@@ -544,7 +543,7 @@ var writeAuthorizationTests = []struct {
 	groups:               []string{"group1", "group2", "group3"},
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
-	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels:             []params.Channel{params.DevelopmentChannel},
 }, {
 	about:                "access provided through development channel, but charm not published",
 	username:             "kirk",
@@ -563,7 +562,7 @@ var writeAuthorizationTests = []struct {
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group12"},
 	stableWritePerm:      []string{"group2"},
-	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel, mongodoc.StableChannel},
+	channels:             []params.Channel{params.DevelopmentChannel, params.StableChannel},
 }, {
 	about:                "access provided through stable channel, but charm not published",
 	username:             "kirk",
@@ -571,7 +570,7 @@ var writeAuthorizationTests = []struct {
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group12"},
 	stableWritePerm:      []string{"group2"},
-	channels:             []mongodoc.Channel{mongodoc.DevelopmentChannel},
+	channels:             []params.Channel{params.DevelopmentChannel},
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
@@ -584,9 +583,9 @@ var writeAuthorizationTests = []struct {
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group47"},
 	developmentWritePerm: []string{"group1"},
 	stableWritePerm:      []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
-		mongodoc.StableChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
+		params.StableChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -599,9 +598,9 @@ var writeAuthorizationTests = []struct {
 	groups:               []string{"group1", "group2", "group3"},
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group1"},
 	stableWritePerm:      []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
-		mongodoc.StableChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
+		params.StableChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -614,8 +613,8 @@ var writeAuthorizationTests = []struct {
 	groups:               []string{"group1", "group2", "group3"},
 	unpublishedWritePerm: []string{"picard", "sisko", "group42", "group1"},
 	developmentWritePerm: []string{"group11"},
-	channels: []mongodoc.Channel{
-		mongodoc.DevelopmentChannel,
+	channels: []params.Channel{
+		params.DevelopmentChannel,
 	},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
@@ -1005,7 +1004,7 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 		rurl,
 		storetesting.Charms.CharmDir("wordpress"))
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(rurl, mongodoc.StableChannel)
+	err = s.store.Publish(rurl, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 	// Change the ACLs for the testing charm.
 	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -24,7 +24,6 @@ import (
 	"gopkg.in/mgo.v2"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
-	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"
@@ -226,7 +225,7 @@ func (s *commonSuite) addPublicCharm(c *gc.C, ch charm.Charm, rurl *router.Resol
 func (s *commonSuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	err := s.store.SetPerms(&rurl.URL, "stable.read", params.Everyone)
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(rurl, mongodoc.StableChannel)
+	err = s.store.Publish(rurl, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -305,7 +304,7 @@ func (s *commonSuite) bakeryDoAsUser(c *gc.C, user string) func(*http.Request) (
 func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
 	for _, svc := range bundle.Data().Services {
 		u := charm.MustParseURL(svc.Charm)
-		if _, err := s.store.FindBestEntity(u, mongodoc.StableChannel, nil); err == nil {
+		if _, err := s.store.FindBestEntity(u, params.StableChannel, nil); err == nil {
 			continue
 		}
 		if u.Revision == -1 {


### PR DESCRIPTION
This is an entirely mechanical change. We also update the dependencies
to use the new-channels-model branch of charmrepo.
