### PR TITLE
disable metrics migration

### DIFF
--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -26,7 +26,6 @@ const (
 	migrationAddPreV5CompatBlob      mongodoc.MigrationName = "add pre-v5 compatibility blobs; second try"
 	migrationNewChannelsModel        mongodoc.MigrationName = "new channels model"
 	migrationStats                   mongodoc.MigrationName = "remove legacy download stats"
-	migrationAddMetrics              mongodoc.MigrationName = "store metrics into entities"
 )
 
 // migrations holds all the migration functions that are executed in the order
@@ -72,9 +71,6 @@ var migrations = []migration{{
 }, {
 	name:    migrationStats,
 	migrate: migrateToArchiveDownloadStatsOnly,
-}, {
-	name:    migrationAddMetrics,
-	migrate: addMetrics,
 }}
 
 // migration holds a migration function with its corresponding name.

--- a/internal/charmstore/migrations_integration_test.go
+++ b/internal/charmstore/migrations_integration_test.go
@@ -218,16 +218,6 @@ var migrationHistory = []versionSpec{{
 		}, {
 			id:     "~someone/trusty/empty-metered-42",
 			entity: storetesting.NewCharm(nil).WithMetrics(&charm.Metrics{}),
-		}, {
-			id: "~someone/trusty/metered-42",
-			entity: storetesting.NewCharm(nil).WithMetrics(&charm.Metrics{
-				Metrics: map[string]charm.Metric{
-					"pings": {
-						Type:        "gauge",
-						Description: "some metrics",
-					},
-				},
-			}),
 		}})
 
 		if err != nil {
@@ -343,18 +333,6 @@ var migrationFromDumpEntityTests = []struct {
 	id: "~someone/trusty/empty-metered-42",
 	checkers: []entityChecker{
 		hasMetrics(nil),
-	},
-}, {
-	id: "~someone/trusty/metered-42",
-	checkers: []entityChecker{
-		hasMetrics(&charm.Metrics{
-			Metrics: map[string]charm.Metric{
-				"pings": {
-					Type:        "gauge",
-					Description: "some metrics",
-				},
-			},
-		}),
 	},
 }}
 


### PR DESCRIPTION
The code to execute the migration remains as it will be used by
a separate utility to run as an online migration.
