### PR TITLE
internal/v5: implement publish API endpoint

### DIFF
--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -128,6 +128,8 @@ func newReqHandler() ReqHandler {
 	handlers.Id["expand-id"] = resolveId(authId(h.serveExpandId))
 	handlers.Id["archive"] = h.serveArchive(handlers.Id["archive"])
 	handlers.Id["archive/"] = resolveId(h.serveArchiveFile)
+	// Publish is a new endpoint; don't provide it in v4.
+	delete(handlers.Id, "publish")
 	h.Router = router.New(handlers, h)
 	return h
 }

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -2496,6 +2496,22 @@ func (s *APISuite) TestChangesPublishedErrors(c *gc.C) {
 	}
 }
 
+func (s *APISuite) TestPublish(c *gc.C) {
+	// V4 SPECIFIC
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "PUT",
+		URL:          storeURL("wordpress/publish"),
+		Do:           bakeryDo(nil),
+		JSONBody:     params.PublishRequest{},
+		ExpectStatus: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Code:    params.ErrNotFound,
+			Message: `not found`,
+		},
+	})
+}
+
 // publishCharmsAtKnownTimes populates the store with
 // a range of charms with known time stamps.
 func (s *APISuite) publishCharmsAtKnownTimes(c *gc.C, charms []publishSpec) {


### PR DESCRIPTION
Also make sure that it's not served from the v4 API.
