### PR TITLE
internal/charmstore: publish entity and its resources in the same operation

### DIFF
--- a/internal/charmstore/common_test.go
+++ b/internal/charmstore/common_test.go
@@ -84,7 +84,7 @@ func addRequiredCharms(c *gc.C, store *Store, bundle charm.Bundle) {
 		}
 		err := store.AddCharmWithArchive(&rurl, ch)
 		c.Assert(err, gc.IsNil)
-		err = store.Publish(&rurl, params.StableChannel)
+		err = store.Publish(&rurl, nil, params.StableChannel)
 		c.Assert(err, gc.IsNil)
 	}
 }

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -980,14 +980,14 @@ func (s *StoreSearchSuite) TestOnlyIndexStableCharms(c *gc.C) {
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(&id.URL), &actual)
 	c.Assert(err, gc.ErrorMatches, "elasticsearch document not found")
 
-	err = s.store.Publish(id, params.DevelopmentChannel)
+	err = s.store.Publish(id, nil, params.DevelopmentChannel)
 	c.Assert(err, gc.IsNil)
 	err = s.store.UpdateSearch(id)
 	c.Assert(err, gc.IsNil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(&id.URL), &actual)
 	c.Assert(err, gc.ErrorMatches, "elasticsearch document not found")
 
-	err = s.store.Publish(id, params.StableChannel)
+	err = s.store.Publish(id, nil, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 	err = s.store.UpdateSearch(id)
 	c.Assert(err, gc.IsNil)
@@ -1018,7 +1018,7 @@ func addCharmForSearch(c *gc.C, s *Store, id *router.ResolvedURL, ch charm.Charm
 	}
 	err = s.SetPerms(&id.URL, "stable.read", acl...)
 	c.Assert(err, gc.IsNil)
-	err = s.Publish(id, params.StableChannel)
+	err = s.Publish(id, nil, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -1034,6 +1034,6 @@ func addBundleForSearch(c *gc.C, s *Store, id *router.ResolvedURL, b charm.Bundl
 	}
 	err = s.SetPerms(&id.URL, "stable.read", acl...)
 	c.Assert(err, gc.IsNil)
-	err = s.Publish(id, params.StableChannel)
+	err = s.Publish(id, nil, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 }

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -409,7 +409,7 @@ func (s *APISuite) addPublicCharm(c *gc.C, charmName, curl string) (*router.Reso
 func (s *APISuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	err := s.store.SetPerms(&rurl.URL, "stable.read", params.Everyone)
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(rurl, params.StableChannel)
+	err = s.store.Publish(rurl, nil, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 }
 

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -154,6 +154,12 @@ func NormalizeBaseEntity(be *mongodoc.BaseEntity) *mongodoc.BaseEntity {
 	if len(be1.ChannelEntities) == 0 {
 		be1.ChannelEntities = nil
 	}
+
+	for c, resources := range be1.ChannelResources {
+		if len(resources) == 0 {
+			delete(be1.ChannelResources, c)
+		}
+	}
 	if len(be1.ChannelResources) == 0 {
 		be1.ChannelResources = nil
 	}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -693,7 +693,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 	// Publish one of the revisions to development, then PUT to meta/perm
 	// and check that the development ACLs have changed.
-	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), params.DevelopmentChannel)
+	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), nil, params.DevelopmentChannel)
 	c.Assert(err, gc.IsNil)
 
 	s.doAsUser("bob", func() {
@@ -745,7 +745,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	})
 	// Publish wordpress-1 to stable and check that the stable ACLs
 	// have changed.
-	err = s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), params.StableChannel)
+	err = s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), nil, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 
 	// The stable permissions only allow charmers currently, so act as
@@ -1777,7 +1777,7 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
 	err := s.store.AddCharmWithArchive(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), storetesting.NewCharm(nil))
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), params.DevelopmentChannel)
+	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), nil, params.DevelopmentChannel)
 	c.Assert(err, gc.IsNil)
 	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
 
