### PR TITLE
internal/charmstore: improve search results for charm names

### DIFF
--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -10,7 +10,7 @@ var (
 	esMapping = mustParseJSON(esMappingJSON)
 )
 
-const esSettingsVersion = 9
+const esSettingsVersion = 10
 
 func mustParseJSON(s string) interface{} {
 	var j json.RawMessage
@@ -27,7 +27,7 @@ const esIndexJSON = `
         "analysis": {
             "filter": {
                 "n3_20grams_filter": {
-                    "type":     "edgeNGram",
+                    "type":     "nGram",
                     "min_gram": 3,
                     "max_gram": 20
                 }
@@ -39,6 +39,13 @@ const esIndexJSON = `
                     "filter": [
                         "lowercase",
                         "n3_20grams_filter"
+                    ]
+                },
+                "lowercase": {
+                    "type":      "custom",
+                    "tokenizer": "keyword",
+                    "filter": [
+                        "lowercase"
                     ]
                 }
             }
@@ -85,7 +92,13 @@ const esMappingJSON = `
           },
           "ngrams": {
             "type": "string",
-            "index_analyzer": "n3_20grams",
+            "analyzer": "n3_20grams",
+            "search_analyzer": "lowercase",
+            "include_in_all": false
+          },
+          "tok": {
+            "type": "string",
+            "analyzer": "simple",
             "include_in_all": false
           }
         }

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -541,28 +541,21 @@ func createSearchDSL(sp SearchParams) elasticsearch.QueryDSL {
 
 	// Full text search
 	var q elasticsearch.Query
+	nameField := "Name.tok"
+	if sp.AutoComplete {
+		nameField = "Name.ngrams"
+	}
 	if sp.Text == "" {
 		q = elasticsearch.MatchAllQuery{}
-	} else if sp.AutoComplete {
-		q = elasticsearch.MatchQuery{
-			Field:    "Name.ngrams",
-			Query:    sp.Text,
-			Analyzer: "keyword",
-		}
 	} else {
 		q = elasticsearch.MultiMatchQuery{
 			Query: sp.Text,
 			Fields: encodeFields(map[string]float64{
-				"Name":                    10,
-				"User":                    7,
-				"CharmMeta.Categories":    5,
-				"CharmMeta.Tags":          5,
-				"BundleData.Tags":         5,
-				"Series":                  5,
-				"CharmProvidedInterfaces": 3,
-				"CharmRequiredInterfaces": 3,
-				"CharmMeta.Description":   1,
-				"BundleReadMe":            1,
+				nameField:              10,
+				"User":                 7,
+				"CharmMeta.Categories": 5,
+				"CharmMeta.Tags":       5,
+				"BundleData.Tags":      5,
 			}),
 		}
 	}

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -380,6 +380,16 @@ var searchTests = []struct {
 			searchEntities["wordpress-simple"].entity,
 		},
 	}, {
+		about: "autocomplete end of word",
+		sp: SearchParams{
+			Text:         "PRESS",
+			AutoComplete: true,
+		},
+		results: Entities{
+			searchEntities["wordpress"].entity,
+			searchEntities["wordpress-simple"].entity,
+		},
+	}, {
 		about: "non-matching autocomplete search",
 		sp: SearchParams{
 			Text:         "worm",

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -370,6 +370,16 @@ var searchTests = []struct {
 			searchEntities["wordpress-simple"].entity,
 		},
 	}, {
+		about: "autocomplete case insensitive",
+		sp: SearchParams{
+			Text:         "woRd",
+			AutoComplete: true,
+		},
+		results: Entities{
+			searchEntities["wordpress"].entity,
+			searchEntities["wordpress-simple"].entity,
+		},
+	}, {
 		about: "non-matching autocomplete search",
 		sp: SearchParams{
 			Text:         "worm",
@@ -656,6 +666,24 @@ var searchTests = []struct {
 		},
 		results: Entities{
 			searchEntities["mysql"].entity,
+		},
+	}, {
+		about: "name search",
+		sp: SearchParams{
+			Text: "wordpress",
+		},
+		results: Entities{
+			searchEntities["wordpress"].entity,
+			searchEntities["wordpress-simple"].entity,
+		},
+	}, {
+		about: "case insensitive search",
+		sp: SearchParams{
+			Text: "WORDPRESS",
+		},
+		results: Entities{
+			searchEntities["wordpress"].entity,
+			searchEntities["wordpress-simple"].entity,
 		},
 	},
 }


### PR DESCRIPTION
Update the elasticsearch indexing so that search is case insensitive
and name matching matches on tokens.

This fixes #638 & #639.
