### PR TITLE
WIP Rename service to application

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -826,7 +826,7 @@ file for a bundle. The id must refer to a bundle, not a charm.
 
 ```go
 type BundleData struct {
-        Services map[string] ServiceSpec
+        Applications map[string] ApplicationSpec
         Machines map[string] MachineSpec `json:",omitempty"`
         Series string                    `json:",omitempty"`
         Relations [][]string             `json:",omitempty"`
@@ -837,13 +837,13 @@ type MachineSpec struct {
         Annotations map[string]string    `json:",omitempty"`
 }
 
-type ServiceSpec struct {
+type ApplicationSpec struct {
         Charm string
         NumUnits int
         To []string                      `json:",omitempty"`
 
         // Options holds the configuration values
-        // to apply to the new service. They should
+        // to apply to the new application. They should
         // be compatible with the charm configuration.
         Options map[string]interface{}   `json:",omitempty"`
         Annotations map[string]string    `json:",omitempty"`
@@ -855,7 +855,7 @@ Example: `GET mediawiki/meta/bundle-metadata`
 
 ```json
 {
-    "Services": {
+    "Applications": {
         "mediawiki": {
             "Charm": "cs:precise/mediawiki-10",
             "NumUnits": 1,

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -8,14 +8,14 @@ version 3 bundles, charmstore (API v4) supports version 3 and version 4.
 ## Version 3 bundles
 
 Version 3 bundles are currently existing bundles that specify a deployment as a
-list of services and, optionally, relations.  The charmstore will not support
+list of applications and, optionally, relations.  The charmstore will not support
 the idea of a "basket" or multiple bundles within one file.  However, existing
 baskets will still be imported, and split up into their component bundles.
 
 ## Version 4 bundles
 
 Version 4 bundles are identical to version 3 bundles except for a few key
-differences: the `branch` attribute of the service spec is no longer supported,
+differences: the `branch` attribute of the application spec is no longer supported,
 they may contain a machine specification, and their deployment directives are
 different from version 3 bundles.
 
@@ -53,7 +53,7 @@ Machines are specified under the `machines` top-level attribute.
 
 ### Deployment directives
 
-Version 4 deployment directives (the `to` attribute on the service spec) is a
+Version 4 deployment directives (the `to` attribute on the application spec) is a
 YAML list of items following the format:
 
     (<containertype>:)?(<unit>|<machine>|new)
@@ -64,13 +64,13 @@ co-locating it with any other units that happen to be there, which may result in
 unintended behavior.
 
 The second part (after the colon) specifies where the new unit should be placed;
-it may refer to a unit of another service specified in the bundle, a machine
+it may refer to a unit of another application specified in the bundle, a machine
 id specified in the machines section, or the special name "new" which specifies
 a newly created machine.
 
-A unit placement may be specified with a service name only, in which case its
+A unit placement may be specified with a application name only, in which case its
 unit number is assumed to be one more than the unit number of the previous unit
-in the list with the same service, or zero if there were none.
+in the list with the same application, or zero if there were none.
 
 If there are less elements in To than NumUnits, the last element is replicated
 to fill it. If there are no elements (or To is omitted), "new" is replicated.
@@ -80,7 +80,7 @@ For example:
     wordpress/0 wordpress/1 lxc:0 kvm:new
 
 specifies that the first two units get hulk-smashed onto the first two units of
-the wordpress service, the third unit gets allocated onto an lxc container on
+the wordpress application, the third unit gets allocated onto an lxc container on
 machine 0, and subsequent units get allocated on kvm containers on new machines.
 
 The above example is the same as this:
@@ -89,10 +89,10 @@ The above example is the same as this:
 
 Version 3 placement directives take the format:
 
-    ((<containertype>:)?<service>(=<unitnumber>)?|0)
+    ((<containertype>:)?<application>(=<unitnumber>)?|0)
 
 meaning that a machine cannot be specified beyond colocating (either through a
-container or hulk-smash) along with a specified unit of another service.
+container or hulk-smash) along with a specified unit of another application.
 Version 3 placement directives may be either a string of a single directive or a
 YAML list of directives in the above format.  The only machine that may be
 specified is machine 0, allowing colocation on the bootstrap node.
@@ -103,7 +103,7 @@ specified is machine 0, allowing colocation on the bootstrap node.
 
 ```yaml
 series: precise
-services:
+applications:
   nova-compute:
     charm: cs:precise/nova-compute
     units: 3
@@ -128,7 +128,7 @@ services:
 
 ```yaml
 series: precise
-services:
+applications:
   # Automatically place
   nova-compute:
     charm: cs:precise/nova-compute

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -8,7 +8,7 @@ version 3 bundles, charmstore (API v4) supports version 3 and version 4.
 ## Version 3 bundles
 
 Version 3 bundles are currently existing bundles that specify a deployment as a
-list of applications and, optionally, relations.  The charmstore will not support
+list of services and, optionally, relations.  The charmstore will not support
 the idea of a "basket" or multiple bundles within one file.  However, existing
 baskets will still be imported, and split up into their component bundles.
 
@@ -103,7 +103,7 @@ specified is machine 0, allowing colocation on the bootstrap node.
 
 ```yaml
 series: precise
-applications:
+services:
   nova-compute:
     charm: cs:precise/nova-compute
     units: 3

--- a/internal/charmstore/addentity.go
+++ b/internal/charmstore/addentity.go
@@ -665,8 +665,8 @@ func bundleCharms(data *charm.BundleData) ([]*charm.URL, error) {
 	// Use a map to de-duplicate the URL list: a bundle can include services
 	// deployed by the same charm.
 	urlMap := make(map[string]*charm.URL)
-	for _, service := range data.Services {
-		url, err := charm.ParseURL(service.Charm)
+	for _, application := range data.Applications {
+		url, err := charm.ParseURL(application.Charm)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}
@@ -689,8 +689,8 @@ func newInt(x int) *int {
 // bundleUnitCount returns the number of units created by the bundle.
 func bundleUnitCount(b *charm.BundleData) int {
 	count := 0
-	for _, service := range b.Services {
-		count += service.NumUnits
+	for _, application := range b.Applications {
+		count += application.NumUnits
 	}
 	return count
 }
@@ -699,14 +699,14 @@ func bundleUnitCount(b *charm.BundleData) int {
 // that will be created or used by the bundle.
 func bundleMachineCount(b *charm.BundleData) int {
 	count := len(b.Machines)
-	for _, service := range b.Services {
+	for _, applications := range b.Applications {
 		// The default placement is "new".
 		placement := &charm.UnitPlacement{
 			Machine: "new",
 		}
 		// Check for "new" placements, which means a new machine
 		// must be added.
-		for _, location := range service.To {
+		for _, location := range applications.To {
 			var err error
 			placement, err = charm.ParsePlacement(location)
 			if err != nil {
@@ -723,7 +723,7 @@ func bundleMachineCount(b *charm.BundleData) int {
 		// element is replicated. For this reason, if the last element is
 		// "new", we need to add more machines.
 		if placement != nil && placement.Machine == "new" {
-			count += service.NumUnits - len(service.To)
+			count += applications.NumUnits - len(applications.To)
 		}
 	}
 	return count

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -210,7 +210,7 @@ var uploadEntityErrorsTests = []struct {
 	about: "bundle uploaded to charm URL",
 	url:   "~charmers/precise/foo-0",
 	upload: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"foo": {
 				Charm: "foo",
 			},
@@ -259,19 +259,19 @@ var uploadEntityErrorsTests = []struct {
 	about: "bundle refers to non-existent charm",
 	url:   "~charmers/bundle/foo-0",
 	upload: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"foo": {
 				Charm: "bad-charm",
 			},
 		},
 	}),
-	expectError: regexp.QuoteMeta(`bundle verification failed: ["service \"foo\" refers to non-existent charm \"bad-charm\""]`),
+	expectError: regexp.QuoteMeta(`bundle verification failed: ["application \"foo\" refers to non-existent charm \"bad-charm\""]`),
 	expectCause: params.ErrInvalidEntity,
 }, {
 	about:       "bundle verification fails",
 	url:         "~charmers/bundle/foo-0",
 	upload:      storetesting.NewBundle(&charm.BundleData{}),
-	expectError: regexp.QuoteMeta(`bundle verification failed: ["at least one service must be specified"]`),
+	expectError: regexp.QuoteMeta(`bundle verification failed: ["at least one application must be specified"]`),
 	expectCause: params.ErrInvalidEntity,
 }, {
 	about:       "invalid zip format",

--- a/internal/charmstore/common_test.go
+++ b/internal/charmstore/common_test.go
@@ -39,8 +39,8 @@ func (s *commonSuite) newStore(c *gc.C, withElasticSearch bool) *Store {
 }
 
 func addRequiredCharms(c *gc.C, store *Store, bundle charm.Bundle) {
-	for _, svc := range bundle.Data().Services {
-		u := charm.MustParseURL(svc.Charm)
+	for _, app := range bundle.Data().Applications {
+		u := charm.MustParseURL(app.Charm)
 		if _, err := store.FindBestEntity(u, params.NoChannel, nil); err == nil {
 			continue
 		}

--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -272,6 +272,22 @@ const esMappingJSON = `
               }
             }
           },
