### PR TITLE
internal/v5: refactor authorization code

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -5,15 +5,15 @@ github.com/juju/gojsonpointer	git	afe8b77aa08f272b49e01b82de78510c11f61500	2015-
 github.com/juju/gojsonreference	git	f0d24ac5ee330baa21721cdff56d45e4ee42628e	2015-02-04T19:46:33Z
 github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-03-12T17:00:16Z
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
-github.com/juju/httprequest	git	89d547093c45e293599088cc63e805c6f1205dc0	2016-03-02T10:09:58Z
-github.com/juju/idmclient	git	98ac3e5ba9acebc7f946ec6478a783836507dd7f	2016-04-13T13:29:21Z
+github.com/juju/httprequest	git	3d72385a5c19cf70e983c8cb888769a2d9efe2ea	2016-04-20T11:37:53Z
+github.com/juju/idmclient	git	24249a7beddb83931417a6a761c29b1234c9cbac	2016-04-25T12:21:04Z
 github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03:58:39Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/names	git	8a0aa0963bbacdc790914892e9ff942e94d6f795	2016-03-30T15:05:33Z
 github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
 github.com/juju/testing	git	162fafccebf20a4207ab93d63b986c230e3f4d2e	2016-04-04T09:43:17Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	eb6cb958762135bb61aed1e0951f657c674d427f	2016-04-11T02:40:59Z
+github.com/juju/utils	git	53080499b3c86a913a57a3a8e2b31cfbb6fe5b1d	2016-04-26T09:38:41Z
 github.com/juju/version	git	ef897ad7f130870348ce306f61332f5335355063	2015-11-27T20:34:00Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
@@ -26,7 +26,7 @@ gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:
 gopkg.in/juju/charm.v6-unstable	git	728a5ea3ff1c1ae8b4c3ac4779c0027f693d1ca5	2016-04-08T11:12:17Z
 gopkg.in/juju/charmrepo.v2-unstable	git	b1af69d31ef0112656f79a74a1f29381af1cc109	2016-04-19T12:03:30Z
 gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z
-gopkg.in/macaroon-bakery.v1	git	fddb3dcd74806133259879d033fdfe92f9e67a8a	2016-04-01T12:14:21Z
+gopkg.in/macaroon-bakery.v1	git	2e7eb1fbcaaeddad5253ce652a57112adc7aa7db	2016-04-25T10:14:06Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -226,7 +226,7 @@ type Context interface {
 	// by nil elements.
 	ResolveURLs(ids []*charm.URL) ([]*ResolvedURL, error)
 
-	// The AuthorizeEntity function will be called to authorize requests
+	// AuthorizeEntity will be called to authorize requests
 	// to any BulkIncludeHandlers. All other handlers are expected
 	// to handle their own authorization.
 	AuthorizeEntity(id *ResolvedURL, req *http.Request) error

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -2878,7 +2878,7 @@ func (s *APISuite) TestWhoAmIReturnsNameAndGroups(c *gc.C) {
 		ExpectStatus: http.StatusOK,
 		ExpectBody: params.WhoAmIResponse{
 			User:   "who",
-			Groups: []string{"foo", "bar"},
+			Groups: []string{"bar", "foo"},
 		},
 	})
 }

--- a/internal/v4/archive.go
+++ b/internal/v4/archive.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 )
 
 // serveArchive returns a handler for /archive that falls back to v5ServeArchive
