### PR TITLE
v4, v5: use cache for iterator

### DIFF
--- a/internal/v4/relations.go
+++ b/internal/v4/relations.go
@@ -9,7 +9,6 @@ import (
 
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
-	"gopkg.in/mgo.v2/bson"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
@@ -27,19 +26,20 @@ func (h ReqHandler) metaCharmRelated(entity *mongodoc.Entity, id *router.Resolve
 	if len(entity.CharmProvidedInterfaces)+len(entity.CharmRequiredInterfaces) == 0 {
 		return &params.RelatedResponse{}, nil
 	}
-	q := h.Store.MatchingInterfacesQuery(entity.CharmProvidedInterfaces, entity.CharmRequiredInterfaces)
-
-	fields := bson.D{
-		{"_id", 1},
-		{"supportedseries", 1},
-		{"charmrequiredinterfaces", 1},
-		{"charmprovidedinterfaces", 1},
-		{"promulgated-url", 1},
-		{"promulgated-revision", 1},
-	}
-
+	fields := charmstore.FieldSelector(
+		"supportedseries",
+		"charmrequiredinterfaces",
+		"charmprovidedinterfaces",
+		"promulgated-url",
+		"promulgated-revision",
+	)
+	query := h.Store.MatchingInterfacesQuery(entity.CharmProvidedInterfaces, entity.CharmRequiredInterfaces)
+	iter := h.Cache.Iter(query.Sort("_id"), fields)
 	var entities []*mongodoc.Entity
-	if err := q.Select(fields).Sort("_id").All(&entities); err != nil {
+	for iter.Next() {
+		entities = append(entities, iter.Entity())
+	}
+	if err := iter.Err(); err != nil {
 		return nil, errgo.Notef(err, "cannot retrieve the related charms")
 	}
 

--- a/internal/v5/auth.go
+++ b/internal/v5/auth.go
@@ -48,6 +48,10 @@ const (
 //
 // This method also sets h.auth to the returned authorization info.
 func (h *ReqHandler) authorize(req *http.Request, acl []string, alwaysAuth bool, entityId *router.ResolvedURL) (authorization, error) {
+	// TODO this is logging statement is actually quite costly
+	// when we're dealing with requests that need to authorize
+	// many entities (e.g. charm-related). Consider removing
+	// it or making it dependent on context.
 	logger.Infof(
 		"authorize, auth location %q, acl %q, path: %q, method: %q, entity: %#v",
 		h.Handler.config.IdentityLocation,

--- a/internal/v5/status.go
+++ b/internal/v5/status.go
@@ -129,9 +129,9 @@ func (h *ReqHandler) findTimesInLogs(logType mongodoc.LogType, startPrefix, endP
 	var log mongodoc.Log
 	iter := h.Store.DB.Logs().
 		Find(bson.D{
-		{"level", mongodoc.InfoLevel},
-		{"type", logType},
-	}).Sort("-time", "-id").Iter()
+			{"level", mongodoc.InfoLevel},
+			{"type", logType},
+		}).Sort("-time", "-id").Iter()
 	for iter.Next(&log) {
 		var msg string
 		if err := json.Unmarshal(log.Data, &msg); err != nil {


### PR DESCRIPTION
This speeds up the charm-related query by a factor of N where N
is the number of related entities (measured ~85% speedup in one test)
