### PR TITLE
internal/{v5,charmstore}: fix so charmstore can work with no IdentityAPIURL

### DIFF
--- a/cmd/charmd/config.yaml
+++ b/cmd/charmd/config.yaml
@@ -6,11 +6,10 @@ auth-password: example-passwd
 #elasticsearch-addr: localhost:9200
 # For locally running services.
 #identity-public-key: CIdWcEUN+0OZnKW9KwruRQnQDY/qqzVdD30CijwiWCk=
-#identity-location: http://localhost:8081/v1/discharger
 #identity-api-url: http://localhost:8081
 # For production identity manager.
 identity-public-key: hmHaPgCC1UfuhYHUSX5+aihSAZesqpVdjRv0mgfIwjo=
-identity-location: https://api.jujucharms.com/identity/v1/discharger
+identity-api-url: https://api.jujucharms.com/identity
 # Agent credentials.
 #agent-username: charmstore@admin@idm
 #agent-key:

--- a/internal/charmstore/migrations_dump_test.go
+++ b/internal/charmstore/migrations_dump_test.go
@@ -258,7 +258,7 @@ func runMigrationVersion(db *mgo.Database, vc versionSpec) error {
 		AuthPassword:      "password",
 		APIAddr:           fmt.Sprintf("localhost:%d", jujutesting.FindTCPPort()),
 		MaxMgoSessions:    10,
-		IdentityLocation:  "https://api.jujucharms.com/identity",
+		IdentityAPIURL:    "https://0.1.2.3/identity",
 		IdentityPublicKey: &bogusPublicKey,
 	})
 	if err != nil {

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -40,12 +40,13 @@ type ServerParams struct {
 
 	// IdentityLocation holds the location of the third party authorization
 	// service to use when creating third party caveats,
-	// for example: http://api.jujucharms.com/identity/v1/discharger
-	// If it is empty, IdentityURL+"/v1/discharger" will be used.
+	// for example: http://api.jujucharms.com/identity
+	// If it is empty, IdentityAPIURL will be used.
 	IdentityLocation string
 
-	// TermsLocation holds the location of the third party
-	// terms service to use when creating third party caveats.
+	// TermsLocations holds the location of the
+	// terms service, which knows about user agreements to
+	// Terms and Conditions required by the charm.
 	TermsLocation string
 
 	// PublicKeyLocator holds a public key store.
@@ -96,11 +97,11 @@ func NewServer(db *mgo.Database, si *SearchIndex, config ServerParams, versions 
 	if len(versions) == 0 {
 		return nil, errgo.Newf("charm store server must serve at least one version of the API")
 	}
-	config.IdentityLocation = strings.Trim(config.IdentityLocation, "/")
-	config.TermsLocation = strings.Trim(config.TermsLocation, "/")
-	config.IdentityAPIURL = strings.Trim(config.IdentityAPIURL, "/")
+	config.IdentityLocation = strings.TrimSuffix(config.IdentityLocation, "/")
+	config.TermsLocation = strings.TrimSuffix(config.TermsLocation, "/")
+	config.IdentityAPIURL = strings.TrimSuffix(config.IdentityAPIURL, "/")
 	if config.IdentityLocation == "" && config.IdentityAPIURL != "" {
-		config.IdentityLocation = config.IdentityAPIURL + "/v1/discharger"
+		config.IdentityLocation = config.IdentityAPIURL
 	}
 	logger.Infof("identity discharge location: %s", config.IdentityLocation)
 	logger.Infof("identity API location: %s", config.IdentityAPIURL)

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -150,6 +150,8 @@ func (s *commonSuite) startServer(c *gc.C) {
 		AuthPassword:     testPassword,
 		StatsCacheMaxAge: time.Nanosecond,
 		MaxMgoSessions:   s.maxMgoSessions,
+		AgentUsername:    "notused",
+		AgentKey:         new(bakery.KeyPair),
 	}
 	keyring := bakery.NewPublicKeyRing()
 	if s.enableIdentity {

--- a/internal/v5/auth.go
+++ b/internal/v5/auth.go
@@ -363,7 +363,7 @@ func (h *ReqHandler) checkRequest(p authorizeParams) (authorization, error) {
 		return authorization{Admin: true}, nil
 	}
 	bk := h.Store.Bakery
-	if errgo.Cause(err) != errNoCreds || bk == nil || h.Handler.config.IdentityAPIURL == "" {
+	if errgo.Cause(err) != errNoCreds || bk == nil || h.Handler.config.IdentityLocation == "" {
 		return authorization{}, errgo.WithCausef(err, params.ErrUnauthorized, "authentication failed")
 	}
 	// active holds whether we're checking with active status.
@@ -718,4 +718,21 @@ func isPublicACL(acl []string) bool {
 		}
 	}
 	return false
+}
+
+type noGroupCache struct{}
+
+func (noGroupCache) Groups(username string) ([]string, error) {
+	return nil, nil
+}
+
+type noGroupsPermChecker struct{}
+
+func (noGroupsPermChecker) Allow(username string, acl []string) (bool, error) {
+	for _, name := range acl {
+		if name == username || name == params.Everyone {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -157,6 +157,8 @@ func (s *commonSuite) startServer(c *gc.C) {
 		AuthPassword:     testPassword,
 		StatsCacheMaxAge: time.Nanosecond,
 		MaxMgoSessions:   s.maxMgoSessions,
+		AgentUsername:    "notused",
+		AgentKey:         new(bakery.KeyPair),
 	}
 	keyring := bakery.NewPublicKeyRing()
 	if s.enableIdentity {

--- a/server.go
+++ b/server.go
@@ -59,8 +59,8 @@ type ServerParams struct {
 
 	// IdentityLocation holds the location of the third party authorization
 	// service to use when creating third party caveats,
-	// for example: http://api.jujucharms.com/identity/v1/discharger
-	// If it is empty, IdentityURL+"/v1/discharger" will be used.
+	// for example: http://api.jujucharms.com/identity
+	// If it is empty, IdentityAPIURL will be used.
 	IdentityLocation string
 
 	// TermsLocations holds the location of the


### PR DESCRIPTION
Quite a few testing clients rely on being able to do this, so let's not break them.

Also make the example config.yaml do the right thing.
