### PR TITLE
internal/v5: implement GET and POST resource

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -9,11 +9,11 @@ github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03
 github.com/juju/idmclient	git	812a86ff450af958df6665839d93590f27961b08	2016-03-16T15:15:55Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
-github.com/juju/names	git	ef19de31613af3735aa69ba3b40accce2faf7316	2016-03-01T22:07:10Z
+github.com/juju/names	git	8a0aa0963bbacdc790914892e9ff942e94d6f795	2016-03-30T15:05:33Z
 github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
-github.com/juju/testing	git	f60b1354ea9f3bfc08f1a1b18494540d9aad0c95	2016-03-23T11:34:08Z
+github.com/juju/testing	git	162fafccebf20a4207ab93d63b986c230e3f4d2e	2016-04-04T09:43:17Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	af32cfaf28093965fdf63373d8447c489efb2875	2016-03-09T18:28:39Z
+github.com/juju/utils	git	55eebc909a9f5e1c0f595d3a52d4a050e40f71dc	2016-03-30T11:42:50Z
 github.com/juju/version	git	ef897ad7f130870348ce306f61332f5335355063	2015-11-27T20:34:00Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
@@ -23,8 +23,8 @@ golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:0
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/juju/charm.v6-unstable	git	99f7bb76910980b2e38fb9d3466d6a8ed163d1bf	2016-03-23T13:17:50Z
-gopkg.in/juju/charmrepo.v2-unstable	git	40c5e122c8596b0ba28e6f05688fa2ebabf27719	2016-03-17T09:00:15Z
+gopkg.in/juju/charm.v6-unstable	git	728a5ea3ff1c1ae8b4c3ac4779c0027f693d1ca5	2016-04-08T11:12:17Z
+gopkg.in/juju/charmrepo.v2-unstable	git	64555d419cf90c85525313e98102158c5e8074f4	2016-04-08T12:19:14Z
 gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z
 gopkg.in/macaroon-bakery.v1	git	6bce7a1e7399542cbafe16cbbb1dfe4591fcafe7	2016-03-16T08:34:47Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z

--- a/docs/API.md
+++ b/docs/API.md
@@ -1753,14 +1753,57 @@ Request body:
 
 The above example is equivalent to the `meta/common-info` example above.
 
+#### GET *id*/meta/resources
+
+The `meta/resources` path returns information on all the resources associated with the given charm *id* as an array of resource objects.
+
+```go
+
+type Resource struct {
+	// Name identifies the resource.
+	Name string
+
+	// Type is the name of the resource type. Currently only
+	// "file" is supported, which is the default if Type is not specified.
+	Type string
+
+	// Path holds where the resource will be stored on units
+	// deployed with the charm.
+	Path string
+
+	// Description contains user-facing info about the resource.
+	Description string `json:",omitempty"`
+
+	// Revision is the revision, if applicable.
+	Revision int
+
+	// Fingerprint is the SHA-384 checksum for the resource blob.
+	Fingerprint []byte
+
+	// Size is the size of the resource, in bytes.
+	Size int64
+}
+
+[]Resource
+```
+
 ### Resources
 
-**Not yet implemented**
+#### POST *id*/resource/*name*?hash=*sha384*[&filename=*path*]
 
-#### POST *id*/resources/name.stream
 
-Posting to the resources path creates a new version of the given stream
-for the charm with the given id. The request returns the new version.
+Posting to the `resource` path uploads a resource (an arbitrary "blob"
+of data) associated with the charm with the given *id*, which must not
+be a bundle. The *sha384* parameter
+must hold the hex-encoded SHA384 hash of the blob.
+
+If provided, the *path* parameter should hold the filename
+that the resource has been read from, and its file extension will
+be verified against the extension of the filename in the
+declared charm metadata resources of the resolved charm.
+
+As a special case, if the filename in the charm metadata has no
+extension, any file name will be allowed.
 
 ```go
 type ResourcesRevision struct {
@@ -1768,23 +1811,15 @@ type ResourcesRevision struct {
 }
 ```
 
