### PR TITLE
internal/v5: allow PUT with channels

### DIFF
--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -312,7 +312,7 @@ func (s *AddEntitySuite) TestUploadEntityErrors(c *gc.C) {
 		url := &router.ResolvedURL{
 			URL: *charm.MustParseURL(test.url),
 		}
-		err = store.UploadEntity(url, &buf, test.blobHash, test.blobSize)
+		err = store.UploadEntity(url, &buf, test.blobHash, test.blobSize, nil)
 		c.Assert(err, gc.ErrorMatches, test.expectError)
 		if test.expectCause != nil {
 			c.Assert(errgo.Cause(err), gc.Equals, test.expectCause)

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -3151,9 +3151,13 @@ func (s *APISuite) TestPublishSuccess(c *gc.C) {
 	})
 
 	assertResolvesTo := func(ch params.Channel, rev int) {
+		chanParam := ""
+		if ch != params.NoChannel {
+			chanParam = "?channel=" + string(ch)
+		}
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler: s.srv,
-			URL:     storeURL(fmt.Sprintf("~bob/precise/wordpress/meta/id-revision?channel=%s", ch)),
+			URL:     storeURL(fmt.Sprintf("~bob/precise/wordpress/meta/id-revision" + chanParam)),
 			Do:      bakeryDo(nil),
 			ExpectBody: params.IdRevisionResponse{
 				Revision: rev,


### PR DESCRIPTION
This will allow the ingester to upload entities to channels in a single
operation.
