### PR TITLE
deps: slightly earlier version of charmrepo

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -5,13 +5,13 @@ github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
-github.com/juju/httprequest	git	273244b6479b0c06c7bcf342eccefc55f3760653	2015-11-18T14:02:22Z
-github.com/juju/idmclient	git	4fbdd655a3bd0c06626a0c422935c15e7a856e34	2016-03-14T14:37:32Z
+github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z
+github.com/juju/idmclient	git	812a86ff450af958df6665839d93590f27961b08	2016-03-16T15:15:55Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
-github.com/juju/names	git	0fa6e46604f432b3064b02b2160fc5e6056131b8	2016-01-22T05:59:08Z
+github.com/juju/names	git	ef19de31613af3735aa69ba3b40accce2faf7316	2016-03-01T22:07:10Z
 github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
-github.com/juju/testing	git	321edad6b2d1ccac4af9ee05c25b8ad734d40546	2016-02-03T23:31:10Z
+github.com/juju/testing	git	4d5a7d64948aae30698f5d97b4c0d1a85a4504b7	2016-03-07T02:41:09Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/utils	git	0cac78a34dd1c42d2f2dc718c345fd13e3a264fc	2016-01-29T15:50:19Z
 github.com/juju/version	git	102b12db83e38cb2ce7003544092ea7b0ca59e92	2015-11-07T04:32:11Z
@@ -24,7 +24,7 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	4ad4f4ba39affe67785e385c1f49e7ec4206896f	2016-03-09T11:06:06Z
-gopkg.in/juju/charmrepo.v2-unstable	git	2b51c86c33add39a02125f16cf62aeeae4e2d762	2016-03-16T19:38:44Z
+gopkg.in/juju/charmrepo.v2-unstable	git	0e86a44c1b8c4bfe3b5c9227a3223fc4c0e947fb	2016-03-16T15:33:12Z
 gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z
 gopkg.in/macaroon-bakery.v1	git	6bce7a1e7399542cbafe16cbbb1dfe4591fcafe7	2016-03-16T08:34:47Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z


### PR DESCRIPTION
The latest version of charmrepo requires changes in charmstore-client.
Use one commit earlier so we can release charmstore-client as-is.

Also update to newer deps used by charmstore-client.
