### PR TITLE
internal/charmstore: fix autocomplete

### DIFF
--- a/elasticsearch/query.go
+++ b/elasticsearch/query.go
@@ -40,15 +40,19 @@ func (m MatchAllQuery) MarshalJSON() ([]byte, error) {
 // MatchQuery provides a query that matches against
 // a complete field.
 type MatchQuery struct {
-	Field string
-	Query string
-	Type  string
+	Field    string
+	Query    string
+	Type     string
+	Analyzer string
 }
 
 func (m MatchQuery) MarshalJSON() ([]byte, error) {
 	params := map[string]interface{}{"query": m.Query}
 	if m.Type != "" {
 		params["type"] = m.Type
+	}
+	if m.Analyzer != "" {
+		params["analyzer"] = m.Analyzer
 	}
 
 	return marshalNamedObject("match", map[string]interface{}{m.Field: params})

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -672,7 +672,6 @@ var searchTests = []struct {
 }
 
 func (s *StoreSearchSuite) TestSearches(c *gc.C) {
-	c.ExpectFailure("autocomplete query not analyzed properly")
 	s.store.ES.Database.RefreshIndex(s.TestIndex)
 	for i, test := range searchTests {
 		c.Logf("test %d: %s", i, test.about)

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -388,6 +388,22 @@ var searchTests = []struct {
 		},
 		results: Entities{},
 	}, {
+		about: "autocomplete with hyphen - match",
+		sp: SearchParams{
+			Text:         "squid-f",
+			AutoComplete: true,
+		},
+		results: Entities{
+			searchEntities["squid-forwardproxy"].entity,
+		},
+	}, {
+		about: "autocomplete with hyphen - no match",
+		sp: SearchParams{
+			Text:         "squid-g",
+			AutoComplete: true,
+		},
+		results: Entities{},
+	}, {
 		about: "description filter search",
 		sp: SearchParams{
 			Text: "",
@@ -656,6 +672,7 @@ var searchTests = []struct {
 }
 
 func (s *StoreSearchSuite) TestSearches(c *gc.C) {
+	c.ExpectFailure("autocomplete query not analyzed properly")
 	s.store.ES.Database.RefreshIndex(s.TestIndex)
 	for i, test := range searchTests {
 		c.Logf("test %d: %s", i, test.about)


### PR DESCRIPTION
Change the way autocomplete searches are performed to only match entities where text is an exact prefix of the entity name.