@@ -26,8 +27,7 @@ func (h ReqHandler) serveArchive(v5ServeArchive router.IdHandler) router.IdHandl
 }
 
 func (h ReqHandler) serveGetArchive(id *router.ResolvedURL, w http.ResponseWriter, req *http.Request) error {
-	_, err := h.AuthorizeEntityAndTerms(req, []*router.ResolvedURL{id})
-	if err != nil {
+	if err := h.AuthorizeEntityForOp(id, req, v5.OpReadWithTerms); err != nil {
 		return errgo.Mask(err, errgo.Any)
 	}
 	blob, err := h.Store.OpenBlobPreV5(id)

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -897,7 +897,7 @@ var isEntityCaveatTests = []struct {
 	expectError: `verification failed: caveat "is-entity cs:~charmers/utopic/wordpress-42" not satisfied: operation on entity cs:utopic/wordpress-9 not allowed`,
 }, {
 	url:         "log",
-	expectError: `verification failed: caveat "is-entity cs:~charmers/utopic/wordpress-42" not satisfied: operation does not involve any of the allowed entities cs:~charmers/utopic/wordpress-42`,
+	expectError: `verification failed: caveat "is-entity cs:~charmers/utopic/wordpress-42" not satisfied: operation does not involve any entities`,
 }}
 
 func (s *authSuite) TestIsEntityCaveat(c *gc.C) {

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v4"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/v5"
 )
 
 var mgoLogger = loggo.GetLogger("mgo")
@@ -142,6 +143,8 @@ func (s *commonSuite) TearDownTest(c *gc.C) {
 
 // startServer creates a new charmstore server.
 func (s *commonSuite) startServer(c *gc.C) {
+	// Disable group caching.
+	s.PatchValue(&v5.PermCacheExpiry, time.Duration(0))
 	config := charmstore.ServerParams{
 		AuthUsername:     testUsername,
 		AuthPassword:     testPassword,

--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -19,14 +19,14 @@ func (h ReqHandler) serveSearch(_ http.Header, req *http.Request) (interface{}, 
 		return "", err
 	}
 	sp.ExpandedMultiSeries = true
-	auth, err := h.CheckRequest(req, nil, v5.OpOther)
+	auth, err := h.Authenticate(req)
 	if err != nil {
 		logger.Infof("authorization failed on search request, granting no privileges: %v", err)
 	}
 	sp.Admin = auth.Admin
 	if auth.Username != "" {
 		sp.Groups = append(sp.Groups, auth.Username)
-		groups, err := h.GroupsForUser(auth.Username)
+		groups, err := h.Handler.GroupsForUser(auth.Username)
 		if err != nil {
 			logger.Infof("cannot get groups for user %q, assuming no groups: %v", auth.Username, err)
 		}

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -3560,7 +3560,7 @@ func (s *APISuite) TestWhoAmIReturnsNameAndGroups(c *gc.C) {
 		ExpectStatus: http.StatusOK,
 		ExpectBody: params.WhoAmIResponse{
 			User:   "who",
-			Groups: []string{"foo", "bar"},
+			Groups: []string{"bar", "foo"},
 		},
 	})
 }

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -867,7 +867,7 @@ var isEntityCaveatTests = []struct {
 	expectError: `verification failed: caveat "is-entity cs:~charmers/utopic/wordpress-42" not satisfied: operation on entity cs:utopic/wordpress-9 not allowed`,
 }, {
 	url:         "log",
-	expectError: `verification failed: caveat "is-entity cs:~charmers/utopic/wordpress-42" not satisfied: operation does not involve any of the allowed entities cs:~charmers/utopic/wordpress-42`,
+	expectError: `verification failed: caveat "is-entity cs:~charmers/utopic/wordpress-42" not satisfied: operation does not involve any entities`,
 }}
 
 func (s *authSuite) TestIsEntityCaveat(c *gc.C) {
@@ -1259,66 +1259,6 @@ func (s *authSuite) TestRenewMacaroon(c *gc.C) {
 	}, {
 		Id: "active-time-before " + expectTime,
 	}})
-}
-
-func (s *authSuite) TestGroupsForUserSuccess(c *gc.C) {
-	h := s.handler(c)
-	defer h.Close()
-	s.idM.groups = map[string][]string{
-		"bob": {"one", "two"},
-	}
-	groups, err := h.GroupsForUser("bob")
-	c.Assert(err, gc.IsNil)
-	c.Assert(groups, jc.DeepEquals, []string{"one", "two"})
-}
-
-func (s *authSuite) TestGroupsForUserWithNoIdentity(c *gc.C) {
-	h := s.handler(c)
-	defer h.Close()
-	groups, err := h.GroupsForUser("someone")
-	c.Assert(err, gc.IsNil)
-	c.Assert(groups, gc.HasLen, 0)
-}
-
-func (s *authSuite) TestGroupsForUserWithInvalidIdentityURL(c *gc.C) {
-	s.PatchValue(&s.srvParams.IdentityAPIURL, ":::::")
-	h := s.handler(c)
-	defer h.Close()
-	groups, err := h.GroupsForUser("someone")
-	c.Assert(err, gc.ErrorMatches, `cannot get groups for someone: cannot parse ":::::": parse :::::: missing protocol scheme`)
-	c.Assert(groups, gc.HasLen, 0)
-}
-
-func (s *authSuite) TestGroupsForUserWithInvalidBody(c *gc.C) {
-	h := s.handler(c)
-	defer h.Close()
-	s.idM.body = "bad"
-	s.idM.contentType = "application/json"
-	groups, err := h.GroupsForUser("someone")
-	c.Assert(err, gc.ErrorMatches, `cannot get groups for someone: GET .*: invalid character 'b' looking for beginning of value`)
-	c.Assert(groups, gc.HasLen, 0)
-}
-
-func (s *authSuite) TestGroupsForUserWithErrorResponse(c *gc.C) {
-	h := s.handler(c)
-	defer h.Close()
-	s.idM.body = `{"message":"some error","code":"some code"}`
-	s.idM.status = http.StatusUnauthorized
-	s.idM.contentType = "application/json"
-	groups, err := h.GroupsForUser("someone")
-	c.Assert(err, gc.ErrorMatches, `cannot get groups for someone: GET .*: some error`)
-	c.Assert(groups, gc.HasLen, 0)
-}
-
-func (s *authSuite) TestGroupsForUserWithBadErrorResponse(c *gc.C) {
-	h := s.handler(c)
-	defer h.Close()
-	s.idM.body = `{"message":"some error"`
-	s.idM.status = http.StatusUnauthorized
-	s.idM.contentType = "application/json"
-	groups, err := h.GroupsForUser("someone")
-	c.Assert(err, gc.ErrorMatches, `cannot get groups for someone: GET .*: cannot unmarshal error response \(status 401 Unauthorized\): unexpected EOF`)
-	c.Assert(groups, gc.HasLen, 0)
 }
 
 // getDelegatableMacaroon acquires a delegatable macaroon good for

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -150,6 +150,8 @@ func (s *commonSuite) TearDownTest(c *gc.C) {
 
 // startServer creates a new charmstore server.
 func (s *commonSuite) startServer(c *gc.C) {
+	// Disable group caching.
+	s.PatchValue(&v5.PermCacheExpiry, time.Duration(0))
 	config := charmstore.ServerParams{
 		AuthUsername:     testUsername,
 		AuthPassword:     testPassword,
@@ -168,6 +170,7 @@ func (s *commonSuite) startServer(c *gc.C) {
 		c.Assert(err, gc.IsNil)
 		err = keyring.AddPublicKeyForLocation(discharger.Location(), true, pk)
 		c.Assert(err, gc.IsNil)
+		c.Logf("added public key for location %v", discharger.Location())
 	}
 	if s.enableTerms {
 		s.dischargeTerms = noDischarge

--- a/internal/v5/log.go
+++ b/internal/v5/log.go
@@ -23,8 +23,8 @@ import (
 // POST /log
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#post-log
 func (h *ReqHandler) serveLog(w http.ResponseWriter, req *http.Request) error {
-	if _, err := h.authorize(req, nil, true, nil); err != nil {
-		return err
+	if err := h.authenticateAdmin(req); err != nil {
+		return errgo.Mask(err, errgo.Any)
 	}
 	switch req.Method {
 	case "GET":

--- a/internal/v5/search.go
+++ b/internal/v5/search.go
@@ -26,14 +26,14 @@ func (h *ReqHandler) serveSearch(_ http.Header, req *http.Request) (interface{},
 	if err != nil {
 		return "", err
 	}
-	auth, err := h.CheckRequest(req, nil, OpOther)
+	auth, err := h.Authenticate(req)
 	if err != nil {
 		logger.Infof("authorization failed on search request, granting no privileges: %v", err)
 	}
 	sp.Admin = auth.Admin
 	if auth.Username != "" {
 		sp.Groups = append(sp.Groups, auth.Username)
-		groups, err := h.GroupsForUser(auth.Username)
+		groups, err := h.Handler.GroupsForUser(auth.Username)
 		if err != nil {
 			logger.Infof("cannot get groups for user %q, assuming no groups: %v", auth.Username, err)
 		}

--- a/internal/v5/stats.go
+++ b/internal/v5/stats.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 )
 
 const dateFormat = "2006-01-02"
@@ -115,7 +116,13 @@ func (h *ReqHandler) serveStatsCounter(_ http.Header, r *http.Request) (interfac
 // PUT stats/update
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#put-statsupdate
 func (h *ReqHandler) serveStatsUpdate(w http.ResponseWriter, r *http.Request) error {
-	if _, err := h.authorize(r, []string{"statsupdate@cs"}, true, nil); err != nil {
+	if _, err := h.authorize(authorizeParams{
+		req: r,
+		acls: []mongodoc.ACL{{
+			Write: []string{"statsupdate@cs"},
+		}},
+		ops: []string{OpWrite},
+	}); err != nil {
 		return err
 	}
 	if r.Method != "PUT" {


### PR DESCRIPTION
We now have a single entry point for all authorization, rather
than using two somewhat similar parallel authorization paths.

We change the operations so that we no longer use the
potentially fragile Deny caveat, instead issuing macaroons
that explicitly state the set of allowed operations.

Plus we clean up the code in several places, including using
the caching idm permission checker, so we won't need to
be round-tripping to idm so often.