@@ -2662,7 +2662,7 @@ func (s *APISuite) TestURLChannelResolving(c *gc.C) {
 		err := s.store.AddCharmWithArchive(add.id, storetesting.NewCharm(nil))
 		c.Assert(err, gc.IsNil)
 		if add.channel != params.UnpublishedChannel {
-			err = s.store.Publish(add.id, add.channel)
+			err = s.store.Publish(add.id, nil, add.channel)
 			c.Assert(err, gc.IsNil)
 		}
 	}

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -563,7 +563,7 @@ func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 	} {
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmArchive(c.MkDir(), rurl.URL.Name))
 		c.Assert(err, gc.IsNil)
-		err = s.store.Publish(rurl, params.StableChannel)
+		err = s.store.Publish(rurl, nil, params.StableChannel)
 		c.Assert(err, gc.IsNil)
 	}
 

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -412,7 +412,7 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 
 		// publish the charm on any required channels.
 		if len(test.channels) > 0 {
-			err := s.store.Publish(rurl, test.channels...)
+			err := s.store.Publish(rurl, nil, test.channels...)
 			c.Assert(err, gc.IsNil)
 		}
 
@@ -639,7 +639,7 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 
 		// publish the charm on any required channels.
 		if len(test.channels) > 0 {
-			err := s.store.Publish(rurl, test.channels...)
+			err := s.store.Publish(rurl, nil, test.channels...)
 			c.Assert(err, gc.IsNil)
 		}
 
@@ -1004,7 +1004,7 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 		rurl,
 		storetesting.Charms.CharmDir("wordpress"))
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(rurl, params.StableChannel)
+	err = s.store.Publish(rurl, nil, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 	// Change the ACLs for the testing charm.
 	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -204,7 +204,7 @@ func (s *commonSuite) addPublicCharm(c *gc.C, ch charm.Charm, rurl *router.Resol
 func (s *commonSuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	err := s.store.SetPerms(&rurl.URL, "stable.read", params.Everyone)
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(rurl, params.StableChannel)
+	err = s.store.Publish(rurl, nil, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 }
 

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -1402,12 +1402,10 @@ func (h *ReqHandler) servePublish(id *router.ResolvedURL, w http.ResponseWriter,
 		}
 	}
 
-	// TODO(ericsnow) Actually handle the resources.
-	if len(publish.Resources) > 0 {
-		return errNotImplemented
-	}
-
-	if err := h.Store.Publish(id, chans...); err != nil {
+	if err := h.Store.Publish(id, publish.Resources, chans...); err != nil {
+		if errgo.Cause(err) == charmstore.ErrPublishResourceMismatch {
+			return errgo.WithCausef(err, params.ErrBadRequest, "")
+		}
 		return errgo.NoteMask(err, "cannot publish charm or bundle", errgo.Is(params.ErrNotFound))
 	}
 	// TODO add publish audit

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -603,7 +603,7 @@ func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 	} {
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmArchive(c.MkDir(), rurl.URL.Name))
 		c.Assert(err, gc.IsNil)
-		err = s.store.Publish(rurl, params.StableChannel)
+		err = s.store.Publish(rurl, nil, params.StableChannel)
 		c.Assert(err, gc.IsNil)
 	}
 

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -412,7 +412,7 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 
 		// publish the charm on any required channels.
 		if len(test.channels) > 0 {
-			err := s.store.Publish(rurl, test.channels...)
+			err := s.store.Publish(rurl, nil, test.channels...)
 			c.Assert(err, gc.IsNil)
 		}
 
@@ -639,7 +639,7 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 
 		// publish the charm on any required channels.
 		if len(test.channels) > 0 {
-			err := s.store.Publish(rurl, test.channels...)
+			err := s.store.Publish(rurl, nil, test.channels...)
 			c.Assert(err, gc.IsNil)
 		}
 
@@ -1004,7 +1004,7 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 		rurl,
 		storetesting.Charms.CharmDir("wordpress"))
 	c.Assert(err, gc.IsNil)
-	err = s.store.Publish(rurl, params.StableChannel)
+	err = s.store.Publish(rurl, nil, params.StableChannel)
 	c.Assert(err, gc.IsNil)
 	// Change the ACLs for the testing charm.
 	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")


### PR DESCRIPTION
For the time being, we aren't strict about checking that all the resources are specified
at publish time. As the test changes for that will be a bit disruptive, we'll do that
in the next PR.
