### PR TITLE
v4 bundle compatibility

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -13,7 +13,7 @@ github.com/juju/names	git	8a0aa0963bbacdc790914892e9ff942e94d6f795	2016-03-30T15
 github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
 github.com/juju/testing	git	b9cfe07211e464f16d78ca9304c503d636b8eefa	2016-05-19T00:49:35Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	53080499b3c86a913a57a3a8e2b31cfbb6fe5b1d	2016-04-26T09:38:41Z
+github.com/juju/utils	git	ffea6ead0c374583e876c8357c9db6e98bc71476	2016-05-26T02:52:51Z
 github.com/juju/version	git	ef897ad7f130870348ce306f61332f5335355063	2015-11-27T20:34:00Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
@@ -24,14 +24,13 @@ golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:0
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/juju/charm.v6-unstable	git	728a5ea3ff1c1ae8b4c3ac4779c0027f693d1ca5	2016-04-08T11:12:17Z
+gopkg.in/juju/charm.v6-unstable	git	503191ddf2590b15db9669c424660ed612d0a30a	2016-05-27T01:46:20Z
 gopkg.in/juju/charmrepo.v2-unstable	git	b1af69d31ef0112656f79a74a1f29381af1cc109	2016-04-19T12:03:30Z
-gopkg.in/juju/jujusvg.v1	git	a60359df348ef2ca40ec3bcd58a01de54f05658e	2016-02-11T10:02:50Z
+gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
+gopkg.in/juju/names.v2	git	e38bc90539f22af61a9c656d35068bd5f0a5b30a	2016-05-25T23:07:23Z
 gopkg.in/macaroon-bakery.v1	git	e7074941455a293ffb7905cd89ca20ee547a03ec	2016-05-27T11:55:54Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
-gopkg.in/tomb.v2	git	14b3d72120e8d10ea6e6b7f87f7175734b1faab8	2014-06-26T14:46:23Z
-gopkg.in/yaml.v1	git	9f9df34309c04878acc86042b16630b0f696e1de	2014-09-24T16:16:07Z
 gopkg.in/yaml.v2	git	a83829b6f1293c91addabc89d0571c246397bbf4	2016-03-01T20:40:22Z
 launchpad.net/tomb	bzr	gustavo@niemeyer.net-20140529072043-hzcrlnl3ygvg914q	18

