### PR TITLE
internal/charmstore: whitespace tokenize query text for autocomplete searches

### DIFF
--- a/elasticsearch/query.go
+++ b/elasticsearch/query.go
@@ -62,13 +62,23 @@ func (m MatchQuery) MarshalJSON() ([]byte, error) {
 type MultiMatchQuery struct {
 	Query  string
 	Fields []string
+
+	// MinimumShouldMatch optionally contains the value for the
+	// minimum_should_match parameter, For details of possible values
+	// please see:
+	// https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
+	MinimumShouldMatch string
 }
 
 func (m MultiMatchQuery) MarshalJSON() ([]byte, error) {
-	return marshalNamedObject("multi_match", map[string]interface{}{
+	mm := map[string]interface{}{
 		"query":  m.Query,
 		"fields": m.Fields,
-	})
+	}
+	if m.MinimumShouldMatch != "" {
+		mm["minimum_should_match"] = m.MinimumShouldMatch
+	}
+	return marshalNamedObject("multi_match", mm)
 }
 
 // FilteredQuery provides a query that includes a filter.

--- a/internal/charmstore/elasticsearch.go
+++ b/internal/charmstore/elasticsearch.go
@@ -10,7 +10,7 @@ var (
 	esMapping = mustParseJSON(esMappingJSON)
 )
 
-const esSettingsVersion = 10
+const esSettingsVersion = 11
 
 func mustParseJSON(s string) interface{} {
 	var j json.RawMessage
@@ -41,9 +41,9 @@ const esIndexJSON = `
                         "n3_20grams_filter"
                     ]
                 },
-                "lowercase": {
+                "lowercase_words": {
                     "type":      "custom",
-                    "tokenizer": "keyword",
+                    "tokenizer": "whitespace",
                     "filter": [
                         "lowercase"
                     ]
@@ -93,7 +93,7 @@ const esMappingJSON = `
           "ngrams": {
             "type": "string",
             "analyzer": "n3_20grams",
-            "search_analyzer": "lowercase",
+            "search_analyzer": "lowercase_words",
             "include_in_all": false
           },
           "tok": {

--- a/internal/charmstore/search.go
+++ b/internal/charmstore/search.go
@@ -557,6 +557,7 @@ func createSearchDSL(sp SearchParams) elasticsearch.QueryDSL {
 				"CharmMeta.Tags":       5,
 				"BundleData.Tags":      5,
 			}),
+			MinimumShouldMatch: "100%",
 		}
 	}
 

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -695,6 +695,24 @@ var searchTests = []struct {
 			searchEntities["wordpress"].entity,
 			searchEntities["wordpress-simple"].entity,
 		},
+	}, {
+		about: "autocomplete with spaces",
+		sp: SearchParams{
+			Text:         "wordpress simple",
+			AutoComplete: true,
+		},
+		results: Entities{
+			searchEntities["wordpress-simple"].entity,
+		},
+	}, {
+		about: "autocomplete with spaces, reversed",
+		sp: SearchParams{
+			Text:         "simple wordpress",
+			AutoComplete: true,
+		},
+		results: Entities{
+			searchEntities["wordpress-simple"].entity,
+		},
 	},
 }
 


### PR DESCRIPTION
Also ensure that all terms are matched in an auto-complete search.
