### PR TITLE
search uses autocomplete=1 by default

### DIFF
--- a/internal/v4/search.go
+++ b/internal/v4/search.go
@@ -15,6 +15,7 @@ const maxConcurrency = 20
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-search
 func (h ReqHandler) serveSearch(_ http.Header, req *http.Request) (interface{}, error) {
 	sp, err := v5.ParseSearchParams(req)
+	sp.AutoComplete = true
 	if err != nil {
 		return "", err
 	}

--- a/internal/v5/list.go
+++ b/internal/v5/list.go
@@ -18,6 +18,7 @@ import (
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-list
 func (h *ReqHandler) serveList(_ http.Header, req *http.Request) (interface{}, error) {
 	sp, err := ParseSearchParams(req)
+	sp.AutoComplete = false
 	if err != nil {
 		return "", err
 	}

--- a/internal/v5/search.go
+++ b/internal/v5/search.go
@@ -110,6 +110,7 @@ func (h *ReqHandler) serveSearchInteresting(w http.ResponseWriter, req *http.Req
 // ParseSearchParms extracts the search paramaters from the request
 func ParseSearchParams(req *http.Request) (charmstore.SearchParams, error) {
 	sp := charmstore.SearchParams{}
+	sp.AutoComplete = true
 	var err error
 	for k, v := range req.Form {
 		switch k {

--- a/internal/v5/search_test.go
+++ b/internal/v5/search_test.go
@@ -89,14 +89,23 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 	}{{
 		about: "bare search",
 		query: "",
+		expectParams: charmstore.SearchParams{
+			AutoComplete: true,
+		},
 	}, {
 		about: "text search",
-		query: "text=test",
+		query: "text=test&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Text: "test",
 		},
 	}, {
-		about: "autocomplete",
+		about: "autocomplete=0",
+		query: "autocomplete=0",
+		expectParams: charmstore.SearchParams{
+			AutoComplete: false,
+		},
+	}, {
+		about: "autocomplete=1",
 		query: "autocomplete=1",
 		expectParams: charmstore.SearchParams{
 			AutoComplete: true,
@@ -107,39 +116,39 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		expectError: `invalid autocomplete parameter: unexpected bool value "true" (must be "0" or "1")`,
 	}, {
 		about: "limit",
-		query: "limit=20",
+		query: "limit=20&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Limit: 20,
 		},
 	}, {
 		about:       "invalid limit",
-		query:       "limit=twenty",
+		query:       "limit=twenty&autocomplete=0",
 		expectError: `invalid limit parameter: could not parse integer: strconv.ParseInt: parsing "twenty": invalid syntax`,
 	}, {
 		about:       "limit too low",
-		query:       "limit=-1",
+		query:       "limit=-1&autocomplete=0",
 		expectError: "invalid limit parameter: expected integer greater than zero",
 	}, {
 		about: "include",
-		query: "include=archive-size",
+		query: "include=archive-size&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Include: []string{"archive-size"},
 		},
 	}, {
 		about: "include many",
-		query: "include=archive-size&include=bundle-data",
+		query: "include=archive-size&include=bundle-data&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Include: []string{"archive-size", "bundle-data"},
 		},
 	}, {
 		about: "include many with blanks",
-		query: "include=archive-size&include=&include=bundle-data",
+		query: "include=archive-size&include=&include=bundle-data&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Include: []string{"archive-size", "bundle-data"},
 		},
 	}, {
 		about: "description filter",
-		query: "description=text",
+		query: "description=text&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"description": {"text"},
@@ -147,7 +156,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		},
 	}, {
 		about: "name filter",
-		query: "name=text",
+		query: "name=text&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"name": {"text"},
@@ -155,7 +164,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		},
 	}, {
 		about: "owner filter",
-		query: "owner=text",
+		query: "owner=text&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"owner": {"text"},
@@ -163,7 +172,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		},
 	}, {
 		about: "provides filter",
-		query: "provides=text",
+		query: "provides=text&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"provides": {"text"},
@@ -171,7 +180,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		},
 	}, {
 		about: "requires filter",
-		query: "requires=text",
+		query: "requires=text&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"requires": {"text"},
@@ -179,7 +188,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		},
 	}, {
 		about: "series filter",
-		query: "series=text",
+		query: "series=text&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"series": {"text"},
@@ -187,7 +196,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		},
 	}, {
 		about: "tags filter",
-		query: "tags=text",
+		query: "tags=text&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"tags": {"text"},
@@ -195,7 +204,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		},
 	}, {
 		about: "type filter",
-		query: "type=text",
+		query: "type=text&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"type": {"text"},
@@ -203,7 +212,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		},
 	}, {
 		about: "many filters",
-		query: "name=name&owner=owner&series=series1&series=series2",
+		query: "name=name&owner=owner&series=series1&series=series2&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"name":   {"name"},
@@ -217,7 +226,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		expectError: "invalid parameter: a",
 	}, {
 		about: "skip",
-		query: "skip=20",
+		query: "skip=20&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Skip: 20,
 		},
@@ -231,7 +240,7 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		expectError: "invalid skip parameter: expected non-negative integer",
 	}, {
 		about: "promulgated filter",
-		query: "promulgated=1",
+		query: "promulgated=1&autocomplete=0",
 		expectParams: charmstore.SearchParams{
 			Filters: map[string][]string{
 				"promulgated": {"1"},


### PR DESCRIPTION
Add autocomplete=1 by default so that old GUI clients return sane
results in search.