+          "Applications": {
+            "type": "object",
+            "dynamic": "false",
+            "properties": {
+              "Charm": {
+                "type": "string",
+                "index": "not_analyzed",
+                "omit_norms": true,
+                "index_options": "docs"
+              },
+              "NumUnits": {
+                "type": "integer",
+                "index": "not_analyzed"
+              }
+            }
+          },
           "Series": {
             "type": "string"
           },

--- a/internal/charmstore/migrations_integration_test.go
+++ b/internal/charmstore/migrations_integration_test.go
@@ -60,7 +60,7 @@ var migrationHistory = []versionSpec{{
 			id:            "~charmers/bundle/promulgatedbundle-0",
 			promulgatedId: "bundle/promulgatedbundle-0",
 			entity: storetesting.NewBundle(&charm.BundleData{
-				Services: map[string]*charm.ServiceSpec{
+				Applications: map[string]*charm.ApplicationSpec{
 					"promulgated": {
 						Charm: "promulgated",
 					},
@@ -69,7 +69,7 @@ var migrationHistory = []versionSpec{{
 		}, {
 			id: "~charmers/bundle/nonpromulgatedbundle-0",
 			entity: storetesting.NewBundle(&charm.BundleData{
-				Services: map[string]*charm.ServiceSpec{
+				Applications: map[string]*charm.ApplicationSpec{
 					"promulgated": {
 						Charm: "promulgated",
 					},

--- a/internal/charmstore/resources_test.go
+++ b/internal/charmstore/resources_test.go
@@ -176,7 +176,7 @@ func (s *resourceSuite) TestListResourcesBundle(c *gc.C) {
 
 	id := MustParseResolvedURL("cs:~charmers/bundle/wordpress-simple-0")
 	b := storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "cs:utopic/wordpress-0",
 			},

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -142,8 +142,8 @@ var searchEntities = map[string]searchEntity{
 	"wordpress-simple": searchEntity{
 		entity: newEntity("cs:~charmers/bundle/wordpress-simple-4", 4),
 		bundleData: &charm.BundleData{
-			Services: map[string]*charm.ServiceSpec{
-				"wordpress": &charm.ServiceSpec{
+			Applications: map[string]*charm.ApplicationSpec{
+				"wordpress": &charm.ApplicationSpec{
 					Charm: "wordpress",
 				},
 			},

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -483,7 +483,7 @@ var bundleUnitCountTests = []struct {
 }{{
 	about: "no units",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "cs:utopic/wordpress-0",
 				NumUnits: 0,
@@ -497,7 +497,7 @@ var bundleUnitCountTests = []struct {
 }, {
 	about: "a single unit",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "cs:trusty/wordpress-42",
 				NumUnits: 1,
@@ -512,7 +512,7 @@ var bundleUnitCountTests = []struct {
 }, {
 	about: "multiple units",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "cs:utopic/wordpress-1",
 				NumUnits: 1,
@@ -562,7 +562,7 @@ var bundleMachineCountTests = []struct {
 }{{
 	about: "no machines",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:utopic/mysql-0",
 				NumUnits: 0,
@@ -576,7 +576,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (no placement)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -591,7 +591,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (machine placement)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -606,7 +606,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (hulk smash)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -626,7 +626,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (co-location)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -642,7 +642,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (containerization)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -667,7 +667,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (no placement)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:utopic/mysql-1",
 				NumUnits: 1,
@@ -686,7 +686,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (machine placement)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:utopic/mysql-1",
 				NumUnits: 2,
@@ -706,7 +706,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (hulk smash)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -731,7 +731,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (co-location)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 2,
@@ -747,7 +747,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (containerization)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 2,
@@ -772,7 +772,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (partial placement in a container)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -792,7 +792,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (partial placement in a new machine)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -812,7 +812,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (partial placement with new machines)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 3,
@@ -836,7 +836,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "placement into container on new machine",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "cs:trusty/wordpress-47",
 				NumUnits: 6,
@@ -1467,11 +1467,11 @@ var findBestEntityBundles = []struct {
 }{{
 	id: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 	bundle: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
-			"wordpress": &charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": &charm.ApplicationSpec{
 				Charm: "cs:wordpress",
 			},
-			"mysql": &charm.ServiceSpec{
+			"mysql": &charm.ApplicationSpec{
 				Charm: "cs:mysql",
 			},
 		},
@@ -1481,11 +1481,11 @@ var findBestEntityBundles = []struct {
 }, {
 	id: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 	bundle: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
-			"wordpress": &charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": &charm.ApplicationSpec{
 				Charm: "cs:wordpress",
 			},
-			"mysql": &charm.ServiceSpec{
+			"mysql": &charm.ApplicationSpec{
 				Charm: "cs:mysql",
 			},
 		},
@@ -1495,11 +1495,11 @@ var findBestEntityBundles = []struct {
 }, {
 	id: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 2),
 	bundle: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
-			"wordpress": &charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": &charm.ApplicationSpec{
 				Charm: "cs:wordpress",
 			},
-			"mysql": &charm.ServiceSpec{
+			"mysql": &charm.ApplicationSpec{
 				Charm: "cs:mysql",
 			},
 		},
@@ -1509,11 +1509,11 @@ var findBestEntityBundles = []struct {
 }, {
 	id: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 	bundle: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
-			"wordpress": &charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": &charm.ApplicationSpec{
 				Charm: "cs:wordpress",
 			},
-			"mysql": &charm.ServiceSpec{
+			"mysql": &charm.ApplicationSpec{
 				Charm: "cs:mysql",
 			},
 		},

--- a/internal/storetesting/charm-repo/bundle/bad/bundle.yaml
+++ b/internal/storetesting/charm-repo/bundle/bad/bundle.yaml
@@ -1,6 +1,6 @@
 # This bundle has a bad relation, which will cause it to fail
 # its verification.
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/internal/storetesting/charm-repo/bundle/openstack/bundle.yaml
+++ b/internal/storetesting/charm-repo/bundle/openstack/bundle.yaml
@@ -1,5 +1,5 @@
 series: precise
-services:
+applications:
   mysql:
     charm: cs:precise/mysql
     constraints: mem=1G

--- a/internal/storetesting/charm-repo/bundle/wordpress-simple/bundle.yaml
+++ b/internal/storetesting/charm-repo/bundle/wordpress-simple/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/internal/storetesting/charm-repo/bundle/wordpress-with-logging/bundle.yaml
+++ b/internal/storetesting/charm-repo/bundle/wordpress-with-logging/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -139,7 +139,7 @@ var metaEndpoints = []metaEndpoint{{
 	get:       entityFieldGetter("BundleData"),
 	checkURL:  newResolvedURL("cs:~charmers/bundle/wordpress-simple-42", 42),
 	assertCheckData: func(c *gc.C, data interface{}) {
-		c.Assert(data.(*charm.BundleData).Services["wordpress"].Charm, gc.Equals, "wordpress")
+		c.Assert(data.(*charm.BundleData).Applications["wordpress"].Charm, gc.Equals, "wordpress")
 	},
 }, {
 	name:      "bundle-unit-count",
@@ -1516,7 +1516,7 @@ func (s *APISuite) TestBundleTags(c *gc.C) {
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", -1)
 	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
 		Tags: []string{"foo", "bar"},
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 			},
@@ -1534,7 +1534,7 @@ func (s *APISuite) TestPromulgatedBundleTags(c *gc.C) {
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", 2)
 	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
 		Tags: []string{"foo", "bar"},
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 			},

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -718,9 +718,9 @@ func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
 	expectErr := `bundle verification failed: [` +
-		`"relation [\"foo:db\" \"mysql:server\"] refers to service \"foo\" not defined in this bundle",` +
-		`"service \"mysql\" refers to non-existent charm \"mysql\"",` +
-		`"service \"wordpress\" refers to non-existent charm \"wordpress\""]`
+		`"relation [\"foo:db\" \"mysql:server\"] refers to application \"foo\" not defined in this bundle",` +
+		`"application \"mysql\" refers to non-existent charm \"mysql\"",` +
+		`"application \"wordpress\" refers to non-existent charm \"wordpress\""]`
 	s.assertCannotUpload(c, "~charmers/bundle/wordpress", f, http.StatusBadRequest, params.ErrInvalidEntity, expectErr)
 }
 

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -267,7 +267,7 @@ func storeURL(path string) string {
 // addRequiredCharms adds any charms required by the given
 // bundle that are not already in the store.
 func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
-	for _, svc := range bundle.Data().Services {
+	for _, svc := range bundle.Data().Applications {
 		u := charm.MustParseURL(svc.Charm)
 		if _, err := s.store.FindBestEntity(u, params.StableChannel, nil); err == nil {
 			continue

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -65,7 +65,7 @@ func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
 
 func (s *APISuite) TestServeDiagram(c *gc.C) {
 	bundle := storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 				Annotations: map[string]string{
@@ -132,7 +132,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 	bundle := storetesting.NewBundle(
 		&charm.BundleData{
-			Services: map[string]*charm.ServiceSpec{
+			Applications: map[string]*charm.ApplicationSpec{
 				"wordpress": {
 					Charm: "wordpress",
 				},

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -627,17 +627,17 @@ func sameMetaAnyResponses(expect interface{}) httptesting.BodyAsserter {
 // to be included in the bundle.
 // For each URL, a corresponding service is automatically created.
 func relationTestingBundle(urls []string) charm.Bundle {
-	services := make(map[string]*charm.ServiceSpec, len(urls))
+	applications := make(map[string]*charm.ApplicationSpec, len(urls))
 	for i, url := range urls {
-		service := &charm.ServiceSpec{
+		application := &charm.ApplicationSpec{
 			Charm:    url,
 			NumUnits: 1,
 		}
-		services[fmt.Sprintf("service-%d", i)] = service
+		applications[fmt.Sprintf("application-%d", i)] = application
 	}
 	return storetesting.NewBundle(
 		&charm.BundleData{
-			Services: services,
+			Applications: applications,
 		})
 
 }

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -145,7 +145,7 @@ var metaEndpoints = []metaEndpoint{{
 	get:       entityFieldGetter("BundleData"),
 	checkURL:  newResolvedURL("cs:~charmers/bundle/wordpress-simple-42", 42),
 	assertCheckData: func(c *gc.C, data interface{}) {
-		c.Assert(data.(*charm.BundleData).Services["wordpress"].Charm, gc.Equals, "wordpress")
+		c.Assert(data.(*charm.BundleData).Applications["wordpress"].Charm, gc.Equals, "wordpress")
 	},
 }, {
 	name:      "bundle-unit-count",
@@ -860,7 +860,7 @@ var metaPublishedTests = []struct {
 }, {
 	id: "~bob/bundle/mybundle-2",
 	entity: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "~charmers/precise/wordpress",
 			},
@@ -1914,7 +1914,7 @@ func (s *APISuite) TestBundleTags(c *gc.C) {
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", -1)
 	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
 		Tags: []string{"foo", "bar"},
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 			},
@@ -1932,7 +1932,7 @@ func (s *APISuite) TestPromulgatedBundleTags(c *gc.C) {
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", 2)
 	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
 		Tags: []string{"foo", "bar"},
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 			},

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -819,9 +819,9 @@ func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
 	expectErr := `bundle verification failed: [` +
-		`"relation [\"foo:db\" \"mysql:server\"] refers to service \"foo\" not defined in this bundle",` +
-		`"service \"mysql\" refers to non-existent charm \"mysql\"",` +
-		`"service \"wordpress\" refers to non-existent charm \"wordpress\""]`
+		`"relation [\"foo:db\" \"mysql:server\"] refers to application \"foo\" not defined in this bundle",` +
+		`"application \"mysql\" refers to non-existent charm \"mysql\"",` +
+		`"application \"wordpress\" refers to non-existent charm \"wordpress\""]`
 	s.assertCannotUpload(c, "~charmers/bundle/wordpress", f, http.StatusBadRequest, params.ErrInvalidEntity, expectErr)
 }
 

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -328,7 +328,7 @@ func (s *commonSuite) bakeryDoAsUser(c *gc.C, user string) func(*http.Request) (
 // addRequiredCharms adds any charms required by the given
 // bundle that are not already in the store.
 func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
-	for _, svc := range bundle.Data().Services {
+	for _, svc := range bundle.Data().Applications {
 		u := charm.MustParseURL(svc.Charm)
 		if _, err := s.store.FindBestEntity(u, params.StableChannel, nil); err == nil {
 			continue

--- a/internal/v5/content_test.go
+++ b/internal/v5/content_test.go
@@ -66,7 +66,7 @@ func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
 
 func (s *APISuite) TestServeDiagram(c *gc.C) {
 	bundle := storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 				Annotations: map[string]string{
@@ -102,7 +102,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	// Check that the output contains valid XML with an SVG tag,
 	// but don't check the details of the output so that this test doesn't
 	// break every time the jujusvg presentation changes.
-	// Also check that we get an image for each service containing the charm
+	// Also check that we get an image for each application containing the charm
 	// icon link.
 	assertXMLContains(c, rec.Body.Bytes(), map[string]func(xml.Token) bool{
 		"svg element":    isStartElementWithName("svg"),
@@ -121,7 +121,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	// Check that the output contains valid XML with an SVG tag,
 	// but don't check the details of the output so that this test doesn't
 	// break every time the jujusvg presentation changes.
-	// Also check that we get an image for each service containing the charm
+	// Also check that we get an image for each application containing the charm
 	// icon link.
 	assertXMLContains(c, rec.Body.Bytes(), map[string]func(xml.Token) bool{
 		"svg element":    isStartElementWithName("svg"),
@@ -133,7 +133,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 	bundle := storetesting.NewBundle(
 		&charm.BundleData{
-			Services: map[string]*charm.ServiceSpec{
+			Applications: map[string]*charm.ApplicationSpec{
 				"wordpress": {
 					Charm: "wordpress",
 				},

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -654,19 +654,19 @@ func sameMetaAnyResponses(expect interface{}) httptesting.BodyAsserter {
 // relationTestingBundle returns a bundle for use in relation
 // testing. The urls parameter holds a list of charm references
 // to be included in the bundle.
-// For each URL, a corresponding service is automatically created.
+// For each URL, a corresponding application is automatically created.
 func relationTestingBundle(urls []string) charm.Bundle {
-	services := make(map[string]*charm.ServiceSpec, len(urls))
+	applications := make(map[string]*charm.ApplicationSpec, len(urls))
 	for i, url := range urls {
-		service := &charm.ServiceSpec{
+		application := &charm.ApplicationSpec{
 			Charm:    url,
 			NumUnits: 1,
 		}
-		services[fmt.Sprintf("service-%d", i)] = service
+		applications[fmt.Sprintf("application-%d", i)] = application
 	}
 	return storetesting.NewBundle(
 		&charm.BundleData{
-			Services: services,
+			Applications: applications,
 		})
 
 }


### PR DESCRIPTION
Bundles now specify applications rather than services. This update essentially is to accommodate the changes to dependent repos like juju/charm (which does the bundle parsing). Bundles specifying either services or applications are ingested.

TODO - figure out how to serve the correct bundle format to old and new Juju clients.
