### PR TITLE
internal/charmstore: reuse macaroon root keys

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -11,7 +11,7 @@ github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/names	git	8a0aa0963bbacdc790914892e9ff942e94d6f795	2016-03-30T15:05:33Z
 github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
-github.com/juju/testing	git	162fafccebf20a4207ab93d63b986c230e3f4d2e	2016-04-04T09:43:17Z
+github.com/juju/testing	git	b9cfe07211e464f16d78ca9304c503d636b8eefa	2016-05-19T00:49:35Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
 github.com/juju/utils	git	53080499b3c86a913a57a3a8e2b31cfbb6fe5b1d	2016-04-26T09:38:41Z
 github.com/juju/version	git	ef897ad7f130870348ce306f61332f5335355063	2015-11-27T20:34:00Z
@@ -19,6 +19,7 @@ github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
 github.com/juju/zip	git	f6b1e93fa2e29a1d7d49b566b2b51efb060c982a	2016-02-05T10:52:21Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
+github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
@@ -26,7 +27,7 @@ gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:
 gopkg.in/juju/charm.v6-unstable	git	728a5ea3ff1c1ae8b4c3ac4779c0027f693d1ca5	2016-04-08T11:12:17Z
 gopkg.in/juju/charmrepo.v2-unstable	git	b1af69d31ef0112656f79a74a1f29381af1cc109	2016-04-19T12:03:30Z
 gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z
-gopkg.in/macaroon-bakery.v1	git	2e7eb1fbcaaeddad5253ce652a57112adc7aa7db	2016-04-25T10:14:06Z
+gopkg.in/macaroon-bakery.v1	git	e7074941455a293ffb7905cd89ca20ee547a03ec	2016-05-27T11:55:54Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v1/bakery/mgostorage"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
@@ -122,6 +123,9 @@ func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
 			AuthPassword:     "test-password",
 			IdentityAPIURL:   "http://0.1.2.3",
 			IdentityLocation: "http://0.1.2.3",
+			RootKeyPolicy: mgostorage.Policy{
+				ExpiryDuration: defaultRootKeyExpiryDuration,
+			},
 		},
 	})
 }
@@ -153,6 +157,9 @@ func (s *ServerSuite) TestNewServerWithElasticSearch(c *gc.C) {
 			AuthPassword:     "test-password",
 			IdentityAPIURL:   "http://0.1.2.3",
 			IdentityLocation: "http://0.1.2.3",
+			RootKeyPolicy: mgostorage.Policy{
+				ExpiryDuration: defaultRootKeyExpiryDuration,
+			},
 		},
 	})
 }

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"gopkg.in/macaroon-bakery.v1/bakery"
+	"gopkg.in/macaroon-bakery.v1/bakery/mgostorage"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -50,7 +51,7 @@ func Versions() []string {
 	return vs
 }
 
-// ServerParams holds configuration for a new API server.
+// ServerParams holds configuration for a new internal API server.
 type ServerParams struct {
 	// AuthUsername and AuthPassword hold the credentials
 	// used for HTTP basic authentication.
@@ -102,6 +103,10 @@ type ServerParams struct {
 	// AuditLogger optionally holds the logger which will be used to
 	// write audit log entries.
 	AuditLogger *lumberjack.Logger
+
+	// RootKeyPolicy holds the default policy used when creating
+	// macaroon root keys.
+	RootKeyPolicy mgostorage.Policy
 }
 
 // NewServer returns a new handler that handles charm store requests and stores


### PR DESCRIPTION
This takes advantage of the mgostorage.RootKeyStorage to avoid
generating root keys every time we make an authorization decision.
