### PR TITLE
internal/v5: implement meta/can-ingest endpoint

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -6,7 +6,7 @@ github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	201
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z
-github.com/juju/idmclient	git	1995850da11150fb9247e43c6089e54eaeaae44a	2016-04-01T13:35:05Z
+github.com/juju/idmclient	git	98ac3e5ba9acebc7f946ec6478a783836507dd7f	2016-04-13T13:29:21Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/names	git	8a0aa0963bbacdc790914892e9ff942e94d6f795	2016-03-30T15:05:33Z
@@ -24,7 +24,7 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	728a5ea3ff1c1ae8b4c3ac4779c0027f693d1ca5	2016-04-08T11:12:17Z
-gopkg.in/juju/charmrepo.v2-unstable	git	c457416da598dffa665fc75aeb5c7265ff1273c0	2016-04-13T10:03:17Z
+gopkg.in/juju/charmrepo.v2-unstable	git	b1af69d31ef0112656f79a74a1f29381af1cc109	2016-04-19T12:03:30Z
 gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z
 gopkg.in/macaroon-bakery.v1	git	fddb3dcd74806133259879d033fdfe92f9e67a8a	2016-04-01T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z

--- a/docs/API.md
+++ b/docs/API.md
@@ -1444,6 +1444,26 @@ Example: `GET trusty/wordpress-42/meta/promulgated`
 }
 ```
 
+#### GET *id*/meta/can-ingest
+
+The `can-ingest` path reports whether the entity with the given ID is
+eligible for ingestion. When an entity is manually uploaded (via the /archive
+endpoint with the POST method), it becomes ineligible for ingestion.
+
+```go
+type CanIngestResponse struct {
+	CanIngest bool
+}
+```
+
+Example: `GET trusty/wordpress-42/meta/can-ingest`
+
+```json
+{
+	"CanIngest": false
+}
+```
+
 #### GET *id*/meta/stats
 
 <pre>

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -200,6 +200,12 @@ type BaseEntity struct {
 	// set of resource names holding the currently published resource
 	// version for that channel and resource name.
 	ChannelResources map[params.Channel][]ResourceRevision
+	
+	// NoIngest is set to true when a charm or bundle has been uploaded
+	// with a POST request. Since the ingester only uses PUT requests
+	// at present, this signifies that someone has taken over control from
+	// the ingester.
+	NoIngest bool	`bson:",omitempty"`
 }
 
 // ResourceRevision specifies an association of a resource name to a

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -141,6 +141,7 @@ func newReqHandler() ReqHandler {
 	delete(handlers.Id, "resource")
 	delete(handlers.Meta, "resources")
 	delete(handlers.Meta, "resources/")
+	delete(handlers.Meta, "can-ingest")
 
 	h.Router = router.New(handlers, h)
 	return h

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -273,6 +273,7 @@ func RouterHandlers(h *ReqHandler) *router.Handlers {
 			"perm":             h.puttableBaseEntityHandler(h.metaPerm, h.putMetaPerm, "channelacls"),
 			"perm/":            h.puttableBaseEntityHandler(h.metaPermWithKey, h.putMetaPermWithKey, "channelacls"),
 			"promulgated":      h.baseEntityHandler(h.metaPromulgated, "promulgated"),
+			"can-ingest":       h.baseEntityHandler(h.metaCanIngest, "noingest"),
 			"resources":        h.EntityHandler(h.metaResources, "charmmeta"),
 			"resources/":       h.EntityHandler(h.metaResourcesSingle, "charmmeta"),
 			"revision-info":    router.SingleIncludeHandler(h.metaRevisionInfo),
@@ -1054,6 +1055,14 @@ func (h *ReqHandler) putMetaPerm(id *router.ResolvedURL, path string, val *json.
 func (h *ReqHandler) metaPromulgated(entity *mongodoc.BaseEntity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
 	return params.PromulgatedResponse{
 		Promulgated: bool(entity.Promulgated),
+	}, nil
+}
+
+// GET id/meta/can-ingest
+// See https://github.com/juju/charmstore/blob/v5-unstable/docs/API.md#get-idmetacan-ingest
+func (h *ReqHandler) metaCanIngest(entity *mongodoc.BaseEntity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
+	return params.CanIngestResponse{
+		CanIngest: !entity.NoIngest,
 	}, nil
 }
 

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -500,6 +500,21 @@ var metaEndpoints = []metaEndpoint{{
 		c.Assert(data, gc.Equals, params.PromulgatedResponse{Promulgated: false})
 	},
 }, {
+	name: "can-ingest",
+	get: func(store *charmstore.Store, url *router.ResolvedURL) (interface{}, error) {
+		e, err := store.FindBaseEntity(&url.URL, nil)
+		if err != nil {
+			return nil, err
+		}
+		return params.CanIngestResponse{
+			CanIngest: !e.NoIngest,
+		}, nil
+	},
+	checkURL: newResolvedURL("cs:~bob/utopic/wordpress-2", -1),
+	assertCheckData: func(c *gc.C, data interface{}) {
+		c.Assert(data, gc.Equals, params.CanIngestResponse{CanIngest: true})
+	},
+}, {
 	name: "supported-series",
 	get: entityGetter(func(entity *mongodoc.Entity) interface{} {
 		if entity.URL.Series == "bundle" {


### PR DESCRIPTION
This will make it possible for charmload to ignore charms
that are under manual control.
