### PR TITLE
internal/v5: implement meta/published endpoint

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -13,6 +13,7 @@ github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T1
 github.com/juju/testing	git	ee18040b46bb1f8c93438383bd51ec77eb8c02ab	2016-01-12T21:04:04Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/utils	git	0cac78a34dd1c42d2f2dc718c345fd13e3a264fc	2016-01-29T15:50:19Z
+github.com/juju/version	git	102b12db83e38cb2ce7003544092ea7b0ca59e92	2015-11-07T04:32:11Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/juju/zip	git	f6b1e93fa2e29a1d7d49b566b2b51efb060c982a	2016-02-05T10:52:21Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
@@ -20,13 +21,14 @@ golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:0
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/juju/charm.v6-unstable	git	87620fd200dc8e6ac4f4ec2cd02c16de8eaf108b	2016-03-03T17:33:54Z
-gopkg.in/juju/charmrepo.v2-unstable	git	08b9d5e5c730b8b055ea0d397b8a76e91e5646c1	2016-03-09T16:20:22Z
+gopkg.in/juju/charm.v6-unstable	git	4ad4f4ba39affe67785e385c1f49e7ec4206896f	2016-03-09T11:06:06Z
+gopkg.in/juju/charmrepo.v2-unstable	git	203f00778c384b635412570fb898d64470bec46f	2016-03-10T15:02:55Z
 gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z
-gopkg.in/macaroon-bakery.v1	git	a165ebf9a2ce170e430ee2360dab11c70c22062c	2016-01-19T15:40:20Z
+gopkg.in/macaroon-bakery.v1	git	65d5ecfeaadf14357d2dee63aba5c4579f5ff8b9	2016-03-10T09:55:48Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/natefinch/lumberjack.v2	git	588a21fb0fa0ebdfde42670fa214576b6f0f22df	2015-05-21T01:59:18Z
+gopkg.in/tomb.v2	git	14b3d72120e8d10ea6e6b7f87f7175734b1faab8	2014-06-26T14:46:23Z
 gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
 gopkg.in/yaml.v2	git	53feefa2559fb8dfa8d81baad31be332c97d6c77	2015-09-24T14:23:14Z
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20140529072043-hzcrlnl3ygvg914q	18

--- a/docs/API.md
+++ b/docs/API.md
@@ -488,6 +488,7 @@ Example: `GET /meta`
     "id-user",
     "manifest",
     "promulgated",
+    "published",
     "revision-info",
     "stats",
     "supported-series",
@@ -1069,6 +1070,33 @@ Example: `GET trusty/juju-gui-3/meta/charm-config`
             "Default": false
         }
     }
+}
+```
+
+#### GET *id*/meta/published
+
+The `meta/published` path returns a list of the channels that
+the entity has been published to.
+
+```go
+type PublishedResponse struct {
+	// Info holds an entry for each channel that the
+	// entity has been published to.
+	Info []PublishedInfo
+}
+
+// PublishedInfo holds information on a channel that an entity
+// has been published to.
+type PublishedInfo struct {
+	// Channel holds the value of the channel that
+	// the entity has been published to.
+	// This will never be "unpublished" as entities
+	// cannot be published to that channel.
+	Channel Channel
+
+	// Current holds whether the entity is the most
+	// recently published member of the channel.
+	Current bool
 }
 ```
 

--- a/internal/charmstore/addentity.go
+++ b/internal/charmstore/addentity.go
@@ -68,7 +68,7 @@ type addParams struct {
 //
 // This method is provided for testing purposes only.
 func (s *Store) AddCharmWithArchive(url *router.ResolvedURL, ch charm.Charm) error {
-	return s.addEntityWithArchive(url, ch)
+	return s.AddEntityWithArchive(url, ch)
 }
 
 // AddBundleWithArchive adds the given bundle, which must
@@ -77,12 +77,15 @@ func (s *Store) AddCharmWithArchive(url *router.ResolvedURL, ch charm.Charm) err
 //
 // This method is provided for testing purposes only.
 func (s *Store) AddBundleWithArchive(url *router.ResolvedURL, b charm.Bundle) error {
-	return s.addEntityWithArchive(url, b)
+	return s.AddEntityWithArchive(url, b)
 }
 
-// addEntityWithArchive provides the implementation for
+// AddEntityWithArchive provides the implementation for
 // both AddCharmWithArchive and AddBundleWithArchive.
-func (s *Store) addEntityWithArchive(url *router.ResolvedURL, archive interface{}) error {
+// It accepts charm.Charm or charm.Bundle implementations
+// defined in the charm package, and any that implement
+// ArchiverTo.
+func (s *Store) AddEntityWithArchive(url *router.ResolvedURL, archive interface{}) error {
 	blob, err := getArchive(archive)
 	if err != nil {
 		return errgo.Notef(err, "cannot get archive")

--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -21,7 +21,7 @@ const (
 	migrationFixBogusPromulgatedURL  mongodoc.MigrationName = "fix promulgate url"
 	migrationAddPreV5CompatBlobBogus mongodoc.MigrationName = "add pre-v5 compatibility blobs"
 	migrationAddPreV5CompatBlob      mongodoc.MigrationName = "add pre-v5 compatibility blobs; second try"
-	migrationNewChannelsModel mongodoc.MigrationName = "new channels model"
+	migrationNewChannelsModel        mongodoc.MigrationName = "new channels model"
 )
 
 // migrations holds all the migration functions that are executed in the order

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -128,11 +128,13 @@ func newReqHandler() ReqHandler {
 	handlers.Id["expand-id"] = resolveId(authId(h.serveExpandId))
 	handlers.Id["archive"] = h.serveArchive(handlers.Id["archive"])
 	handlers.Id["archive/"] = resolveId(authId(h.serveArchiveFile))
-	// Publish is a new endpoint; don't provide it in v4.
+
+	// Delete new endpoints that we don't want to provide in v4.
 	delete(handlers.Id, "publish")
-	// Resources is a new endpoint; don't provide it in v4.
+	delete(handlers.Meta, "published")
 	delete(handlers.Id, "resources")
 	delete(handlers.Meta, "resources")
+
 	h.Router = router.New(handlers, h)
 	return h
 }

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -226,6 +226,7 @@ var metaCharmRelatedTests = []struct {
 				Meta: map[string]interface{}{
 					"id-name": params.IdNameResponse{"wordpress"},
 					"charm-metadata": &charm.Meta{
+						Format: 1,
 						Provides: map[string]charm.Relation{
 							"website": {
 								Name:      "website",

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -229,6 +229,7 @@ var metaCharmRelatedTests = []struct {
 				Meta: map[string]interface{}{
 					"id-name": params.IdNameResponse{"wordpress"},
 					"charm-metadata": &charm.Meta{
+						Format: 1,
 						Provides: map[string]charm.Relation{
 							"website": {
 								Name:      "website",


### PR DESCRIPTION
This enables us to query any entity to find out what channels
it's in and whether it's the currently chosen entity for those channels.
