### PR TITLE
add refresh-macaroon endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2165,6 +2165,17 @@ type WhoAmIResponse struct {
 }
 ```
 
+#### GET /refresh-macaroon
+
+This endpoint returns a macaroon restricted for use only to read the charm
+specified by the 'id' parameter.  The caller must make the request with a
+macaroon returned from a previus call to either refresh-macaroon or
+delegatable-macaroon.
+
+Calling this endpoint with a macaroon returned from a previous call to
+refresh-macaroon will revoke that macaroon.
+
+
 ### Logs
 
 #### GET /log


### PR DESCRIPTION
This endpoint is intended to be used by juju-core to get what we've been calling the long-lived macaroon for juju-core to use when requesting information from the charmstore asynchronously from user interaction - such as the daily check for new updates to a charm revision, and for retrieving resource bytes from the store on-demand when charms request them.

The idea is that juju will first call this endpoint during deploy with the macaroon retrieved from delegatable-macaroon, and then it'll use this macaroon for all further checks.  Every time the charm revision updater queries the charmstore for updates to a charm, it'll also (independently) call this endpoint to refresh its macaroon.  Once the controller gets the new macaroon, the old macaroon is revoked, so that even if one of these macaroons leaks out, it'll only be good until the next time refresh-macaroon is called with it.