--- a/docs/API.md
+++ b/docs/API.md
@@ -826,7 +826,7 @@ file for a bundle. The id must refer to a bundle, not a charm.
 
 ```go
 type BundleData struct {
-        Services map[string] ServiceSpec
+        Applications map[string] ApplicationSpec
         Machines map[string] MachineSpec `json:",omitempty"`
         Series string                    `json:",omitempty"`
         Relations [][]string             `json:",omitempty"`
@@ -837,13 +837,13 @@ type MachineSpec struct {
         Annotations map[string]string    `json:",omitempty"`
 }
 
-type ServiceSpec struct {
+type ApplicationSpec struct {
         Charm string
         NumUnits int
         To []string                      `json:",omitempty"`
 
         // Options holds the configuration values
-        // to apply to the new service. They should
+        // to apply to the new application. They should
         // be compatible with the charm configuration.
         Options map[string]interface{}   `json:",omitempty"`
         Annotations map[string]string    `json:",omitempty"`
@@ -855,7 +855,7 @@ Example: `GET mediawiki/meta/bundle-metadata`
 
 ```json
 {
-    "Services": {
+    "Applications": {
         "mediawiki": {
             "Charm": "cs:precise/mediawiki-10",
             "NumUnits": 1,

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -8,14 +8,14 @@ version 3 bundles, charmstore (API v4) supports version 3 and version 4.
 ## Version 3 bundles
 
 Version 3 bundles are currently existing bundles that specify a deployment as a
-list of services and, optionally, relations.  The charmstore will not support
+list of applications and, optionally, relations.  The charmstore will not support
 the idea of a "basket" or multiple bundles within one file.  However, existing
 baskets will still be imported, and split up into their component bundles.
 
 ## Version 4 bundles
 
 Version 4 bundles are identical to version 3 bundles except for a few key
-differences: the `branch` attribute of the service spec is no longer supported,
+differences: the `branch` attribute of the application spec is no longer supported,
 they may contain a machine specification, and their deployment directives are
 different from version 3 bundles.
 
@@ -53,7 +53,7 @@ Machines are specified under the `machines` top-level attribute.
 
 ### Deployment directives
 
-Version 4 deployment directives (the `to` attribute on the service spec) is a
+Version 4 deployment directives (the `to` attribute on the application spec) is a
 YAML list of items following the format:
 
     (<containertype>:)?(<unit>|<machine>|new)
@@ -64,13 +64,13 @@ co-locating it with any other units that happen to be there, which may result in
 unintended behavior.
 
 The second part (after the colon) specifies where the new unit should be placed;
-it may refer to a unit of another service specified in the bundle, a machine
+it may refer to a unit of another application specified in the bundle, a machine
 id specified in the machines section, or the special name "new" which specifies
 a newly created machine.
 
-A unit placement may be specified with a service name only, in which case its
+A unit placement may be specified with a application name only, in which case its
 unit number is assumed to be one more than the unit number of the previous unit
-in the list with the same service, or zero if there were none.
+in the list with the same application, or zero if there were none.
 
 If there are less elements in To than NumUnits, the last element is replicated
 to fill it. If there are no elements (or To is omitted), "new" is replicated.
@@ -80,7 +80,7 @@ For example:
     wordpress/0 wordpress/1 lxc:0 kvm:new
 
 specifies that the first two units get hulk-smashed onto the first two units of
-the wordpress service, the third unit gets allocated onto an lxc container on
+the wordpress application, the third unit gets allocated onto an lxc container on
 machine 0, and subsequent units get allocated on kvm containers on new machines.
 
 The above example is the same as this:
@@ -89,10 +89,10 @@ The above example is the same as this:
 
 Version 3 placement directives take the format:
 
-    ((<containertype>:)?<service>(=<unitnumber>)?|0)
+    ((<containertype>:)?<application>(=<unitnumber>)?|0)
 
 meaning that a machine cannot be specified beyond colocating (either through a
-container or hulk-smash) along with a specified unit of another service.
+container or hulk-smash) along with a specified unit of another application.
 Version 3 placement directives may be either a string of a single directive or a
 YAML list of directives in the above format.  The only machine that may be
 specified is machine 0, allowing colocation on the bootstrap node.
@@ -103,7 +103,7 @@ specified is machine 0, allowing colocation on the bootstrap node.
 
 ```yaml
 series: precise
-services:
+applications:
   nova-compute:
     charm: cs:precise/nova-compute
     units: 3
@@ -128,7 +128,7 @@ services:
 
 ```yaml
 series: precise
-services:
+applications:
   # Automatically place
   nova-compute:
     charm: cs:precise/nova-compute

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -8,7 +8,7 @@ version 3 bundles, charmstore (API v4) supports version 3 and version 4.
 ## Version 3 bundles
 
 Version 3 bundles are currently existing bundles that specify a deployment as a
-list of applications and, optionally, relations.  The charmstore will not support
+list of services and, optionally, relations.  The charmstore will not support
 the idea of a "basket" or multiple bundles within one file.  However, existing
 baskets will still be imported, and split up into their component bundles.
 
@@ -103,7 +103,7 @@ specified is machine 0, allowing colocation on the bootstrap node.
 
 ```yaml
 series: precise
-applications:
+services:
   nova-compute:
     charm: cs:precise/nova-compute
     units: 3

--- a/internal/charmstore/addentity.go
+++ b/internal/charmstore/addentity.go
@@ -665,8 +665,8 @@ func bundleCharms(data *charm.BundleData) ([]*charm.URL, error) {
 	// Use a map to de-duplicate the URL list: a bundle can include services
 	// deployed by the same charm.
 	urlMap := make(map[string]*charm.URL)
-	for _, service := range data.Services {
-		url, err := charm.ParseURL(service.Charm)
+	for _, application := range data.Applications {
+		url, err := charm.ParseURL(application.Charm)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}
@@ -689,8 +689,8 @@ func newInt(x int) *int {
 // bundleUnitCount returns the number of units created by the bundle.
 func bundleUnitCount(b *charm.BundleData) int {
 	count := 0
-	for _, service := range b.Services {
-		count += service.NumUnits
+	for _, application := range b.Applications {
+		count += application.NumUnits
 	}
 	return count
 }
@@ -699,14 +699,14 @@ func bundleUnitCount(b *charm.BundleData) int {
 // that will be created or used by the bundle.
 func bundleMachineCount(b *charm.BundleData) int {
 	count := len(b.Machines)
-	for _, service := range b.Services {
+	for _, applications := range b.Applications {
 		// The default placement is "new".
 		placement := &charm.UnitPlacement{
 			Machine: "new",
 		}
 		// Check for "new" placements, which means a new machine
 		// must be added.
-		for _, location := range service.To {
+		for _, location := range applications.To {
 			var err error
 			placement, err = charm.ParsePlacement(location)
 			if err != nil {
@@ -723,7 +723,7 @@ func bundleMachineCount(b *charm.BundleData) int {
 		// element is replicated. For this reason, if the last element is
 		// "new", we need to add more machines.
 		if placement != nil && placement.Machine == "new" {
-			count += service.NumUnits - len(service.To)
+			count += applications.NumUnits - len(applications.To)
 		}
 	}
 	return count

--- a/internal/charmstore/addentity.go
+++ b/internal/charmstore/addentity.go
@@ -185,14 +185,30 @@ func (s *Store) addEntityFromReader(id *router.ResolvedURL, r io.ReadSeeker, blo
 		chans:            chans,
 	}
 	if id.URL.Series == "bundle" {
+		var addedCompat bool
 		b, err := s.newBundle(id, r, blobSize)
 		if err != nil {
 			return errgo.Mask(err, errgo.Is(params.ErrInvalidEntity), errgo.Is(params.ErrDuplicateUpload), errgo.Is(params.ErrEntityIdNotAllowed))
 		}
-		if err := s.addBundle(b, p); err != nil {
-			return errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload), errgo.Is(params.ErrEntityIdNotAllowed))
+		info, err := addPreV5BundleCompatibilityHackBlob(s.BlobStore, r, p.blobName, p.blobSize)
+		if err != nil && errgo.Cause(err) != errNoCompat {
+			return errgo.Notef(err, "cannot add pre-v5 compatibility blob")
 		}
-		return nil
+		if err == nil {
+			addedCompat = true
+			p.preV5BlobHash = info.hash
+			p.preV5BlobHash256 = info.hash256
+			p.preV5BlobSize = info.size
+		}
+		err = s.addBundle(b, p)
+		if err != nil && addedCompat {
+			// We added a compatibility blob so we need to remove it.
+			compatBlobName := preV5CompatibilityBlobName(p.blobName)
+			if err1 := s.BlobStore.Remove(compatBlobName); err1 != nil {
+				logger.Errorf("cannot remove blob %s after error: %v", compatBlobName, err1)
+			}
+		}
+		return errgo.Mask(err, errgo.Is(params.ErrDuplicateUpload), errgo.Is(params.ErrEntityIdNotAllowed))
 	}
 	ch, err := s.newCharm(id, r, blobSize)
 	if err != nil {
@@ -203,7 +219,7 @@ func (s *Store) addEntityFromReader(id *router.ResolvedURL, r io.ReadSeeker, blo
 			return errgo.Notef(err, "cannot seek to start of archive")
 		}
 		logger.Infof("adding pre-v5 compat blob for %#v", id)
-		info, err := addPreV5CompatibilityHackBlob(s.BlobStore, r, p.blobName, p.blobSize)
+		info, err := addPreV5CharmCompatibilityHackBlob(s.BlobStore, r, p.blobName, p.blobSize)
 		if err != nil {
 			return errgo.Notef(err, "cannot add pre-v5 compatibility blob")
 		}
@@ -225,89 +241,31 @@ func (s *Store) addEntityFromReader(id *router.ResolvedURL, r io.ReadSeeker, blo
 	return nil
 }
 
-type preV5CompatibilityHackBlobInfo struct {
+type compatibilityHackBlobInfo struct {
 	hash    string
 	hash256 string
 	size    int64
 }
 
-// addPreV5CompatibilityHackBlob adds a second blob to the blob store that
+// addPreV5CharmCompatibilityHackBlob adds a second blob to the blob store that
 // contains a suffix to the zipped charm archive file that updates the zip
 // index to point to an updated version of metadata.yaml that does
 // not have a series field. The original blob is held in r.
-// It updates the fields in p accordingly.
 //
 // We do this because earlier versions of the charm package have a version
 // of the series field that holds a single string rather than a slice of string
 // so will fail when reading the new slice-of-string form, and we
 // don't want to change the field name from "series".
-func addPreV5CompatibilityHackBlob(blobStore *blobstore.Store, r io.ReadSeeker, blobName string, blobSize int64) (*preV5CompatibilityHackBlobInfo, error) {
-	readerAt := ReaderAtSeeker(r)
-	z, err := jujuzip.NewReader(readerAt, blobSize)
+func addPreV5CharmCompatibilityHackBlob(blobStore *blobstore.Store, r io.ReadSeeker, blobName string, blobSize int64) (*compatibilityHackBlobInfo, error) {
+	data, err := updateZipFile(r, blobSize, "metadata.yaml", removeSeriesField)
 	if err != nil {
-		return nil, errgo.Notef(err, "cannot open charm archive")
+		return nil, errgo.Mask(err)
 	}
-	var metadataf *jujuzip.File
-	for _, f := range z.File {
-		if f.Name == "metadata.yaml" {
-			metadataf = f
-			break
-		}
-	}
-	if metadataf == nil {
-		return nil, errgo.New("no metadata.yaml file found")
-	}
-	fr, err := metadataf.Open()
+	info, err := addCompatibilityHackBlob(blobStore, r, preV5CompatibilityBlobName(blobName), blobSize, data)
 	if err != nil {
-		return nil, errgo.Notef(err, "cannot open metadata.yaml from archive")
+		return nil, errgo.Mask(err)
 	}
-	defer fr.Close()
-	data, err := removeSeriesField(fr)
-	if err != nil {
-		return nil, errgo.Notef(err, "cannot remove series field from metadata")
-	}
-	var appendedBlob bytes.Buffer
-	zw := z.Append(&appendedBlob)
-	updatedf := metadataf.FileHeader // Work around invalid duplicate FileHeader issue.
-	zwf, err := zw.CreateHeader(&updatedf)
-	if err != nil {
-		return nil, errgo.Notef(err, "cannot create appended metadata entry")
-	}
-	if _, err := zwf.Write(data); err != nil {
-		return nil, errgo.Notef(err, "cannot write appended metadata data")
-	}
-	if err := zw.Close(); err != nil {
-		return nil, errgo.Notef(err, "cannot close zip file")
-	}
-	data = appendedBlob.Bytes()
-	sha384sum := sha512.Sum384(data)
-
-	err = blobStore.PutUnchallenged(&appendedBlob, preV5CompatibilityBlobName(blobName), int64(len(data)), fmt.Sprintf("%x", sha384sum[:]))
-	if err != nil {
-		return nil, errgo.Notef(err, "cannot put archive blob")
-	}
-
-	sha384w := sha512.New384()
-	sha256w := sha256.New()
-	hashw := io.MultiWriter(sha384w, sha256w)
-	if _, err := r.Seek(0, 0); err != nil {
-		return nil, errgo.Notef(err, "cannnot seek to start of blob")
-	}
-	if _, err := io.Copy(hashw, r); err != nil {
-		return nil, errgo.Notef(err, "cannot recalculate blob checksum")
-	}
-	hashw.Write(data)
-	return &preV5CompatibilityHackBlobInfo{
-		size:    blobSize + int64(len(data)),
-		hash256: fmt.Sprintf("%x", sha256w.Sum(nil)),
-		hash:    fmt.Sprintf("%x", sha384w.Sum(nil)),
-	}, nil
-}
-
-// preV5CompatibilityBlobName returns the name of the zip file suffix used
-// to overwrite the metadata.yaml file for pre-v5 compatibility purposes.
-func preV5CompatibilityBlobName(blobName string) string {
-	return blobName + ".pre-v5-suffix"
+	return info, nil
 }
 
 func removeSeriesField(r io.Reader) ([]byte, error) {
@@ -325,6 +283,135 @@ func removeSeriesField(r io.Reader) ([]byte, error) {
 		return nil, errgo.Notef(err, "cannot re-marshal metadata.yaml")
 	}
 	return data, nil
+}
+
+var errNoCompat = errgo.New("no compatibility blob required")
+
+// addPreV5BundleCompatibilityHackBlob adds a second blob to the blob
+// store that contains a suffix to the zipped charm archive file that
+// updates the zip index to point to an updated version of bundle.yaml
+// that has a services field instead of a applications field.
+//
+// We do this because the bundle format has changed to use an
+// applications field rather than a services field. This updates those
+// bundles to be compatible with the older version of juju that cannot
+// parse an applications field.
+func addPreV5BundleCompatibilityHackBlob(blobStore *blobstore.Store, r io.ReadSeeker, blobName string, blobSize int64) (*compatibilityHackBlobInfo, error) {
+	r.Seek(0, 0)
+	data, err := updateZipFile(r, blobSize, "bundle.yaml", applicationsToServices)
+	if err != nil {
+		return nil, errgo.Mask(err, errgo.Is(errNoCompat))
+	}
+	info, err := addCompatibilityHackBlob(blobStore, r, preV5CompatibilityBlobName(blobName), blobSize, data)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return info, nil
+}
+
+func applicationsToServices(r io.Reader) ([]byte, error) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	var meta map[string]interface{}
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		return nil, errgo.Notef(err, "cannot unmarshal bundle.yaml")
+	}
+	if _, ok := meta["services"]; ok {
+		return nil, errNoCompat
+	}
+	meta["services"] = meta["applications"]
+	delete(meta, "applications")
+	data, err = yaml.Marshal(meta)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot re-marshal bundle.yaml")
+	}
+	return data, nil
+}
+
+// addCompatibilityHackBlob adds a new blob to blobStore containing
+// appendData. It then calculates the size, sha256 & sha384 of the
+// combined contents of r and appendData and returns these values.
+func addCompatibilityHackBlob(blobStore *blobstore.Store, r io.ReadSeeker, blobName string, blobSize int64, appendData []byte) (*compatibilityHackBlobInfo, error) {
+	sha384sum := sha512.Sum384(appendData)
+
+	if err := blobStore.PutUnchallenged(
+		bytes.NewReader(appendData),
+		blobName,
+		int64(len(appendData)),
+		fmt.Sprintf("%x", sha384sum[:]),
+	); err != nil {
+		return nil, errgo.Notef(err, "cannot put archive blob")
+	}
+
+	sha384w := sha512.New384()
+	sha256w := sha256.New()
+	hashw := io.MultiWriter(sha384w, sha256w)
+	if _, err := r.Seek(0, 0); err != nil {
+		return nil, errgo.Notef(err, "cannnot seek to start of blob")
+	}
+	if _, err := io.Copy(hashw, r); err != nil {
+		return nil, errgo.Notef(err, "cannot recalculate blob checksum")
+	}
+	hashw.Write(appendData)
+	return &compatibilityHackBlobInfo{
+		size:    blobSize + int64(len(appendData)),
+		hash256: fmt.Sprintf("%x", sha256w.Sum(nil)),
+		hash:    fmt.Sprintf("%x", sha384w.Sum(nil)),
+	}, nil
+}
+
+// UpdateZipFile finds filename in r and passes it to updatef for
+// modification. It then returns the bytes that could be appended to r
+// that cause the zip file to reference the modified version of the file.
+//
+// Any errors returned from updatef will not have the cause masked.
+func updateZipFile(r io.ReadSeeker, size int64, filename string, updatef func(io.Reader) ([]byte, error)) ([]byte, error) {
+	readerAt := ReaderAtSeeker(r)
+	z, err := jujuzip.NewReader(readerAt, size)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot open archive")
+	}
+	var uf *jujuzip.File
+	for _, f := range z.File {
+		if f.Name == filename {
+			uf = f
+			break
+		}
+	}
+	if uf == nil {
+		return nil, errgo.Newf("no %q file found", filename)
+	}
+	fr, err := uf.Open()
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot open %q from archive", filename)
+	}
+	defer fr.Close()
+	data, err := updatef(fr)
+	if err != nil {
+		return nil, errgo.NoteMask(err, fmt.Sprintf("cannot update %q", filename), errgo.Any)
+	}
+	var appendedBlob bytes.Buffer
+	zw := z.Append(&appendedBlob)
+	header := uf.FileHeader // Work around invalid duplicate FileHeader issue.
+	zwf, err := zw.CreateHeader(&header)
+	if err != nil {
+		return nil, errgo.Notef(err, "cannot create appended %q entry", filename)
+	}
+	if _, err := zwf.Write(data); err != nil {
+		return nil, errgo.Notef(err, "cannot write appended %q data", filename)
+	}
+	if err := zw.Close(); err != nil {
+		return nil, errgo.Notef(err, "cannot close zip file")
+	}
+	return appendedBlob.Bytes(), nil
+}
+
+// preV5CompatibilityBlobName returns the name of the zip file suffix used
+// to overwrite the metadata.yaml file for pre-v5 compatibility purposes.
+func preV5CompatibilityBlobName(blobName string) string {
+	return blobName + ".pre-v5-suffix"
 }
 
 // newCharm returns a new charm implementation from the archive blob

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -210,7 +210,7 @@ var uploadEntityErrorsTests = []struct {
 	about: "bundle uploaded to charm URL",
 	url:   "~charmers/precise/foo-0",
 	upload: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"foo": {
 				Charm: "foo",
 			},
@@ -259,19 +259,19 @@ var uploadEntityErrorsTests = []struct {
 	about: "bundle refers to non-existent charm",
 	url:   "~charmers/bundle/foo-0",
 	upload: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"foo": {
 				Charm: "bad-charm",
 			},
 		},
 	}),
-	expectError: regexp.QuoteMeta(`bundle verification failed: ["service \"foo\" refers to non-existent charm \"bad-charm\""]`),
+	expectError: regexp.QuoteMeta(`bundle verification failed: ["application \"foo\" refers to non-existent charm \"bad-charm\""]`),
 	expectCause: params.ErrInvalidEntity,
 }, {
 	about:       "bundle verification fails",
 	url:         "~charmers/bundle/foo-0",
 	upload:      storetesting.NewBundle(&charm.BundleData{}),
-	expectError: regexp.QuoteMeta(`bundle verification failed: ["at least one service must be specified"]`),
+	expectError: regexp.QuoteMeta(`bundle verification failed: ["at least one application must be specified"]`),
 	expectCause: params.ErrInvalidEntity,
 }, {
 	about:       "invalid zip format",

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"time"
@@ -322,6 +323,33 @@ func (s *AddEntitySuite) TestUploadEntityErrors(c *gc.C) {
 	}
 }
 
+func (s *AddEntitySuite) TestUploadBundleWithServices(c *gc.C) {
+	store := s.newStore(c, true)
+	defer store.Close()
+	blob, _ := storetesting.NewBlob([]storetesting.File{{
+		Name: "README.md",
+		Data: []byte("Readme\n"),
+	}, {
+		Name: "bundle.yaml",
+		Data: []byte(`
+services:
+  mysql:
+    charm: mysql
+    num_units: 1
+  wordpress:
+    charm: wordpress
+    num_units: 1
+`),
+	}})
+	file := filepath.Join(c.MkDir(), "bundle.zip")
+	ioutil.WriteFile(file, blob, 0666)
+	ba, err := charm.ReadBundle(file)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ba.Data().Applications, gc.HasLen, 2)
+
+	s.checkAddBundle(c, ba, router.MustNewResolvedURL("cs:~who/bundle/wordpress-bundle-33", 33))
+}
+
 func (s *AddEntitySuite) checkAddCharm(c *gc.C, ch charm.Charm, url *router.ResolvedURL) {
 	store := s.newStore(c, true)
 	defer store.Close()
@@ -462,12 +490,23 @@ func assertBlobFields(c *gc.C, doc *mongodoc.Entity, url *router.ResolvedURL, ha
 	if doc.CharmMeta != nil && len(doc.CharmMeta.Series) > 0 {
 		// It's a multi-series charm, so the PreV5* fields should be active.
 		if doc.PreV5BlobSize <= doc.Size {
-			c.Fatalf("pre-v5 blobsize %d is unexpectedly less than original blob size %d", doc.PreV5BlobSize, doc.Size)
+			c.Fatalf("pre-v5 blobsize %d is unexpectedly less than or equal to original blob size %d", doc.PreV5BlobSize, doc.Size)
 		}
 		c.Assert(doc.PreV5BlobHash, gc.Not(gc.Equals), "")
 		c.Assert(doc.PreV5BlobHash, gc.Not(gc.Equals), hash)
 		c.Assert(doc.PreV5BlobHash256, gc.Not(gc.Equals), "")
 		c.Assert(doc.PreV5BlobHash256, gc.Not(gc.Equals), hash256)
+	} else if url.URL.Series == "bundle" && doc.PreV5BlobHash != doc.BlobHash {
+		// It's a bundle with a different PreV5BlobHash, check
+		// that all other fields are consistently different.
+		// TODO(mhilton) use BundleData.UnmarshaledWithServices
+		// to determine whether to make this check.
+		c.Assert(doc.PreV5BlobHash, gc.Not(gc.Equals), "")
+		c.Assert(doc.PreV5BlobHash256, gc.Not(gc.Equals), "")
+		c.Assert(doc.PreV5BlobHash256, gc.Not(gc.Equals), hash256)
+		if doc.PreV5BlobSize <= doc.Size {
+			c.Fatalf("pre-v5 blobsize %d is unexpectedly less than or equal to original blob size %d", doc.PreV5BlobSize, doc.Size)
+		}
 	} else {
 		c.Assert(doc.PreV5BlobSize, gc.Equals, doc.Size)
 		c.Assert(doc.PreV5BlobHash, gc.Equals, doc.BlobHash)

--- a/internal/charmstore/common_test.go
+++ b/internal/charmstore/common_test.go
@@ -39,8 +39,8 @@ func (s *commonSuite) newStore(c *gc.C, withElasticSearch bool) *Store {
 }
 
 func addRequiredCharms(c *gc.C, store *Store, bundle charm.Bundle) {
-	for _, svc := range bundle.Data().Services {
-		u := charm.MustParseURL(svc.Charm)
+	for _, app := range bundle.Data().Applications {
+		u := charm.MustParseURL(app.Charm)
 		if _, err := store.FindBestEntity(u, params.NoChannel, nil); err == nil {
 			continue
 		}

--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -272,6 +272,22 @@ const esMappingJSON = `
               }
             }
           },