-#### GET *id*/resources/name.stream[-revision]/arch/filename
+#### GET *id*/resource/*name*[/*revision*]
 
-Getting from the `/resources` path retrieves a charm resource from the charm
-with the given id. If version is not specified, it retrieves the latest version
-of the resource. The SHA-256 hash of the data is specified in the HTTP response
-headers.
+Getting from the `/resource` path retrieves a charm resource from the charm
+with the given id. If version is not specified, it retrieves the latest published
+version of the resource (for the "unpublished" channel, this will be
+the most recently uploaded version of the resource).
 
-#### PUT *id*/resources/[~user/]series/name.stream-revision/arch?sha256=hash
-
-Putting to the `resources` path uploads a resource (an arbitrary "blob" of
-data) associated with the charm with id series/name, which must not be a
-bundle. Stream and arch specify which of the charms resource streams and which
-architecture the resource will be associated with, respectively. Revision
-specifies the revision of the stream that's being uploaded to.
-
-The hash value must specify the hash of the stream. If the same series, name,
-stream, revision combination is PUT again, it must specify the same hash.
+The SHA-384 checksum of the data is returned
+in the Content-Sha384 HTTP response header.
 
 ### Search
 

--- a/internal/charmstore/resources.go
+++ b/internal/charmstore/resources.go
@@ -199,6 +199,8 @@ func (s *Store) nextResourceRevision(baseURL *charm.URL, name string) (int, erro
 // ResolveResource finds the resource specified. If a matching resource
 // cannot be found an error with the cause params.ErrNotFound will be
 // returned.
+// If revision is negative, the most recently published revision
+// for the given channel will be returned.
 func (s *Store) ResolveResource(url *router.ResolvedURL, name string, revision int, channel params.Channel) (*mongodoc.Resource, error) {
 	if channel == params.NoChannel {
 		channel = params.StableChannel
@@ -222,7 +224,7 @@ func (s *Store) ResolveResource(url *router.ResolvedURL, name string, revision i
 			if revision >= 0 {
 				suffix = fmt.Sprintf("/%d", revision)
 			}
-			return nil, errgo.WithCausef(nil, params.ErrNotFound, "%s has no %q%s resource", url, name, suffix)
+			return nil, errgo.WithCausef(nil, params.ErrNotFound, "%s has no %q resource", url, name+suffix)
 		}
 		return nil, errgo.Mask(err)
 	}

--- a/internal/charmstore/resources_test.go
+++ b/internal/charmstore/resources_test.go
@@ -259,7 +259,7 @@ var resolveResourceTests = []struct {
 	name:             "for-install",
 	revision:         3,
 	channel:          params.UnpublishedChannel,
-	expectError:      `cs:~charmers/xenial/starsay-3 has no "for-install"/3 resource`,
+	expectError:      `cs:~charmers/xenial/starsay-3 has no "for-install/3" resource`,
 	expectErrorCause: params.ErrNotFound,
 }, {
 	about:          "no revision specified without channel",

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -138,7 +138,7 @@ func newReqHandler() ReqHandler {
 	// Delete new endpoints that we don't want to provide in v4.
 	delete(handlers.Id, "publish")
 	delete(handlers.Meta, "published")
-	delete(handlers.Id, "resources")
+	delete(handlers.Id, "resource")
 	delete(handlers.Meta, "resources")
 
 	h.Router = router.New(handlers, h)

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 	"time"
 
-	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
@@ -83,7 +82,7 @@ var _ = gc.Suite(&APISuite{})
 // patchLegacyDownloadCountsEnabled sets LegacyDownloadCountsEnabled to the
 // given value for the duration of the test.
 // TODO (frankban): remove this function when removing the legacy counts logic.
-func patchLegacyDownloadCountsEnabled(addCleanup func(jujutesting.CleanupFunc), value bool) {
+func patchLegacyDownloadCountsEnabled(addCleanup func(func(*gc.C)), value bool) {
 	original := charmstore.LegacyDownloadCountsEnabled
 	charmstore.LegacyDownloadCountsEnabled = value
 	addCleanup(func(*gc.C) {

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -227,7 +227,7 @@ func RouterHandlers(h *ReqHandler) *router.Handlers {
 			"publish":     resolveId(h.servePublish),
 			"promulgate":  resolveId(h.serveAdminPromulgate),
 			"readme":      resolveId(authId(h.serveReadMe), "contents", "blobname"),
-			"resources":   resolveId(authId(h.serveResources)),
+			"resource/":   resolveId(authId(h.serveResources), "charmmeta"),
 		},
 		Meta: map[string]router.BulkIncludeHandler{
 			"archive-size":         h.EntityHandler(h.metaArchiveSize, "size"),

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -114,7 +114,6 @@ func (h *ReqHandler) serveGetArchive(id *router.ResolvedURL, w http.ResponseWrit
 func (h *ReqHandler) SendEntityArchive(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request, blob *charmstore.Blob) {
 	header := w.Header()
 	setArchiveCacheControl(w.Header(), h.isPublic(id))
-	logger.Infof("sendEntityArchive setting %s=%s", params.ContentHashHeader, blob.Hash)
 	header.Set(params.ContentHashHeader, blob.Hash)
 	header.Set(params.EntityIdHeader, id.PreferredURL().String())
 

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -1526,6 +1526,10 @@ func hashOf(r io.Reader) (hashSum string, size int64) {
 	return fmt.Sprintf("%x", hash.Sum(nil)), n
 }
 
+func hashOfString(s string) string {
+	return hashOfBytes([]byte(s))
+}
+
 // assertCacheControl asserts that the cache control headers are
 // appropriately set. The isPublic parameter specifies
 // whether the id in the request represents a public charm or bundle.

--- a/internal/v5/resources.go
+++ b/internal/v5/resources.go
@@ -6,34 +6,33 @@ package v5 // import "gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 import (
 	"net/http"
 	"net/url"
+	"path"
+	"strconv"
+	"strings"
 
+	"github.com/juju/httprequest"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
+	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 )
 
-// GET id/meta/resources
+// GET id/meta/resource
 // https://github.com/juju/charmstore/blob/v5/docs/API.md#get-idmetaresources
 func (h *ReqHandler) metaResources(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	if entity.URL.Series == "bundle" {
-		// Bundles do not have resources so we return an empty result.
-		return []params.Resource{}, nil
+		return nil, nil
 	}
-	if entity.CharmMeta == nil {
-		// This shouldn't happen...
-		panic("entity missing charm metadata")
-	}
-
 	// TODO(ericsnow) Handle flags.
 	// TODO(ericsnow) Use h.Store.ListResources() once that exists.
 	resources, err := basicListResources(entity)
 	if err != nil {
 		return nil, err
 	}
-	var results []params.Resource
+	results := make([]params.Resource, 0, len(resources))
 	for _, res := range resources {
 		result := params.Resource2API(res)
 		results = append(results, result)
@@ -42,6 +41,10 @@ func (h *ReqHandler) metaResources(entity *mongodoc.Entity, id *router.ResolvedU
 }
 
 func basicListResources(entity *mongodoc.Entity) ([]resource.Resource, error) {
+	if entity.CharmMeta == nil {
+		return nil, errgo.Newf("entity missing charm metadata")
+	}
+
 	var resources []resource.Resource
 	for _, meta := range entity.CharmMeta.Resources {
 		// We use an origin of "upload" since resources cannot be uploaded yet.
@@ -57,16 +60,15 @@ func basicListResources(entity *mongodoc.Entity) ([]resource.Resource, error) {
 	return resources, nil
 }
 
-// POST id/resources/name
+// POST id/resource/name
 // https://github.com/juju/charmstore/blob/v5/docs/API.md#post-idresourcesname
 //
-// GET  id/resources/name[/revision]
+// GET  id/resource/name[/revision]
 // https://github.com/juju/charmstore/blob/v5/docs/API.md#get-idresourcesnamerevision
 func (h *ReqHandler) serveResources(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error {
-	// Resources are "published" using "PUT id/publish" so we don't
+	// Resources are "published" using "POST id/publish" so we don't
 	// support PUT here.
-	// TODO(ericsnow) Support DELETE to remove a resource?
-	// (like serveArchive() does)
+	// TODO(ericsnow) Support DELETE to remove a resource (like serveArchive)?
 	switch req.Method {
 	case "GET":
 		return h.serveDownloadResource(id, w, req)
@@ -78,9 +80,97 @@ func (h *ReqHandler) serveResources(id *router.ResolvedURL, w http.ResponseWrite
 }
 
 func (h *ReqHandler) serveDownloadResource(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error {
-	return errNotImplemented
+	rid, err := parseResourceId(strings.TrimPrefix(req.URL.Path, "/"))
+	if err != nil {
+		return errgo.WithCausef(err, params.ErrNotFound, "")
+	}
+	ch, err := h.entityChannel(id)
+	if err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
+	}
+	r, err := h.Store.ResolveResource(id, rid.Name, rid.Revision, ch)
+	if err != nil {
+		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
+	}
+	blob, err := h.Store.OpenResourceBlob(r)
+	if err != nil {
+		return errgo.Notef(err, "cannot open resource blob")
+	}
+	defer blob.Close()
+	header := w.Header()
+	setArchiveCacheControl(w.Header(), h.isPublic(id))
+	header.Set(params.ContentHashHeader, blob.Hash)
+
+	// TODO(rog) should we set connection=close here?
+	// See https://codereview.appspot.com/5958045
+	serveContent(w, req, blob.Size, blob)
+	return nil
 }
 
 func (h *ReqHandler) serveUploadResource(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error {
-	return errNotImplemented
+	if id.URL.Series == "bundle" {
+		return errgo.WithCausef(nil, params.ErrForbidden, "cannot upload a resource to a bundle")
+	}
+	name := strings.TrimPrefix(req.URL.Path, "/")
+	if !validResourceName(name) {
+		return badRequestf(nil, "invalid resource name")
+	}
+	hash := req.Form.Get("hash")
+	if hash == "" {
+		return badRequestf(nil, "hash parameter not specified")
+	}
+	if req.ContentLength == -1 {
+		return badRequestf(nil, "Content-Length not specified")
+	}
+	e, err := h.Cache.Entity(&id.URL, charmstore.FieldSelector("charmmeta"))
+	if err != nil {
+		// Should never happen, as the entity will have been cached
+		// when the charm URL was resolved.
+		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
+	}
+	r, ok := e.CharmMeta.Resources[name]
+	if !ok {
+		return errgo.WithCausef(nil, params.ErrForbidden, "resource %q not found in charm metadata", name)
+	}
+	if r.Type != resource.TypeFile {
+		return errgo.WithCausef(nil, params.ErrForbidden, "non-file resource types not supported")
+	}
+	if filename := req.Form.Get("filename"); filename != "" {
+		if charmExt := path.Ext(r.Path); charmExt != "" {
+			// The resource has a filename extension. Check that it matches.
+			if charmExt != path.Ext(filename) {
+				return errgo.WithCausef(nil, params.ErrForbidden, "filename extension mismatch (got %q want %q)", path.Ext(filename), charmExt)
+			}
+		}
+	}
+	rdoc, err := h.Store.UploadResource(e, name, req.Body, hash, req.ContentLength)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	return httprequest.WriteJSON(w, http.StatusOK, &params.ResourceUploadResponse{
+		Revision: rdoc.Revision,
+	})
+}
+
+func parseResourceId(path string) (mongodoc.ResourceRevision, error) {
+	i := strings.Index(path, "/")
+	if i == -1 {
+		return mongodoc.ResourceRevision{
+			Name:     path,
+			Revision: -1,
+		}, nil
+	}
+	revno, err := strconv.Atoi(path[i+1:])
+	if err != nil {
+		return mongodoc.ResourceRevision{}, errgo.Newf("malformed revision number")
+	}
+	return mongodoc.ResourceRevision{
+		Name:     path[0:i],
+		Revision: revno,
+	}, nil
+}
+
+func validResourceName(name string) bool {
+	// TODO we should probably be more restrictive than this.
+	return !strings.Contains(name, "/")
 }

--- a/internal/v5/resources_test.go
+++ b/internal/v5/resources_test.go
@@ -1,0 +1,411 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package v5_test // import "gopkg.in/juju/charmstore.v5-unstable/internal/v5"
+
+import (
+	"crypto/sha512"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/juju/testing/httptesting"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charm.v6-unstable/resource"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
+)
+
+type ResourceSuite struct {
+	commonSuite
+}
+
+var _ = gc.Suite(&ResourceSuite{})
+
+func (s *ResourceSuite) SetUpSuite(c *gc.C) {
+	s.enableIdentity = true
+	s.commonSuite.SetUpSuite(c)
+}
+
+func (s *ResourceSuite) TestPost(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"someResource": {
+				Name: "someResource",
+				Type: resource.TypeFile,
+				Path: "1.zip",
+			},
+		},
+	}), id)
+	content := "some content"
+	hash := fmt.Sprintf("%x", sha512.Sum384([]byte(content)))
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "POST",
+		Body:         strings.NewReader(content),
+		URL:          storeURL(fmt.Sprintf("%s/resource/someResource?hash=%s&filename=foo.zip", id.URL.Path(), hash)),
+		ExpectStatus: http.StatusOK,
+		ExpectBody: params.ResourceUploadResponse{
+			Revision: 0,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+
+	// Check that the resource has really been uploaded.
+	r, err := s.store.ResolveResource(id, "someResource", 0, "")
+	c.Assert(err, gc.IsNil)
+
+	blob, err := s.store.OpenResourceBlob(r)
+	c.Assert(err, gc.IsNil)
+	defer blob.Close()
+	data, err := ioutil.ReadAll(blob)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Equals, content)
+}
+
+func (s *ResourceSuite) TestGet(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"someResource": {
+				Name: "someResource",
+				Type: resource.TypeFile,
+				Path: "1.zip",
+			},
+		},
+	}), id)
+	content := "some content"
+	s.uploadResource(c, id, "someResource", content+"0")
+	s.uploadResource(c, id, "someResource", content+"1")
+	s.uploadResource(c, id, "someResource", content+"2")
+
+	// Get with the revision should return the resource.
+	resp := httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		Method:  "GET",
+		URL:     storeURL(id.URL.Path() + "/resource/someResource/1"),
+	})
+	c.Assert(resp.Body.String(), gc.Equals, content+"1")
+	c.Assert(resp.Header().Get(params.ContentHashHeader), gc.Equals, hashOfString(content+"1"))
+	c.Assert(resp.Code, gc.Equals, http.StatusOK)
+	assertCacheControl(c, resp.Header(), true)
+
+	// Get with no revision should get a "not found" error because there are
+	// no published resources associated with the published charm.
+	// TODO this shouldn't happen because it shouldn't be possible
+	// to make the charm public without first uploading its resources.
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "GET",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource"),
+		ExpectStatus: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Code:    params.ErrNotFound,
+			Message: `cs:~charmers/precise/wordpress-0 has no "someResource" resource on stable channel`,
+		},
+	})
+
+	// If we publish the resource, it should be available with no revision.
+	entity, err := s.store.FindEntity(id, nil)
+	c.Assert(err, gc.IsNil)
+	err = s.store.PublishResources(entity, params.StableChannel, []mongodoc.ResourceRevision{{
+		Name:     "someResource",
+		Revision: 2,
+	}})
+	c.Assert(err, gc.IsNil)
+
+	resp = httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		Method:  "GET",
+		URL:     storeURL(id.URL.Path() + "/resource/someResource"),
+	})
+	c.Assert(resp.Body.String(), gc.Equals, content+"2")
+	c.Assert(resp.Header().Get(params.ContentHashHeader), gc.Equals, hashOfString(content+"2"))
+	c.Assert(resp.Code, gc.Equals, http.StatusOK)
+}
+
+func (s *ResourceSuite) TestInvalidMethod(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(nil), id)
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "PUT",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource"),
+		ExpectStatus: http.StatusMethodNotAllowed,
+		ExpectBody: params.Error{
+			Code:    params.ErrMethodNotAllowed,
+			Message: `PUT not allowed`,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+}
+
+func (s *ResourceSuite) TestCannotUploadToBundle(c *gc.C) {
+	id, _ := s.addPublicBundleFromRepo(c, "wordpress-simple", newResolvedURL("cs:~charmers/bundle/something-32", 32), true)
+
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "POST",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource"),
+		ExpectStatus: http.StatusForbidden,
+		ExpectBody: params.Error{
+			Code:    params.ErrForbidden,
+			Message: `cannot upload a resource to a bundle`,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+}
+
+func (s *ResourceSuite) TestUploadInvalidResourceName(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(nil), id)
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "POST",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource/x"),
+		ExpectStatus: http.StatusBadRequest,
+		ExpectBody: params.Error{
+			Code:    params.ErrBadRequest,
+			Message: `invalid resource name`,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+}
+
+func (s *ResourceSuite) TestUploadNoHash(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(nil), id)
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "POST",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource"),
+		ExpectStatus: http.StatusBadRequest,
+		ExpectBody: params.Error{
+			Code:    params.ErrBadRequest,
+			Message: `hash parameter not specified`,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+}
+
+func (s *ResourceSuite) TestUploadNoContentLength(c *gc.C) {
+	type exoticReader struct {
+		io.ReadSeeker
+	}
+
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(nil), id)
+
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "POST",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource?hash=d0gf00d"),
+		Body:         exoticReader{strings.NewReader("x")},
+		ExpectStatus: http.StatusBadRequest,
+		ExpectBody: params.Error{
+			Code:    params.ErrBadRequest,
+			Message: `Content-Length not specified`,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+}
+
+func (s *ResourceSuite) TestUploadResourceNotDeclaredInCharm(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(nil), id)
+
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "POST",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource?hash=d0gf00d"),
+		ExpectStatus: http.StatusForbidden,
+		ExpectBody: params.Error{
+			Code:    params.ErrForbidden,
+			Message: `resource "someResource" not found in charm metadata`,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+}
+
+func (s *ResourceSuite) TestUploadResourceFilenameExtensionMismatch(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"someResource": {
+				Name: "someResource",
+				Type: resource.TypeFile,
+				Path: "1.zip",
+			},
+		},
+	}), id)
+
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "POST",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource?hash=d0gf00d&filename=foo.dat"),
+		ExpectStatus: http.StatusForbidden,
+		ExpectBody: params.Error{
+			Code:    params.ErrForbidden,
+			Message: `filename extension mismatch (got ".dat" want ".zip")`,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+}
+
+func (s *ResourceSuite) TestUploadResourceFilenameWithNoExtension(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"someResource": {
+				Name: "someResource",
+				Type: resource.TypeFile,
+				Path: "1.zip",
+			},
+		},
+	}), id)
+
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "POST",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource?hash=d0gf00d&filename=foo"),
+		ExpectStatus: http.StatusForbidden,
+		ExpectBody: params.Error{
+			Code:    params.ErrForbidden,
+			Message: `filename extension mismatch (got "" want ".zip")`,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+}
+
+func (s *ResourceSuite) TestUploadResourcePathWithNoExtension(c *gc.C) {
+	// If the resource path has no extension, we don't check the
+	// file extension.
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"someResource": {
+				Name: "someResource",
+				Type: resource.TypeFile,
+				Path: "something",
+			},
+		},
+	}), id)
+	content := "x"
+	hash := fmt.Sprintf("%x", sha512.Sum384([]byte(content)))
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler: s.srv,
+		Method:  "POST",
+		URL:     storeURL(id.URL.Path() + "/resource/someResource?hash=" + hash + "&filename=foo.zip"),
+		Body:    strings.NewReader(content),
+		ExpectBody: params.ResourceUploadResponse{
+			Revision: 0,
+		},
+		Do: s.bakeryDoAsUser(c, "charmers"),
+	})
+}
+
+func (s *ResourceSuite) TestDownloadBadResourceRevision(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"someResource": {
+				Name: "someResource",
+				Type: resource.TypeFile,
+				Path: "1.zip",
+			},
+		},
+	}), id)
+	content := "some content"
+	s.uploadResource(c, id, "someResource", content)
+
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "GET",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource/x"),
+		ExpectStatus: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Code:    params.ErrNotFound,
+			Message: `not found: malformed revision number`,
+		},
+	})
+}
+
+func (s *ResourceSuite) TestDownloadResourceNotFound(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.addPublicCharm(c, storetesting.NewCharm(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"someResource": {
+				Name: "someResource",
+				Type: resource.TypeFile,
+				Path: "1.zip",
+			},
+		},
+	}), id)
+	content := "some content"
+	s.uploadResource(c, id, "someResource", content)
+
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "GET",
+		URL:          storeURL(id.URL.Path() + "/resource/otherResource/0"),
+		ExpectStatus: http.StatusNotFound,
+		ExpectBody: params.Error{
+			Code:    params.ErrNotFound,
+			Message: `cs:~charmers/precise/wordpress-0 has no "otherResource/0" resource`,
+		},
+	})
+}
+
+func (s *ResourceSuite) TestDownloadPrivateCharmResource(c *gc.C) {
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	err := s.store.AddCharmWithArchive(id, storetesting.NewCharm(&charm.Meta{
+		Resources: map[string]resource.Meta{
+			"someResource": {
+				Name: "someResource",
+				Type: resource.TypeFile,
+				Path: "1.zip",
+			},
+		},
+	}))
+	c.Assert(err, gc.IsNil)
+	content := "some content"
+	s.uploadResource(c, id, "someResource", content)
+
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler:      s.srv,
+		Method:       "GET",
+		URL:          storeURL(id.URL.Path() + "/resource/someResource/0"),
+		ExpectStatus: http.StatusUnauthorized,
+		ExpectBody: params.Error{
+			Code:    params.ErrUnauthorized,
+			Message: `unauthorized: access denied for user "bob"`,
+		},
+		Do: s.bakeryDoAsUser(c, "bob"),
+	})
+
+	resp := httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		Method:  "GET",
+		URL:     storeURL(id.URL.Path() + "/resource/someResource/0"),
+		Do:      s.bakeryDoAsUser(c, "charmers"),
+	})
+	c.Assert(resp.Body.String(), gc.Equals, content)
+	c.Assert(resp.Header().Get(params.ContentHashHeader), gc.Equals, hashOfString(content))
+	c.Assert(resp.Code, gc.Equals, http.StatusOK)
+	assertCacheControl(c, resp.Header(), false)
+}
+
+func (s *ResourceSuite) uploadResource(c *gc.C, id *router.ResolvedURL, name string, content string) {
+	entity, err := s.store.FindEntity(id, nil)
+	c.Assert(err, gc.IsNil)
+	hash := fmt.Sprintf("%x", sha512.Sum384([]byte(content)))
+	_, err = s.store.UploadResource(entity, name, strings.NewReader(content), hash, int64(len(content)))
+	c.Assert(err, gc.IsNil)
+}

--- a/internal/v5/status.go
+++ b/internal/v5/status.go
@@ -127,11 +127,10 @@ func (h *ReqHandler) checkLogs(
 // end messages were last added.
 func (h *ReqHandler) findTimesInLogs(logType mongodoc.LogType, startPrefix, endPrefix string) (start, end time.Time, err error) {
 	var log mongodoc.Log
-	iter := h.Store.DB.Logs().
-		Find(bson.D{
-			{"level", mongodoc.InfoLevel},
-			{"type", logType},
-		}).Sort("-time", "-id").Iter()
+	iter := h.Store.DB.Logs().Find(bson.D{
+		{"level", mongodoc.InfoLevel},
+		{"type", logType},
+	}).Sort("-time", "-id").Iter()
 	for iter.Next(&log) {
 		var msg string
 		if err := json.Unmarshal(log.Data, &msg); err != nil {


### PR DESCRIPTION
Also rename the /resources endpoint to /resource so that it works
in the way expected by the charmstore client, and update the API
docs to add the new endpoints.
