### PR TITLE
internal/charmstore: fix add-preV5blob migration

### DIFF
--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -13,11 +13,12 @@ import (
 )
 
 const (
-	migrationAddSupportedSeries     mongodoc.MigrationName = "add supported series"
-	migrationAddDevelopment         mongodoc.MigrationName = "add development"
-	migrationAddDevelopmentACLs     mongodoc.MigrationName = "add development acls"
-	migrationFixBogusPromulgatedURL mongodoc.MigrationName = "fix promulgate url"
-	migrationAddPreV5CompatBlob     mongodoc.MigrationName = "add pre-v5 compatibility blobs"
+	migrationAddSupportedSeries      mongodoc.MigrationName = "add supported series"
+	migrationAddDevelopment          mongodoc.MigrationName = "add development"
+	migrationAddDevelopmentACLs      mongodoc.MigrationName = "add development acls"
+	migrationFixBogusPromulgatedURL  mongodoc.MigrationName = "fix promulgate url"
+	migrationAddPreV5CompatBlobBogus mongodoc.MigrationName = "add pre-v5 compatibility blobs"
+	migrationAddPreV5CompatBlob      mongodoc.MigrationName = "add pre-v5 compatibility blobs; second try"
 )
 
 // migrations holds all the migration functions that are executed in the order
@@ -53,6 +54,11 @@ var migrations = []migration{{
 }, {
 	name:    migrationFixBogusPromulgatedURL,
 	migrate: fixBogusPromulgatedURL,
+}, {
+	// The original migration that attempted to do this actually did
+	// nothing, so leave it here but use a new name for the
+	// fixed version.
+	name: migrationAddPreV5CompatBlobBogus,
 }, {
 	name:    migrationAddPreV5CompatBlob,
 	migrate: addPreV5CompatBlob,
@@ -221,11 +227,11 @@ func addPreV5CompatBlob(db StoreDatabase) error {
 	iter := entities.Find(bson.D{{
 		"prev5blobhash", bson.D{{"$exists", false}},
 	}}).Select(map[string]int{
-		"size":                  1,
-		"blobhash":              1,
-		"blobname":              1,
-		"blobhash256":           1,
-		"charm-metadata.series": 1,
+		"size":             1,
+		"blobhash":         1,
+		"blobname":         1,
+		"blobhash256":      1,
+		"charmmeta.series": 1,
 	}).Iter()
 	var entity mongodoc.Entity
 	for iter.Next(&entity) {

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"sync"
 
 	jujutesting "github.com/juju/testing"
@@ -152,11 +153,7 @@ func (s *migrationsSuite) newServer(c *gc.C) error {
 
 // patchMigrations patches the charm store migration list with the given migrations.
 func (s *migrationsSuite) patchMigrations(c *gc.C, ms []migration) {
-	original := migrations
-	s.AddCleanup(func(*gc.C) {
-		migrations = original
-	})
-	migrations = ms
+	s.PatchValue(&migrations, ms)
 }
 
 // makeMigrations generates default migrations using the given names, and then
@@ -482,11 +479,12 @@ func (s *migrationsSuite) TestFixBogusPromulgatedURL(c *gc.C) {
 }
 
 func (s *migrationsSuite) TestAddPreV5CompatBlob(c *gc.C) {
+	neededMigrations := getMigrations(migrationAddPreV5CompatBlob)
 	// Remove all migrations and add some entities.
 	// Then remove all the pre-v5-related stuff from the database,
 	// add the preV5CompatBlob migration and check that it works.
 	s.patchMigrations(c, nil)
-	p, err := NewPool(s.Session.DB("juju_test"), nil, &bakery.NewServiceParams{}, ServerParams{})
+	p, err := NewPool(s.db.Database, nil, &bakery.NewServiceParams{}, ServerParams{})
 	c.Assert(err, gc.IsNil)
 	store := p.Store()
 	p.Close()
@@ -509,7 +507,9 @@ func (s *migrationsSuite) TestAddPreV5CompatBlob(c *gc.C) {
 
 	iter := s.db.Entities().Find(nil).Iter()
 	var entity mongodoc.Entity
+	count := 0
 	for iter.Next(&entity) {
+		count++
 		if entity.PreV5BlobHash != entity.BlobHash {
 			err := store.BlobStore.Remove(preV5CompatibilityBlobName(entity.BlobName))
 			c.Assert(err, gc.IsNil)
@@ -526,8 +526,9 @@ func (s *migrationsSuite) TestAddPreV5CompatBlob(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 	}
 	c.Assert(iter.Err(), gc.IsNil)
+	c.Assert(count, gc.Equals, 4) // sanity check!
 
-	s.patchMigrations(c, getMigrations(migrationAddPreV5CompatBlob))
+	s.patchMigrations(c, neededMigrations)
 
 	err = s.newServer(c)
 	c.Assert(err, gc.IsNil)
@@ -548,6 +549,11 @@ func (s *migrationsSuite) TestAddPreV5CompatBlob(c *gc.C) {
 		if url.URL.Series == "bundle" {
 			continue
 		}
+		if strings.Contains(urlStr, "multi") {
+			entity, err := store.FindEntity(url, nil)
+			c.Assert(err, gc.IsNil)
+			c.Check(entity.BlobHash, gc.Not(gc.Equals), entity.PreV5BlobHash)
+		}
 		ch, err := charm.ReadCharmArchiveBytes(data)
 		c.Assert(err, gc.IsNil)
 		c.Assert(ch.Meta().Series, gc.HasLen, 0)
@@ -566,10 +572,15 @@ func (s *migrationsSuite) checkExecuted(c *gc.C, expected ...mongodoc.MigrationN
 
 func getMigrations(names ...mongodoc.MigrationName) (ms []migration) {
 	for _, name := range names {
+		found := false
 		for _, m := range migrations {
 			if m.name == name {
 				ms = append(ms, m)
+				found = true
 			}
+		}
+		if !found {
+			panic("no migrations found for " + string(name))
 		}
 	}
 	return ms


### PR DESCRIPTION
The test wasn't testing anything, it turns out. We have now made a more failsafe
test and QA'd the migration.
