### PR TITLE
reuse delegatable-macaroon root keys; EnsureIndex on root keys

### DIFF
--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -414,6 +414,9 @@ func (s *Store) ensureIndexes() error {
 			return errgo.Notef(err, "cannot ensure index with keys %v on collection %s", idx.i, idx.c.Name)
 		}
 	}
+	if err := s.pool.rootKeys.EnsureIndex(s.DB.Macaroons()); err != nil {
+		return errgo.Notef(err, "cannot ensure root keys index")
+	}
 	return nil
 }
 
@@ -1227,8 +1230,6 @@ func (s StoreDatabase) Macaroons() *mgo.Collection {
 
 // allCollections holds for each collection used by the charm store a
 // function returns that collection.
-// The macaroons collection is omitted because it does
-// not exist until a macaroon is actually created.
 var allCollections = []func(StoreDatabase) *mgo.Collection{
 	StoreDatabase.StatCounters,
 	StoreDatabase.StatTokens,
@@ -1237,6 +1238,7 @@ var allCollections = []func(StoreDatabase) *mgo.Collection{
 	StoreDatabase.Resources,
 	StoreDatabase.Logs,
 	StoreDatabase.Migrations,
+	StoreDatabase.Macaroons,
 }
 
 // Collections returns a slice of all the collections used

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -1129,7 +1129,6 @@ func (s *StoreSuite) TestCollections(c *gc.C) {
 	// Some collections don't have indexes so they are created only when used.
 	createdOnUse := map[string]bool{
 		"migrations": true,
-		"macaroons":  true,
 	}
 	// Check that all collections mentioned by Collections are actually created.
 	for _, coll := range colls {

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -1283,11 +1283,11 @@ func (h *ReqHandler) serveDelegatableMacaroon(_ http.Header, req *http.Request) 
 		if auth.Username == "" {
 			return nil, errgo.WithCausef(nil, params.ErrForbidden, "delegatable macaroon is not obtainable using admin credentials")
 		}
-		shortTermBakery := h.Store.BakeryWithPolicy(mgostorage.Policy{
-			ExpiryDuration: DelegatableMacaroonExpiry,
-		})
 		// TODO propagate expiry time from macaroons in request.
-		m, err := shortTermBakery.NewMacaroon("", nil, []checkers.Caveat{
+
+		// Note that we don't use a root key store with a short term
+		// expiry, as we don't want to create a new root key every minute.
+		m, err := h.Store.Bakery.NewMacaroon("", nil, []checkers.Caveat{
 			checkers.DeclaredCaveat(UsernameAttr, auth.Username),
 			checkers.TimeBeforeCaveat(time.Now().Add(DelegatableMacaroonExpiry)),
 			checkers.AllowCaveat(authnCheckableOps...),


### PR DESCRIPTION
This means we won't generate a root key every minute for short-term delegatable macaroons.
It also means that we'll delete root keys automatically when they expire.
