### PR TITLE
internal/v5: return long-lived macaroon from delegatable-macaroon

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -200,12 +200,12 @@ type BaseEntity struct {
 	// set of resource names holding the currently published resource
 	// version for that channel and resource name.
 	ChannelResources map[params.Channel][]ResourceRevision
-	
+
 	// NoIngest is set to true when a charm or bundle has been uploaded
 	// with a POST request. Since the ingester only uses PUT requests
 	// at present, this signifies that someone has taken over control from
 	// the ingester.
-	NoIngest bool	`bson:",omitempty"`
+	NoIngest bool `bson:",omitempty"`
 }
 
 // ResourceRevision specifies an association of a resource name to a

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -1390,7 +1390,6 @@ func (s *APISuite) TestMetaTerms(c *gc.C) {
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL(id2 + "meta/terms"),
-		Method:       "GET",
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Code:    params.ErrNotFound,
@@ -1406,7 +1405,6 @@ func (s *APISuite) TestMetaTermsBundle(c *gc.C) {
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL(id.URL.Path() + "/meta/terms"),
-		Method:       "GET",
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Code:    params.ErrMetadataNotFound,

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -1179,7 +1179,6 @@ func (s *ArchiveSuite) TestArchiveFileErrors(c *gc.C) {
 			Handler:      s.srv,
 			URL:          storeURL(test.path),
 			Do:           bakeryDo(nil),
-			Method:       "GET",
 			ExpectStatus: test.expectStatus,
 			ExpectBody: params.Error{
 				Message: test.expectMessage,

--- a/internal/v5/export_test.go
+++ b/internal/v5/export_test.go
@@ -4,12 +4,12 @@
 package v5 // import "gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 
 var (
-	ProcessIcon          = processIcon
-	ErrProbablyNotXML    = errProbablyNotXML
-	TestAddAuditCallback = &testAddAuditCallback
-	FromResourceDoc      = fromResourceDoc
-
+	ProcessIcon               = processIcon
+	ErrProbablyNotXML         = errProbablyNotXML
+	TestAddAuditCallback      = &testAddAuditCallback
+	FromResourceDoc           = fromResourceDoc
 	GetNewPromulgatedRevision = (*ReqHandler).getNewPromulgatedRevision
-
-	ResolveURL = resolveURL
+	ResolveURL                = resolveURL
+	RenewMacaroon             = renewMacaroon
+	TimeNow                   = &timeNow
 )


### PR DESCRIPTION
We add an "active-time-before" caveat so even though technically
the macaroon lasts forever, the client is obliged to replace it
after that expiry time, giving the charmstore the opportunity
to change macaroon format etc.
