### PR TITLE
Avoid internal compiler error on gccgo

### DIFF
--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -369,10 +369,10 @@ func (h *ReqHandler) WillIncludeMetadata(includes []string) {
 		for _, f := range fi.P.Fields {
 			fields[f] = 1
 		}
-		switch fi.P.Key {
-		case entityHandlerKey{}:
+		switch fi.P.Key.(type) {
+		case entityHandlerKey:
 			h.Cache.AddEntityFields(fields)
-		case baseEntityHandlerKey{}:
+		case baseEntityHandlerKey:
 			h.Cache.AddBaseEntityFields(fields)
 		}
 	}


### PR DESCRIPTION
Something in the handling of constants by gccgo 4.9 blows up
when trying to compile api.go:

In function ‘v5.WillIncludeMetadata.pN59_gopkg_in_juju_charmstore_v5_unstable_internal_v5.ReqHandler’:
go1: internal compiler error: in fold_binary_loc, at fold-const.c:10124

Adjusting the switch statement to look at type rather than compare
against literals avoids the issue.
