### PR TITLE
Return an empty list for bundles.

### DIFF
--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -601,9 +601,6 @@ var metaEndpoints = []metaEndpoint{{
 }}
 
 func basicListResources(entity *mongodoc.Entity) ([]resource.Resource, error) {
-	if entity.URL.Series == "bundle" {
-		return nil, errgo.Newf("bundles do not have resources")
-	}
 	var resources []resource.Resource
 	for _, meta := range entity.CharmMeta.Resources {
 		// We use an origin of "upload" since charms cannot be uploaded yet.

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -534,6 +534,9 @@ var metaEndpoints = []metaEndpoint{{
 		if err != nil {
 			return nil, err
 		}
+		if entity.URL.Series == "bundle" {
+			return []params.Resource{}, nil
+		}
 		// TODO(ericsnow) Switch to store.ListResources() once it exists.
 		resources, err := basicListResources(entity)
 		if err != nil {

--- a/internal/v5/resources.go
+++ b/internal/v5/resources.go
@@ -23,7 +23,6 @@ func (h *ReqHandler) metaResources(entity *mongodoc.Entity, id *router.ResolvedU
 		return []params.Resource{}, nil
 	}
 	if entity.CharmMeta == nil {
-		// This shouldn't happen, but we'll play it safe.
 		return []params.Resource{}, nil
 	}
 
@@ -42,13 +41,6 @@ func (h *ReqHandler) metaResources(entity *mongodoc.Entity, id *router.ResolvedU
 }
 
 func basicListResources(entity *mongodoc.Entity) ([]resource.Resource, error) {
-	if entity.URL.Series == "bundle" {
-		return nil, badRequestf(nil, "bundles do not have resources")
-	}
-	if entity.CharmMeta == nil {
-		return nil, errgo.Newf("entity missing charm metadata")
-	}
-
 	var resources []resource.Resource
 	for _, meta := range entity.CharmMeta.Resources {
 		// We use an origin of "upload" since resources cannot be uploaded yet.

--- a/internal/v5/resources.go
+++ b/internal/v5/resources.go
@@ -23,7 +23,8 @@ func (h *ReqHandler) metaResources(entity *mongodoc.Entity, id *router.ResolvedU
 		return []params.Resource{}, nil
 	}
 	if entity.CharmMeta == nil {
-		return []params.Resource{}, nil
+		// This shouldn't happen...
+		panic("entity missing charm metadata")
 	}
 
 	// TODO(ericsnow) Handle flags.

--- a/internal/v5/resources.go
+++ b/internal/v5/resources.go
@@ -18,6 +18,15 @@ import (
 // GET id/meta/resources
 // https://github.com/juju/charmstore/blob/v5/docs/API.md#get-idmetaresources
 func (h *ReqHandler) metaResources(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
+	if entity.URL.Series == "bundle" {
+		// Bundles do not have resources so we return an empty result.
+		return []params.Resource{}, nil
+	}
+	if entity.CharmMeta == nil {
+		// This shouldn't happen, but we'll play it safe.
+		return []params.Resource{}, nil
+	}
+
 	// TODO(ericsnow) Handle flags.
 	// TODO(ericsnow) Use h.Store.ListResources() once that exists.
 	resources, err := basicListResources(entity)


### PR DESCRIPTION
(resolves issue #585)

The "resources" meta endpoint was returning an error for bundles.  It should have been returning an empty list.