+          "Applications": {
+            "type": "object",
+            "dynamic": "false",
+            "properties": {
+              "Charm": {
+                "type": "string",
+                "index": "not_analyzed",
+                "omit_norms": true,
+                "index_options": "docs"
+              },
+              "NumUnits": {
+                "type": "integer",
+                "index": "not_analyzed"
+              }
+            }
+          },
           "Series": {
             "type": "string"
           },

--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -151,10 +151,10 @@ func addPreV5CompatBlob(db StoreDatabase) error {
 	}).Iter()
 	var entity mongodoc.Entity
 	for iter.Next(&entity) {
-		var info *preV5CompatibilityHackBlobInfo
+		var info *compatibilityHackBlobInfo
 
 		if entity.CharmMeta == nil || len(entity.CharmMeta.Series) == 0 {
-			info = &preV5CompatibilityHackBlobInfo{
+			info = &compatibilityHackBlobInfo{
 				hash:    entity.BlobHash,
 				hash256: entity.BlobHash256,
 				size:    entity.Size,
@@ -164,7 +164,7 @@ func addPreV5CompatBlob(db StoreDatabase) error {
 			if err != nil {
 				return errgo.Notef(err, "cannot open original blob")
 			}
-			info, err = addPreV5CompatibilityHackBlob(blobStore, r, entity.BlobName, entity.Size)
+			info, err = addPreV5CharmCompatibilityHackBlob(blobStore, r, entity.BlobName, entity.Size)
 			r.Close()
 			if err != nil {
 				return errgo.Mask(err)
@@ -409,11 +409,11 @@ func migrateToArchiveDownloadStatsOnly(db StoreDatabase) error {
 			return errgo.Notef(err, "cannot set the download count on entity: %v", entity.URL)
 		}
 		if entity.PromulgatedURL != nil {
-			mykey := promulgatedKey {
+			mykey := promulgatedKey{
 				series: entity.Series,
-				name: entity.Name,
+				name:   entity.Name,
 			}
-			if e,ok := promulgatedBySeriesAndName[mykey]; !ok || entity.PromulgatedRevision > e.PromulgatedRevision {
+			if e, ok := promulgatedBySeriesAndName[mykey]; !ok || entity.PromulgatedRevision > e.PromulgatedRevision {
 				promulgatedBySeriesAndName[mykey] = entity
 			}
 		}
@@ -422,7 +422,7 @@ func migrateToArchiveDownloadStatsOnly(db StoreDatabase) error {
 		return errgo.Notef(err, "cannot iterate through entities")
 	}
 
-	for _, promulgated := range  promulgatedBySeriesAndName {
+	for _, promulgated := range promulgatedBySeriesAndName {
 		legacyDownloadStats, ok := promulgated.ExtraInfo[params.LegacyDownloadStats]
 		if !ok {
 			return errgo.Newf("cannot retrieve the legacy download stats on promulgated: %v", promulgated.URL)

--- a/internal/charmstore/migrations_integration_test.go
+++ b/internal/charmstore/migrations_integration_test.go
@@ -60,7 +60,7 @@ var migrationHistory = []versionSpec{{
 			id:            "~charmers/bundle/promulgatedbundle-0",
 			promulgatedId: "bundle/promulgatedbundle-0",
 			entity: storetesting.NewBundle(&charm.BundleData{
-				Services: map[string]*charm.ServiceSpec{
+				Applications: map[string]*charm.ApplicationSpec{
 					"promulgated": {
 						Charm: "promulgated",
 					},
@@ -69,7 +69,7 @@ var migrationHistory = []versionSpec{{
 		}, {
 			id: "~charmers/bundle/nonpromulgatedbundle-0",
 			entity: storetesting.NewBundle(&charm.BundleData{
-				Services: map[string]*charm.ServiceSpec{
+				Applications: map[string]*charm.ApplicationSpec{
 					"promulgated": {
 						Charm: "promulgated",
 					},

--- a/internal/charmstore/resources_test.go
+++ b/internal/charmstore/resources_test.go
@@ -176,7 +176,7 @@ func (s *resourceSuite) TestListResourcesBundle(c *gc.C) {
 
 	id := MustParseResolvedURL("cs:~charmers/bundle/wordpress-simple-0")
 	b := storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "cs:utopic/wordpress-0",
 			},

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -131,8 +131,8 @@ var searchEntities = map[string]searchEntity{
 	"wordpress-simple": {
 		entity: newEntity("cs:~charmers/bundle/wordpress-simple-4", 4),
 		bundleData: &charm.BundleData{
-			Services: map[string]*charm.ServiceSpec{
-				"wordpress": {
+			Applications: map[string]*charm.ApplicationSpec{
+				"wordpress": &charm.ApplicationSpec{
 					Charm: "wordpress",
 				},
 			},

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -483,7 +483,7 @@ var bundleUnitCountTests = []struct {
 }{{
 	about: "no units",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "cs:utopic/wordpress-0",
 				NumUnits: 0,
@@ -497,7 +497,7 @@ var bundleUnitCountTests = []struct {
 }, {
 	about: "a single unit",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "cs:trusty/wordpress-42",
 				NumUnits: 1,
@@ -512,7 +512,7 @@ var bundleUnitCountTests = []struct {
 }, {
 	about: "multiple units",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "cs:utopic/wordpress-1",
 				NumUnits: 1,
@@ -562,7 +562,7 @@ var bundleMachineCountTests = []struct {
 }{{
 	about: "no machines",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:utopic/mysql-0",
 				NumUnits: 0,
@@ -576,7 +576,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (no placement)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -591,7 +591,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (machine placement)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -606,7 +606,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (hulk smash)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -626,7 +626,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (co-location)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -642,7 +642,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "a single machine (containerization)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -667,7 +667,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (no placement)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:utopic/mysql-1",
 				NumUnits: 1,
@@ -686,7 +686,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (machine placement)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:utopic/mysql-1",
 				NumUnits: 2,
@@ -706,7 +706,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (hulk smash)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -731,7 +731,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (co-location)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 2,
@@ -747,7 +747,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (containerization)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 2,
@@ -772,7 +772,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (partial placement in a container)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -792,7 +792,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (partial placement in a new machine)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 1,
@@ -812,7 +812,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "multiple machines (partial placement with new machines)",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"mysql": {
 				Charm:    "cs:trusty/mysql-42",
 				NumUnits: 3,
@@ -836,7 +836,7 @@ var bundleMachineCountTests = []struct {
 }, {
 	about: "placement into container on new machine",
 	data: &charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "cs:trusty/wordpress-47",
 				NumUnits: 6,
@@ -1476,11 +1476,11 @@ var findBestEntityBundles = []struct {
 }{{
 	id: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-0", 0),
 	bundle: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
-			"wordpress": {
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": &charm.ApplicationSpec{
 				Charm: "cs:wordpress",
 			},
-			"mysql": {
+			"mysql": &charm.ApplicationSpec{
 				Charm: "cs:mysql",
 			},
 		},
@@ -1490,11 +1490,11 @@ var findBestEntityBundles = []struct {
 }, {
 	id: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", 1),
 	bundle: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
-			"wordpress": {
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": &charm.ApplicationSpec{
 				Charm: "cs:wordpress",
 			},
-			"mysql": {
+			"mysql": &charm.ApplicationSpec{
 				Charm: "cs:mysql",
 			},
 		},
@@ -1504,11 +1504,11 @@ var findBestEntityBundles = []struct {
 }, {
 	id: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 2),
 	bundle: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
-			"wordpress": {
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": &charm.ApplicationSpec{
 				Charm: "cs:wordpress",
 			},
-			"mysql": {
+			"mysql": &charm.ApplicationSpec{
 				Charm: "cs:mysql",
 			},
 		},
@@ -1518,11 +1518,11 @@ var findBestEntityBundles = []struct {
 }, {
 	id: router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-3", 3),
 	bundle: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
-			"wordpress": {
+		Applications: map[string]*charm.ApplicationSpec{
+			"wordpress": &charm.ApplicationSpec{
 				Charm: "cs:wordpress",
 			},
-			"mysql": {
+			"mysql": &charm.ApplicationSpec{
 				Charm: "cs:mysql",
 			},
 		},

--- a/internal/storetesting/charm-repo/bundle/bad/bundle.yaml
+++ b/internal/storetesting/charm-repo/bundle/bad/bundle.yaml
@@ -1,6 +1,6 @@
 # This bundle has a bad relation, which will cause it to fail
 # its verification.
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/internal/storetesting/charm-repo/bundle/openstack/bundle.yaml
+++ b/internal/storetesting/charm-repo/bundle/openstack/bundle.yaml
@@ -1,5 +1,5 @@
 series: precise
-services:
+applications:
   mysql:
     charm: cs:precise/mysql
     constraints: mem=1G

--- a/internal/storetesting/charm-repo/bundle/wordpress-simple/bundle.yaml
+++ b/internal/storetesting/charm-repo/bundle/wordpress-simple/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/internal/storetesting/charm-repo/bundle/wordpress-with-logging/bundle.yaml
+++ b/internal/storetesting/charm-repo/bundle/wordpress-with-logging/bundle.yaml
@@ -1,4 +1,4 @@
-services:
+applications:
     wordpress:
         charm: wordpress
         num_units: 1

--- a/internal/storetesting/charm.go
+++ b/internal/storetesting/charm.go
@@ -70,12 +70,12 @@ func NewBundle(data *charm.BundleData) *Bundle {
 		panic(err)
 	}
 	readMe := "boring"
-	blob, hash := newBlob([]file{{
-		name: "bundle.yaml",
-		data: dataYAML,
+	blob, hash := NewBlob([]File{{
+		Name: "bundle.yaml",
+		Data: dataYAML,
 	}, {
-		name: "README.md",
-		data: []byte(readMe),
+		Name: "README.md",
+		Data: []byte(readMe),
 	}})
 	return &Bundle{
 		blob:     blob,
@@ -109,12 +109,12 @@ func NewCharm(meta *charm.Meta) *Charm {
 	if err != nil {
 		panic(err)
 	}
-	blob, hash := newBlob([]file{{
-		name: "metadata.yaml",
-		data: metaYAML,
+	blob, hash := NewBlob([]File{{
+		Name: "metadata.yaml",
+		Data: metaYAML,
 	}, {
-		name: "README.md",
-		data: []byte("boring"),
+		Name: "README.md",
+		Data: []byte("boring"),
 	}})
 	return &Charm{
 		blob:     blob,
@@ -164,21 +164,23 @@ func (c *Charm) Size() int64 {
 	return int64(len(c.blob))
 }
 
-type file struct {
-	name string
-	data []byte
+// File represents a file which will be added to a new blob.
+type File struct {
+	Name string
+	Data []byte
 }
 
-// newBlob returns a zip archive containing the given files.
-func newBlob(files []file) ([]byte, string) {
+// NewBlob returns a zip archive containing the given files, along with
+// its blobstore hash.
+func NewBlob(files []File) ([]byte, string) {
 	var blob bytes.Buffer
 	zw := zip.NewWriter(&blob)
 	for _, f := range files {
-		w, err := zw.Create(f.name)
+		w, err := zw.Create(f.Name)
 		if err != nil {
 			panic(err)
 		}
-		if _, err := w.Write(f.data); err != nil {
+		if _, err := w.Write(f.Data); err != nil {
 			panic(err)
 		}
 	}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -128,7 +128,7 @@ var metaEndpoints = []metaEndpoint{{
 	get:       entityFieldGetter("BundleData"),
 	checkURL:  newResolvedURL("cs:~charmers/bundle/wordpress-simple-42", 42),
 	assertCheckData: func(c *gc.C, data interface{}) {
-		c.Assert(data.(*charm.BundleData).Services["wordpress"].Charm, gc.Equals, "wordpress")
+		c.Assert(data.(*charm.BundleData).Applications["wordpress"].Charm, gc.Equals, "wordpress")
 	},
 }, {
 	name:      "bundle-unit-count",
@@ -1505,7 +1505,7 @@ func (s *APISuite) TestBundleTags(c *gc.C) {
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", -1)
 	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
 		Tags: []string{"foo", "bar"},
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 			},
@@ -1523,7 +1523,7 @@ func (s *APISuite) TestPromulgatedBundleTags(c *gc.C) {
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", 2)
 	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
 		Tags: []string{"foo", "bar"},
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 			},

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -718,9 +718,9 @@ func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
 	expectErr := `bundle verification failed: [` +
-		`"relation [\"foo:db\" \"mysql:server\"] refers to service \"foo\" not defined in this bundle",` +
-		`"service \"mysql\" refers to non-existent charm \"mysql\"",` +
-		`"service \"wordpress\" refers to non-existent charm \"wordpress\""]`
+		`"relation [\"foo:db\" \"mysql:server\"] refers to application \"foo\" not defined in this bundle",` +
+		`"application \"mysql\" refers to non-existent charm \"mysql\"",` +
+		`"application \"wordpress\" refers to non-existent charm \"wordpress\""]`
 	s.assertCannotUpload(c, "~charmers/bundle/wordpress", f, http.StatusBadRequest, params.ErrInvalidEntity, expectErr)
 }
 

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -718,9 +718,9 @@ func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
 	expectErr := `bundle verification failed: [` +
-		`"relation [\"foo:db\" \"mysql:server\"] refers to application \"foo\" not defined in this bundle",` +
 		`"application \"mysql\" refers to non-existent charm \"mysql\"",` +
-		`"application \"wordpress\" refers to non-existent charm \"wordpress\""]`
+		`"application \"wordpress\" refers to non-existent charm \"wordpress\"",` +
+		`"relation [\"foo:db\" \"mysql:server\"] refers to application \"foo\" not defined in this bundle"]`
 	s.assertCannotUpload(c, "~charmers/bundle/wordpress", f, http.StatusBadRequest, params.ErrInvalidEntity, expectErr)
 }
 
@@ -870,7 +870,7 @@ func (s *ArchiveSuite) assertUploadBundle(c *gc.C, method string, url *router.Re
 		Id: id,
 		Meta: entityMetaInfo{
 			ArchiveSize: &params.ArchiveSizeResponse{Size: size},
-			BundleMeta:  b.Data(),
+			BundleMeta:  v4BundleMetadata(b.Data()), // V4 SPECIFIC
 		},
 	},
 	)
@@ -1371,7 +1371,7 @@ type entityMetaInfo struct {
 	CharmMeta    *charm.Meta                 `json:"charm-metadata,omitempty"`
 	CharmConfig  *charm.Config               `json:"charm-config,omitempty"`
 	CharmActions *charm.Actions              `json:"charm-actions,omitempty"`
-	BundleMeta   *charm.BundleData           `json:"bundle-metadata,omitempty"`
+	BundleMeta   interface{}                 `json:"bundle-metadata,omitempty"` // V4 SPECIFIC
 }
 
 func (s *ArchiveSuite) assertEntityInfo(c *gc.C, expect entityInfo) {

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -267,7 +267,7 @@ func storeURL(path string) string {
 // addRequiredCharms adds any charms required by the given
 // bundle that are not already in the store.
 func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
-	for _, svc := range bundle.Data().Services {
+	for _, svc := range bundle.Data().Applications {
 		u := charm.MustParseURL(svc.Charm)
 		if _, err := s.store.FindBestEntity(u, params.StableChannel, nil); err == nil {
 			continue

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -65,7 +65,7 @@ func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
 
 func (s *APISuite) TestServeDiagram(c *gc.C) {
 	bundle := storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 				Annotations: map[string]string{
@@ -132,7 +132,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 	bundle := storetesting.NewBundle(
 		&charm.BundleData{
-			Services: map[string]*charm.ServiceSpec{
+			Applications: map[string]*charm.ApplicationSpec{
 				"wordpress": {
 					Charm: "wordpress",
 				},

--- a/internal/v4/list_test.go
+++ b/internal/v4/list_test.go
@@ -174,7 +174,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 		about: "bundle-metadata",
 		query: "name=wordpress-simple&type=bundle&include=bundle-metadata",
 		meta: map[string]interface{}{
-			"bundle-metadata": getListBundle("wordpress-simple").Data(),
+			"bundle-metadata": v4BundleMetadata(getListBundle("wordpress-simple").Data()), // V4 SPECIFIC
 		},
 	}, {
 		about: "bundle-machine-count",

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -374,7 +374,7 @@ var metaBundlesContainingTests = []struct {
 		Id: charm.MustParseURL("bundle/wordpress-complex-1"),
 		Meta: map[string]interface{}{
 			"id-name":         params.IdNameResponse{"wordpress-complex"},
-			"bundle-metadata": metaBundlesContainingBundles["1 ~charmers/bundle/wordpress-complex-1"].Data(),
+			"bundle-metadata": v4BundleMetadata(metaBundlesContainingBundles["1 ~charmers/bundle/wordpress-complex-1"].Data()), // V4 SPECIFIC
 		},
 	}},
 }, {
@@ -527,19 +527,19 @@ var metaBundlesContainingTests = []struct {
 		Id: charm.MustParseURL("bundle/useless-0"),
 		Meta: map[string]interface{}{
 			"id-name":         params.IdNameResponse{"useless"},
-			"bundle-metadata": metaBundlesContainingBundles["0 ~charmers/bundle/useless-0"].Data(),
+			"bundle-metadata": v4BundleMetadata(metaBundlesContainingBundles["0 ~charmers/bundle/useless-0"].Data()), //V4 SPECIFIC
 		},
 	}, {
 		Id: charm.MustParseURL("bundle/wordpress-complex-1"),
 		Meta: map[string]interface{}{
 			"id-name":         params.IdNameResponse{"wordpress-complex"},
-			"bundle-metadata": metaBundlesContainingBundles["1 ~charmers/bundle/wordpress-complex-1"].Data(),
+			"bundle-metadata": v4BundleMetadata(metaBundlesContainingBundles["1 ~charmers/bundle/wordpress-complex-1"].Data()), //V4 SPECIFIC
 		},
 	}, {
 		Id: charm.MustParseURL("bundle/wordpress-simple-1"),
 		Meta: map[string]interface{}{
 			"id-name":         params.IdNameResponse{"wordpress-simple"},
-			"bundle-metadata": metaBundlesContainingBundles["1 ~charmers/bundle/wordpress-simple-1"].Data(),
+			"bundle-metadata": v4BundleMetadata(metaBundlesContainingBundles["1 ~charmers/bundle/wordpress-simple-1"].Data()), //V4 SPECIFIC
 		},
 	}},
 }, {

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -627,17 +627,17 @@ func sameMetaAnyResponses(expect interface{}) httptesting.BodyAsserter {
 // to be included in the bundle.
 // For each URL, a corresponding service is automatically created.
 func relationTestingBundle(urls []string) charm.Bundle {
-	services := make(map[string]*charm.ServiceSpec, len(urls))
+	applications := make(map[string]*charm.ApplicationSpec, len(urls))
 	for i, url := range urls {
-		service := &charm.ServiceSpec{
+		application := &charm.ApplicationSpec{
 			Charm:    url,
 			NumUnits: 1,
 		}
-		services[fmt.Sprintf("service-%d", i)] = service
+		applications[fmt.Sprintf("application-%d", i)] = application
 	}
 	return storetesting.NewBundle(
 		&charm.BundleData{
-			Services: services,
+			Applications: applications,
 		})
 
 }

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -320,7 +320,7 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 		about: "bundle-metadata",
 		query: "name=wordpress-simple&type=bundle&include=bundle-metadata",
 		meta: map[string]interface{}{
-			"bundle-metadata": getSearchBundle("wordpress-simple").Data(),
+			"bundle-metadata": v4BundleMetadata(getSearchBundle("wordpress-simple").Data()), // V4 SPECIFIC
 		},
 	}, {
 		about: "bundle-machine-count",

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -134,7 +134,7 @@ var metaEndpoints = []metaEndpoint{{
 	get:       entityFieldGetter("BundleData"),
 	checkURL:  newResolvedURL("cs:~charmers/bundle/wordpress-simple-42", 42),
 	assertCheckData: func(c *gc.C, data interface{}) {
-		c.Assert(data.(*charm.BundleData).Services["wordpress"].Charm, gc.Equals, "wordpress")
+		c.Assert(data.(*charm.BundleData).Applications["wordpress"].Charm, gc.Equals, "wordpress")
 	},
 }, {
 	name:      "bundle-unit-count",
@@ -849,7 +849,7 @@ var metaPublishedTests = []struct {
 }, {
 	id: "~bob/bundle/mybundle-2",
 	entity: storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "~charmers/precise/wordpress",
 			},
@@ -1903,7 +1903,7 @@ func (s *APISuite) TestBundleTags(c *gc.C) {
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", -1)
 	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
 		Tags: []string{"foo", "bar"},
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 			},
@@ -1921,7 +1921,7 @@ func (s *APISuite) TestPromulgatedBundleTags(c *gc.C) {
 	url := newResolvedURL("~charmers/bundle/wordpress-simple-2", 2)
 	s.addPublicBundle(c, storetesting.NewBundle(&charm.BundleData{
 		Tags: []string{"foo", "bar"},
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 			},

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -819,9 +819,9 @@ func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
 	expectErr := `bundle verification failed: [` +
-		`"relation [\"foo:db\" \"mysql:server\"] refers to application \"foo\" not defined in this bundle",` +
 		`"application \"mysql\" refers to non-existent charm \"mysql\"",` +
-		`"application \"wordpress\" refers to non-existent charm \"wordpress\""]`
+		`"application \"wordpress\" refers to non-existent charm \"wordpress\"",` +
+		`"relation [\"foo:db\" \"mysql:server\"] refers to application \"foo\" not defined in this bundle"]`
 	s.assertCannotUpload(c, "~charmers/bundle/wordpress", f, http.StatusBadRequest, params.ErrInvalidEntity, expectErr)
 }
 

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -819,9 +819,9 @@ func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
 	expectErr := `bundle verification failed: [` +
-		`"relation [\"foo:db\" \"mysql:server\"] refers to service \"foo\" not defined in this bundle",` +
-		`"service \"mysql\" refers to non-existent charm \"mysql\"",` +
-		`"service \"wordpress\" refers to non-existent charm \"wordpress\""]`
+		`"relation [\"foo:db\" \"mysql:server\"] refers to application \"foo\" not defined in this bundle",` +
+		`"application \"mysql\" refers to non-existent charm \"mysql\"",` +
+		`"application \"wordpress\" refers to non-existent charm \"wordpress\""]`
 	s.assertCannotUpload(c, "~charmers/bundle/wordpress", f, http.StatusBadRequest, params.ErrInvalidEntity, expectErr)
 }
 

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -328,7 +328,7 @@ func (s *commonSuite) bakeryDoAsUser(c *gc.C, user string) func(*http.Request) (
 // addRequiredCharms adds any charms required by the given
 // bundle that are not already in the store.
 func (s *commonSuite) addRequiredCharms(c *gc.C, bundle charm.Bundle) {
-	for _, svc := range bundle.Data().Services {
+	for _, svc := range bundle.Data().Applications {
 		u := charm.MustParseURL(svc.Charm)
 		if _, err := s.store.FindBestEntity(u, params.StableChannel, nil); err == nil {
 			continue

--- a/internal/v5/content.go
+++ b/internal/v5/content.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
-	"gopkg.in/juju/jujusvg.v1"
+	"gopkg.in/juju/jujusvg.v2"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"

--- a/internal/v5/content_test.go
+++ b/internal/v5/content_test.go
@@ -66,7 +66,7 @@ func (s *APISuite) TestServeDiagramErrors(c *gc.C) {
 
 func (s *APISuite) TestServeDiagram(c *gc.C) {
 	bundle := storetesting.NewBundle(&charm.BundleData{
-		Services: map[string]*charm.ServiceSpec{
+		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm: "wordpress",
 				Annotations: map[string]string{
@@ -102,7 +102,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	// Check that the output contains valid XML with an SVG tag,
 	// but don't check the details of the output so that this test doesn't
 	// break every time the jujusvg presentation changes.
-	// Also check that we get an image for each service containing the charm
+	// Also check that we get an image for each application containing the charm
 	// icon link.
 	assertXMLContains(c, rec.Body.Bytes(), map[string]func(xml.Token) bool{
 		"svg element":    isStartElementWithName("svg"),
@@ -121,7 +121,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	// Check that the output contains valid XML with an SVG tag,
 	// but don't check the details of the output so that this test doesn't
 	// break every time the jujusvg presentation changes.
-	// Also check that we get an image for each service containing the charm
+	// Also check that we get an image for each application containing the charm
 	// icon link.
 	assertXMLContains(c, rec.Body.Bytes(), map[string]func(xml.Token) bool{
 		"svg element":    isStartElementWithName("svg"),
@@ -133,7 +133,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 	bundle := storetesting.NewBundle(
 		&charm.BundleData{
-			Services: map[string]*charm.ServiceSpec{
+			Applications: map[string]*charm.ApplicationSpec{
 				"wordpress": {
 					Charm: "wordpress",
 				},

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -654,19 +654,19 @@ func sameMetaAnyResponses(expect interface{}) httptesting.BodyAsserter {
 // relationTestingBundle returns a bundle for use in relation
 // testing. The urls parameter holds a list of charm references
 // to be included in the bundle.
-// For each URL, a corresponding service is automatically created.
+// For each URL, a corresponding application is automatically created.
 func relationTestingBundle(urls []string) charm.Bundle {
-	services := make(map[string]*charm.ServiceSpec, len(urls))
+	applications := make(map[string]*charm.ApplicationSpec, len(urls))
 	for i, url := range urls {
-		service := &charm.ServiceSpec{
+		application := &charm.ApplicationSpec{
 			Charm:    url,
 			NumUnits: 1,
 		}
-		services[fmt.Sprintf("service-%d", i)] = service
+		applications[fmt.Sprintf("application-%d", i)] = application
 	}
 	return storetesting.NewBundle(
 		&charm.BundleData{
-			Services: services,
+			Applications: applications,
 		})
 
 }


### PR DESCRIPTION
This adds the change of name from services to applications for bundles, and also makes a version of the bundle that uses services available on the v4 endpoints to be compatible with juju 1.25.
