### PR TITLE
fix resolution with multiple multi series charms

### DIFF
--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -570,9 +570,26 @@ func (s *Store) findEntityInChannel(url *charm.URL, ch params.Channel, fields ma
 	}
 	var entityURL *charm.URL
 	if url.Series == "" {
-		for _, u := range baseEntity.ChannelEntities[ch] {
-			if entityURL == nil || seriesScore[u.Series] > seriesScore[entityURL.Series] {
+		var entitySeries string
+		for s, u := range baseEntity.ChannelEntities[ch] {
+			// Determine the preferred URL from the available series.
+			//
+			// Note that because each of the series has a different
+			// score the only situation where the score in the URL is
+			// where there is more than one series supported by a
+			// multi-series charm. In this case the tie is broken by
+			// looking for the preferred series from the ones
+			// supported by the charm. To save fetching every charm
+			// to look at the supported series the key is used,
+			// because when a charm is listed as the published
+			// version for a series it must support that series.
+			if entityURL == nil ||
+				seriesScore[u.Series] > seriesScore[entityURL.Series] ||
+				// Note that if the two series are the same, they must both be
+				// multi-series URLs.
+				seriesScore[u.Series] == seriesScore[entityURL.Series] && seriesScore[s] > seriesScore[entitySeries] {
 				entityURL = u
+				entitySeries = s
 			}
 		}
 	} else {

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -2526,7 +2526,6 @@ var findBestEntityTests = []struct {
 }}
 
 func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
-	c.ExpectFailure("multiple multi-series charms do not resolve predictably")
 	store := s.newStore(c, false)
 	defer store.Close()
 	for _, ch := range findBestEntityCharms {

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -1457,6 +1457,16 @@ var findBestEntityCharms = []struct {
 	charm:       storetesting.NewCharm(nil),
 	development: true,
 	stable:      false,
+}, {
+	id:          router.MustNewResolvedURL("~charmers/elasticsearch-0", -1),
+	charm:       storetesting.NewCharm(storetesting.MetaWithSupportedSeries(nil, "trusty")),
+	development: true,
+	stable:      true,
+}, {
+	id:          router.MustNewResolvedURL("~charmers/elasticsearch-1", -1),
+	charm:       storetesting.NewCharm(storetesting.MetaWithSupportedSeries(nil, "xenial")),
+	development: true,
+	stable:      true,
 }}
 
 var findBestEntityBundles = []struct {
@@ -2509,9 +2519,14 @@ var findBestEntityTests = []struct {
 	url:      "ceph",
 	channel:  params.UnpublishedChannel,
 	expectID: router.MustNewResolvedURL("~openstack-charmers/trusty/ceph-0", 1),
+}, {
+	url:      "~charmers/elasticsearch",
+	channel:  params.StableChannel,
+	expectID: router.MustNewResolvedURL("~charmers/elasticsearch-1", -1),
 }}
 
 func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
+	c.ExpectFailure("multiple multi-series charms do not resolve predictably")
 	store := s.newStore(c, false)
 	defer store.Close()
 	for _, ch := range findBestEntityCharms {
@@ -2546,16 +2561,19 @@ func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
 
 	for i, test := range findBestEntityTests {
 		c.Logf("test %d: %s (%s)", i, test.url, test.channel)
-		entity, err := store.FindBestEntity(charm.MustParseURL(test.url), test.channel, nil)
-		if test.expectError != "" {
-			c.Assert(err, gc.ErrorMatches, test.expectError)
-			if test.expectErrorCause != nil {
-				c.Assert(errgo.Cause(err), gc.Equals, test.expectErrorCause)
+		// Run FindBestEntity a number of times to make sure resolution is predicatable.
+		for j := 0; j < 10; j++ {
+			entity, err := store.FindBestEntity(charm.MustParseURL(test.url), test.channel, nil)
+			if test.expectError != "" {
+				c.Assert(err, gc.ErrorMatches, test.expectError)
+				if test.expectErrorCause != nil {
+					c.Assert(errgo.Cause(err), gc.Equals, test.expectErrorCause)
+				}
+				continue
 			}
-			continue
+			c.Assert(err, gc.IsNil)
+			c.Assert(EntityResolvedURL(entity), jc.DeepEquals, test.expectID)
 		}
-		c.Assert(err, gc.IsNil)
-		c.Assert(EntityResolvedURL(entity), jc.DeepEquals, test.expectID)
 	}
 }
 


### PR DESCRIPTION
This fixes issue #617. When resolving charms that could resolve to more than one multi-series charm always choose the charm which supports the highest scoring series.
