### PR TITLE
internal/charmstore: enforce all resources at publish time

### DIFF
--- a/internal/charmstore/common_test.go
+++ b/internal/charmstore/common_test.go
@@ -4,13 +4,11 @@
 package charmstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
 import (
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon-bakery.v1/bakery"
 
-	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 )
@@ -38,27 +36,6 @@ func (s *commonSuite) newStore(c *gc.C, withElasticSearch bool) *Store {
 	store := p.Store()
 	defer p.Close()
 	return store
-}
-
-func addCharm(c *gc.C, store *Store, curl *charm.URL) (*mongodoc.Entity, *charm.CharmDir) {
-	resolvedURL := MustParseResolvedURL(curl.String())
-	ch := storetesting.Charms.CharmDir(curl.Name)
-	err := store.AddCharmWithArchive(resolvedURL, ch)
-	c.Assert(err, jc.ErrorIsNil)
-	entity, err := store.FindEntity(resolvedURL, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	return entity, ch
-}
-
-func addBundle(c *gc.C, store *Store, curl *charm.URL) *mongodoc.Entity {
-	resolvedURL := MustParseResolvedURL(curl.String())
-	b := storetesting.Charms.BundleDir(curl.Name)
-	addRequiredCharms(c, store, b)
-	err := store.AddBundleWithArchive(resolvedURL, b)
-	c.Assert(err, jc.ErrorIsNil)
-	entity, err := store.FindEntity(resolvedURL, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	return entity
 }
 
 func addRequiredCharms(c *gc.C, store *Store, bundle charm.Bundle) {

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -542,9 +542,9 @@ var metaEndpoints = []metaEndpoint{{
 		}
 		entity, err := store.FindEntity(url, nil)
 		if err != nil {
-			return nil, err
+			return nil, errgo.Mask(err)
 		}
-		resources, err := store.ListResources(entity, params.UnpublishedChannel)
+		resources, err := store.ListResources(url, params.UnpublishedChannel)
 		if err != nil {
 			return resources, err
 		}
@@ -565,19 +565,24 @@ var metaEndpoints = []metaEndpoint{{
 			Name:        "for-install",
 			Type:        "file",
 			Path:        "initial.tgz",
-			Revision:    -1,
+			Revision:    0,
+			Fingerprint: rawHash(hashOfString("for-install content")),
+			Size:        int64(len("for-install content")),
 			Description: "get things started",
 		}, {
 			Name:        "for-store",
 			Type:        "file",
 			Path:        "dummy.tgz",
-			Revision:    -1,
+			Revision:    0,
+			Fingerprint: rawHash(hashOfString("for-store content")),
+			Size:        int64(len("for-store content")),
 			Description: "One line that is useful when operators need to push it.",
 		}, {
 			Name:        "for-upload",
 			Type:        "file",
 			Path:        "config.xml",
-			Revision:    -1,
+			Fingerprint: rawHash(hashOfString("for-upload content")),
+			Size:        int64(len("for-upload content")),
 			Description: "Who uses xml anymore?",
 		}})
 	},

--- a/internal/v5/resources.go
+++ b/internal/v5/resources.go
@@ -104,7 +104,7 @@ func (h *ReqHandler) serveUploadResource(id *router.ResolvedURL, w http.Response
 			}
 		}
 	}
-	rdoc, err := h.Store.UploadResource(e, name, req.Body, hash, req.ContentLength)
+	rdoc, err := h.Store.UploadResource(id, name, req.Body, hash, req.ContentLength)
 	if err != nil {
 		return errgo.Mask(err)
 	}
@@ -146,7 +146,7 @@ func (h *ReqHandler) metaResources(entity *mongodoc.Entity, id *router.ResolvedU
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}
-	resources, err := h.Store.ListResources(entity, ch)
+	resources, err := h.Store.ListResources(id, ch)
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}


### PR DESCRIPTION
We also change the ListResources and UploadResources Store methods
so they're consistent with the rest of the API and take a ResolvedURL not
an entity. This makes them somewhat less efficient in the short term,
but a) it's highly unlikely they're going to be a bottleneck and b) we will
need to sort out entity caching at the store layer anyway in due course,
and having everything consistent will make that easier.
