### PR TITLE
Entity document: include publishing info in a single published field.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -33,7 +33,7 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/charm.v6-unstable	git	a3bb92d047b0892452b6a39ece59b4d3a2ac35b9	2016-07-22T08:34:31Z
-gopkg.in/juju/charmrepo.v2-unstable	git	23b264cb0bf61c98def936f1a8779b1ab5662d47	2016-08-03T15:05:40Z
+gopkg.in/juju/charmrepo.v2-unstable	git	5dd155745b0989bea548c6f44c7495cdd3228ff4	2016-08-04T07:19:06Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
 gopkg.in/juju/names.v2	git	e38bc90539f22af61a9c656d35068bd5f0a5b30a	2016-05-25T23:07:23Z
 gopkg.in/macaroon-bakery.v1	git	e7074941455a293ffb7905cd89ca20ee547a03ec	2016-05-27T11:55:54Z

--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -5,6 +5,8 @@ package charmstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/char
 
 import (
 	"gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
@@ -22,6 +24,7 @@ const (
 	migrationStats                   mongodoc.MigrationName = "remove legacy download stats"
 	migrationEdgeEntities            mongodoc.MigrationName = "rename development to edge in entities"
 	migrationEdgeBaseEntities        mongodoc.MigrationName = "rename development to edge in base entities"
+	migrationPublishedEntities       mongodoc.MigrationName = "include published status in a single entity field"
 )
 
 // migrations holds all the migration functions that are executed in the order
@@ -70,6 +73,9 @@ var migrations = []migration{{
 }, {
 	name:    migrationEdgeBaseEntities,
 	migrate: migrateEdgeBaseEntities,
+}, {
+	name:    migrationPublishedEntities,
+	migrate: migratePublishedEntities,
 }}
 
 // migration holds a migration function with its corresponding name.
@@ -168,6 +174,51 @@ func migrateEdgeBaseEntities(db StoreDatabase) error {
 		},
 	}}); err != nil {
 		return errgo.Notef(err, "cannot rename development keys in base entities")
+	}
+	return nil
+}
+
+type preMigratePublishedEntitiesEntity struct {
+	URL          *charm.URL `bson:"_id"`
+	Stable, Edge bool
+}
+
+// migratePublishedEntities deletes the "edge" and "stable" boolean fields in
+// the entity document and replaces them with a single "published" map.
+func migratePublishedEntities(db StoreDatabase) error {
+	entities := db.Entities()
+	iter := entities.Find(bson.D{{
+		// Assume that if an entity has the "stable" field, it also has the
+		// "edge" one and it hasn't been migrated yet.
+		"stable", bson.D{{"$exists", true}},
+	}}).Select(map[string]int{
+		"stable": 1,
+		"edge":   1,
+	}).Iter()
+
+	// For every resulting entity populate the "published" field and then
+	// remove "stable" and "edge" ones.
+	var entity preMigratePublishedEntitiesEntity
+	for iter.Next(&entity) {
+		err := entities.UpdateId(entity.URL, bson.D{{
+			"$set", bson.D{
+				{"published", map[params.Channel]bool{
+					params.StableChannel: entity.Stable,
+					params.EdgeChannel:   entity.Edge,
+				}},
+			},
+		}, {
+			"$unset", bson.D{
+				{"stable", ""},
+				{"edge", ""},
+			},
+		}})
+		if err != nil {
+			return errgo.Notef(err, "cannot update entity")
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return errgo.Notef(err, "cannot iterate through entities")
 	}
 	return nil
 }

--- a/internal/charmstore/migrations_integration_test.go
+++ b/internal/charmstore/migrations_integration_test.go
@@ -250,7 +250,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(0),
 		hasCompatibilityBlob(false),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(true),
 	},
 }, {
@@ -258,7 +258,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(1),
 		hasCompatibilityBlob(false),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(false),
 	},
 }, {
@@ -266,7 +266,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(-1),
 		hasCompatibilityBlob(false),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(true),
 	},
 }, {
@@ -274,7 +274,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(0),
 		hasCompatibilityBlob(false),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(true),
 	},
 }, {
@@ -282,7 +282,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(-1),
 		hasCompatibilityBlob(false),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(true),
 	},
 }, {
@@ -290,7 +290,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(-1),
 		hasCompatibilityBlob(true),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(true),
 	},
 }, {
@@ -298,7 +298,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(-1),
 		hasCompatibilityBlob(true),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(true),
 	},
 }, {
@@ -306,7 +306,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(-1),
 		hasCompatibilityBlob(false),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(true),
 	},
 }, {
@@ -314,7 +314,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(-1),
 		hasCompatibilityBlob(false),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(false),
 	},
 }, {
@@ -322,7 +322,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(-1),
 		hasCompatibilityBlob(false),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(false),
 	},
 }, {
@@ -330,7 +330,7 @@ var migrationFromDumpEntityTests = []struct {
 	checkers: []entityChecker{
 		hasPromulgatedRevision(-1),
 		hasCompatibilityBlob(false),
-		isDevelopment(true),
+		isEdge(true),
 		isStable(true),
 		hasMetrics(nil),
 	},
@@ -617,18 +617,13 @@ func checkBaseEntityInvariants(c *gc.C, e *mongodoc.BaseEntity, store *Store) {
 			}
 			ce, err := store.FindEntity(MustParseResolvedURL(url.String()), nil)
 			c.Assert(err, gc.IsNil)
-			switch ch {
-			case params.EdgeChannel:
-				c.Assert(ce.Edge, gc.Equals, true)
-			case params.StableChannel:
-				c.Assert(ce.Stable, gc.Equals, true)
-			default:
+			if !ValidChannels[ch] {
 				c.Fatalf("unknown channel %q found", ch)
 			}
+			c.Assert(ce.Published[ch], gc.Equals, true)
 			if series != "bundle" && !stringInSlice(series, ce.SupportedSeries) {
 				c.Fatalf("series %q not found in supported series %q", series, ce.SupportedSeries)
 			}
-
 		}
 	}
 }
@@ -666,15 +661,15 @@ func hasCompatibilityBlob(hasBlob bool) entityChecker {
 	}
 }
 
-func isDevelopment(isDev bool) entityChecker {
+func isEdge(isDev bool) entityChecker {
 	return func(c *gc.C, entity *mongodoc.Entity) {
-		c.Assert(entity.Edge, gc.Equals, isDev)
+		c.Assert(entity.Published[params.EdgeChannel], gc.Equals, isDev)
 	}
 }
 
 func isStable(isStable bool) entityChecker {
 	return func(c *gc.C, entity *mongodoc.Entity) {
-		c.Assert(entity.Stable, gc.Equals, isStable)
+		c.Assert(entity.Published[params.StableChannel], gc.Equals, isStable)
 	}
 }
 

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -390,10 +390,10 @@ func (s *Store) ensureIndexes() error {
 		mgo.Index{Key: []string{"bundlecharms"}},
 	}, {
 		s.DB.Entities(),
-		mgo.Index{Key: []string{"name", "edge", "-promulgated-revision", "-supportedseries"}},
+		mgo.Index{Key: []string{"name", "published", "-promulgated-revision", "-supportedseries"}},
 	}, {
 		s.DB.Entities(),
-		mgo.Index{Key: []string{"name", "edge", "user", "-revision", "-supportedseries"}},
+		mgo.Index{Key: []string{"name", "published", "user", "-revision", "-supportedseries"}},
 	}, {
 		s.DB.BaseEntities(),
 		mgo.Index{Key: []string{"name"}},
@@ -496,8 +496,7 @@ func (s *Store) FindBestEntity(url *charm.URL, channel params.Channel, fields ma
 			"promulgated-revision": 1,
 			"series":               1,
 			"revision":             1,
-			"edge":                 1,
-			"stable":               1,
+			"published":            1,
 		}
 		for f := range fields {
 			nfields[f] = 1
@@ -515,15 +514,8 @@ func (s *Store) FindBestEntity(url *charm.URL, channel params.Channel, fields ma
 		// If a channel was specified make sure the entity is in that channel.
 		// This is crucial because if we don't do this, then the user could choose
 		// to use any chosen set of ACLs against any entity.
-		switch channel {
-		case params.StableChannel:
-			if !entity.Stable {
-				return nil, errgo.WithCausef(nil, params.ErrNotFound, "%s not found in stable channel", url)
-			}
-		case params.EdgeChannel:
-			if !entity.Edge {
-				return nil, errgo.WithCausef(nil, params.ErrNotFound, "%s not found in edge channel", url)
-			}
+		if ValidChannels[channel] && channel != params.UnpublishedChannel && !entity.Published[channel] {
+			return nil, errgo.WithCausef(nil, params.ErrNotFound, "%s not found in %s channel", url, channel)
 		}
 		return entity, nil
 	}
@@ -766,8 +758,9 @@ func (s *Store) UpdateBaseEntity(url *router.ResolvedURL, update bson.D) error {
 var ErrPublishResourceMismatch = errgo.Newf("charm published with incorrect resources")
 
 // Publish assigns channels to the entity corresponding to the given URL.
-// An error is returned if no channels are provided. For the time being,
-// the only supported channels are "edge" and "stable".
+// An error is returned if no channels are provided. See ValidChannels in this
+// package for the list of supported channels. The unpublished channel cannot
+// be provided.
 //
 // If the given resources do not match those expected or they're not
 // found, an error with a ErrPublichResourceMismatch cause will be returned.
@@ -776,12 +769,12 @@ func (s *Store) Publish(url *router.ResolvedURL, resources map[string]int, chann
 	// Throw away any channels that we don't like.
 	actualChannels := make([]params.Channel, 0, len(channels))
 	for _, c := range channels {
-		switch c {
-		case params.StableChannel:
+		if !ValidChannels[c] || c == params.UnpublishedChannel {
+			continue
+		}
+		actualChannels = append(actualChannels, c)
+		if c == params.StableChannel {
 			updateSearch = true
-			fallthrough
-		case params.EdgeChannel:
-			actualChannels = append(actualChannels, c)
 		}
 	}
 	channels = actualChannels
@@ -810,7 +803,7 @@ func (s *Store) Publish(url *router.ResolvedURL, resources map[string]int, chann
 	// Update the entity's published channels.
 	update := make(bson.D, 0, len(channels)*(len(series)+1)) // ...ish.
 	for _, c := range channels {
-		update = append(update, bson.DocElem{string(c), true})
+		update = append(update, bson.DocElem{"published." + string(c), true})
 	}
 	if err := s.UpdateEntity(url, bson.D{{"$set", update}}); err != nil {
 		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
@@ -824,7 +817,6 @@ func (s *Store) Publish(url *router.ResolvedURL, resources map[string]int, chann
 		}
 		update = append(update, bson.DocElem{fmt.Sprintf("channelresources.%s", c), resourceDocs})
 	}
-
 	if err := s.UpdateBaseEntity(url, bson.D{{"$set", update}}); err != nil {
 		return errgo.Mask(err)
 	}
@@ -1067,10 +1059,11 @@ func (s *Store) SetPromulgated(url *router.ResolvedURL, promulgate bool) error {
 }
 
 // SetPerms sets the ACL specified by which for the base entity with the
-// given id. The which parameter is in the form "[channel].operation",
-// where channel, if specified, is one of "edge" or "stable" and operation
-// is one of "read" or "write". If which does not specify a channel then
-// the unpublished ACL is updated. This is only provided for testing.
+// given id. The which parameter is in the form "channel.operation",
+// where channel is the string corresponding to one of the ValidChannels
+// and operation is one of "read" or "write". If which does not specify a
+// channel then the unpublished ACL is updated.
+// This is only provided for testing.
 func (s *Store) SetPerms(id *charm.URL, which string, acl ...string) error {
 	return s.DB.BaseEntities().UpdateId(mongodoc.BaseURL(id), bson.D{{"$set",
 		bson.D{{"channelacls." + which, acl}},
@@ -1395,7 +1388,7 @@ func (store *Store) ListQuery(sp SearchParams) (*ListQuery, error) {
 func (lq *ListQuery) Iter(fields map[string]int) *mgo.Iter {
 	qfields := FieldSelector(
 		"promulgated-url",
-		"edge",
+		"published",
 		"name",
 		"user",
 		"series",
@@ -1413,7 +1406,7 @@ func (lq *ListQuery) Iter(fields map[string]int) *mgo.Iter {
 			"$baseurl",
 			"$series",
 			bson.D{{
-				"$cond", []string{"$edge", "true", "false"},
+				"$cond", []string{"$published.edge", "true", "false"},
 			}},
 		},
 	}}})

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -3499,8 +3499,10 @@ var publishTests = []struct {
 		URL: charm.MustParseURL("~who/django"),
 	},
 	expectedEntity: &mongodoc.Entity{
-		URL:  charm.MustParseURL("~who/trusty/django-42"),
-		Edge: true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3515,8 +3517,10 @@ var publishTests = []struct {
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
 	channels: []params.Channel{params.EdgeChannel},
 	initialEntity: &mongodoc.Entity{
-		URL:  charm.MustParseURL("~who/trusty/django-42"),
-		Edge: true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3527,8 +3531,10 @@ var publishTests = []struct {
 		},
 	},
 	expectedEntity: &mongodoc.Entity{
-		URL:  charm.MustParseURL("~who/trusty/django-42"),
-		Edge: true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3543,8 +3549,10 @@ var publishTests = []struct {
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
 	channels: []params.Channel{params.EdgeChannel},
 	initialEntity: &mongodoc.Entity{
-		URL:    charm.MustParseURL("~who/trusty/django-42"),
-		Stable: true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.StableChannel: true,
+		},
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3555,9 +3563,11 @@ var publishTests = []struct {
 		},
 	},
 	expectedEntity: &mongodoc.Entity{
-		URL:    charm.MustParseURL("~who/trusty/django-42"),
-		Stable: true,
-		Edge:   true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.EdgeChannel:   true,
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3581,8 +3591,10 @@ var publishTests = []struct {
 		URL: charm.MustParseURL("~who/django"),
 	},
 	expectedEntity: &mongodoc.Entity{
-		URL:    charm.MustParseURL("~who/trusty/django-42"),
-		Stable: true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3597,8 +3609,10 @@ var publishTests = []struct {
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
 	channels: []params.Channel{params.StableChannel},
 	initialEntity: &mongodoc.Entity{
-		URL:  charm.MustParseURL("~who/trusty/django-42"),
-		Edge: true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3609,9 +3623,11 @@ var publishTests = []struct {
 		},
 	},
 	expectedEntity: &mongodoc.Entity{
-		URL:    charm.MustParseURL("~who/trusty/django-42"),
-		Edge:   true,
-		Stable: true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.EdgeChannel:   true,
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3629,8 +3645,10 @@ var publishTests = []struct {
 	url:      MustParseResolvedURL("~who/trusty/django-42"),
 	channels: []params.Channel{params.StableChannel},
 	initialEntity: &mongodoc.Entity{
-		URL:    charm.MustParseURL("~who/trusty/django-42"),
-		Stable: true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.StableChannel: true,
+		},
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3641,8 +3659,10 @@ var publishTests = []struct {
 		},
 	},
 	expectedEntity: &mongodoc.Entity{
-		URL:    charm.MustParseURL("~who/trusty/django-42"),
-		Stable: true,
+		URL: charm.MustParseURL("~who/trusty/django-42"),
+		Published: map[params.Channel]bool{
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3666,7 +3686,9 @@ var publishTests = []struct {
 	expectedEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"trusty", "wily"},
-		Edge:            true,
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3682,8 +3704,10 @@ var publishTests = []struct {
 	url:      MustParseResolvedURL("~who/django-42"),
 	channels: []params.Channel{params.EdgeChannel},
 	initialEntity: &mongodoc.Entity{
-		URL:             charm.MustParseURL("~who/django-42"),
-		Edge:            true,
+		URL: charm.MustParseURL("~who/django-42"),
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 		SupportedSeries: []string{"trusty", "wily"},
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
@@ -3696,8 +3720,10 @@ var publishTests = []struct {
 		},
 	},
 	expectedEntity: &mongodoc.Entity{
-		URL:             charm.MustParseURL("~who/django-42"),
-		Edge:            true,
+		URL: charm.MustParseURL("~who/django-42"),
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 		SupportedSeries: []string{"trusty", "wily"},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
@@ -3717,7 +3743,9 @@ var publishTests = []struct {
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-47"),
 		SupportedSeries: []string{"trusty", "wily", "precise"},
-		Stable:          true,
+		Published: map[params.Channel]bool{
+			params.StableChannel: true,
+		},
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3730,8 +3758,10 @@ var publishTests = []struct {
 	expectedEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-47"),
 		SupportedSeries: []string{"trusty", "wily", "precise"},
-		Stable:          true,
-		Edge:            true,
+		Published: map[params.Channel]bool{
+			params.EdgeChannel:   true,
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3760,7 +3790,9 @@ var publishTests = []struct {
 	expectedEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"trusty", "wily", "precise"},
-		Stable:          true,
+		Published: map[params.Channel]bool{
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3779,7 +3811,9 @@ var publishTests = []struct {
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"wily"},
-		Edge:            true,
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3792,8 +3826,10 @@ var publishTests = []struct {
 	expectedEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"wily"},
-		Edge:            true,
-		Stable:          true,
+		Published: map[params.Channel]bool{
+			params.EdgeChannel:   true,
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3813,7 +3849,9 @@ var publishTests = []struct {
 	initialEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"trusty", "wily", "precise"},
-		Stable:          true,
+		Published: map[params.Channel]bool{
+			params.StableChannel: true,
+		},
 	},
 	initialBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3829,7 +3867,9 @@ var publishTests = []struct {
 	expectedEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"trusty", "wily", "precise"},
-		Stable:          true,
+		Published: map[params.Channel]bool{
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3854,8 +3894,10 @@ var publishTests = []struct {
 		URL: charm.MustParseURL("~who/django"),
 	},
 	expectedEntity: &mongodoc.Entity{
-		URL:    charm.MustParseURL("~who/bundle/django-42"),
-		Stable: true,
+		URL: charm.MustParseURL("~who/bundle/django-42"),
+		Published: map[params.Channel]bool{
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),
@@ -3888,8 +3930,10 @@ var publishTests = []struct {
 	expectedEntity: &mongodoc.Entity{
 		URL:             charm.MustParseURL("~who/django-42"),
 		SupportedSeries: []string{"trusty", "wily"},
-		Edge:            true,
-		Stable:          true,
+		Published: map[params.Channel]bool{
+			params.EdgeChannel:   true,
+			params.StableChannel: true,
+		},
 	},
 	expectedBaseEntity: &mongodoc.BaseEntity{
 		URL: charm.MustParseURL("~who/django"),

--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -136,15 +136,8 @@ type Entity struct {
 	// If the entity is not promulgated this should be set to -1.
 	PromulgatedRevision int `bson:"promulgated-revision"`
 
-	// TODO we could potentially use map[params.Channel] bool
-	// instead of having a separate field for each channel.
-
-	// Edge holds whether the entity has been published in the "edge" channel.
-	Edge bool
-
-	// Stable holds whether the entity has been published in the
-	// "stable" channel.
-	Stable bool
+	// Published holds whether the entity has been published on a channel.
+	Published map[params.Channel]bool `json:",omitempty" bson:",omitempty"`
 }
 
 // PreferredURL returns the preferred way to refer to this entity. If

--- a/internal/mongodoc/doc_test.go
+++ b/internal/mongodoc/doc_test.go
@@ -7,6 +7,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2/bson"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
@@ -77,14 +78,18 @@ var preferredURLTests = []struct {
 	entity: &mongodoc.Entity{
 		URL:            charm.MustParseURL("~dmr/trusty/c-1"),
 		PromulgatedURL: charm.MustParseURL("trusty/c-2"),
-		Edge:           true,
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 	},
 	expectURLFalse: "cs:~dmr/trusty/c-1",
 	expectURLTrue:  "cs:trusty/c-2",
 }, {
 	entity: &mongodoc.Entity{
-		URL:  charm.MustParseURL("~dmr/trusty/c-1"),
-		Edge: true,
+		URL: charm.MustParseURL("~dmr/trusty/c-1"),
+		Published: map[params.Channel]bool{
+			params.EdgeChannel: true,
+		},
 	},
 	expectURLFalse: "cs:~dmr/trusty/c-1",
 	expectURLTrue:  "cs:~dmr/trusty/c-1",

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -95,7 +95,7 @@ func (h *Handler) NewReqHandler(req *http.Request) (ReqHandler, error) {
 	// TODO Why is the v4 API accepting a channel parameter anyway? We
 	// should probably always use "stable".
 	for _, ch := range req.Form["channel"] {
-		if !v5.ValidChannels[params.Channel(ch)] {
+		if !charmstore.ValidChannels[params.Channel(ch)] {
 			return ReqHandler{}, badRequestf(nil, "invalid channel %q specified in request", ch)
 		}
 	}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -3357,9 +3357,9 @@ func entityACLs(store *charmstore.Store, url *router.ResolvedURL) (mongodoc.ACL,
 		return mongodoc.ACL{}, err
 	}
 	ch := params.UnpublishedChannel
-	if e.Stable {
+	if e.Published[params.StableChannel] {
 		ch = params.StableChannel
-	} else if e.Edge {
+	} else if e.Published[params.EdgeChannel] {
 		ch = params.EdgeChannel
 	}
 	return be.ChannelACLs[ch], nil

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -928,7 +928,7 @@ func (s *ArchiveSuite) assertUpload(c *gc.C, method string, url *router.Resolved
 	c.Assert(entity.PreV5BlobSize, gc.Not(gc.Equals), int64(0))
 
 	c.Assert(entity.PromulgatedURL, gc.DeepEquals, url.PromulgatedURL())
-	c.Assert(entity.Edge, gc.Equals, false)
+	c.Assert(entity.Published, gc.IsNil)
 
 	return expectId, entity.PreV5BlobSize
 }

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -2958,7 +2958,7 @@ var publishErrorsTests = []struct {
 	}),
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
-		Message: `cannot publish to "bad"`,
+		Message: `unrecognized channel "bad"`,
 		Code:    params.ErrBadRequest,
 	},
 }, {
@@ -2970,7 +2970,7 @@ var publishErrorsTests = []struct {
 	}),
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
-		Message: `cannot publish to ""`,
+		Message: `cannot publish to an empty channel`,
 		Code:    params.ErrBadRequest,
 	},
 }, {
@@ -2982,7 +2982,7 @@ var publishErrorsTests = []struct {
 	}),
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
-		Message: `cannot publish to "unpublished"`,
+		Message: `cannot publish to the unpublished channel`,
 		Code:    params.ErrBadRequest,
 	},
 }, {
@@ -4093,9 +4093,9 @@ func entityACLs(store *charmstore.Store, url *router.ResolvedURL) (mongodoc.ACL,
 		return mongodoc.ACL{}, err
 	}
 	ch := params.UnpublishedChannel
-	if e.Stable {
+	if e.Published[params.StableChannel] {
 		ch = params.StableChannel
-	} else if e.Edge {
+	} else if e.Published[params.EdgeChannel] {
 		ch = params.EdgeChannel
 	}
 	return be.ChannelACLs[ch], nil

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -248,7 +248,7 @@ func (h *ReqHandler) servePutArchive(id *charm.URL, w http.ResponseWriter, req *
 	var chans []params.Channel
 	for _, c := range req.Form["channel"] {
 		c := params.Channel(c)
-		if c != params.EdgeChannel && c != params.StableChannel {
+		if !charmstore.ValidChannels[c] || c == params.UnpublishedChannel {
 			return badRequestf(nil, "cannot put entity into channel %q", c)
 		}
 		chans = append(chans, c)

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -1045,12 +1045,7 @@ func (s *commonArchiveSuite) assertUpload(c *gc.C, p uploadParams) (id *charm.UR
 	for _, ch := range p.chans {
 		expectChans[ch] = true
 	}
-
-	for _, ch := range []params.Channel{
-		params.UnpublishedChannel,
-		params.EdgeChannel,
-		params.StableChannel,
-	} {
+	for _, ch := range charmstore.OrderedChannels {
 		_, err := s.store.FindBestEntity(&p.id.URL, ch, nil)
 		if expectChans[ch] {
 			c.Assert(err, gc.IsNil)
@@ -1067,8 +1062,13 @@ func (s *commonArchiveSuite) assertUpload(c *gc.C, p uploadParams) (id *charm.UR
 		c.Assert(entity.BlobHash256, gc.Equals, hash256Sum)
 	}
 	c.Assert(entity.PromulgatedURL, gc.DeepEquals, p.id.PromulgatedURL())
-	c.Assert(entity.Edge, gc.Equals, expectChans[params.EdgeChannel])
-	c.Assert(entity.Stable, gc.Equals, expectChans[params.StableChannel])
+
+	delete(expectChans, params.UnpublishedChannel)
+	if len(expectChans) == 0 {
+		c.Assert(entity.Published, gc.IsNil)
+	} else {
+		c.Assert(entity.Published, gc.DeepEquals, expectChans)
+	}
 
 	// Test that the expected entry has been created
 	// in the blob store.


### PR DESCRIPTION
Replace the Stable and Edge fields: this scales better in preparation for adding two additional channels.
The corresponding migration is implemented in the branch.

Also refactor the code so that there is a single point where the list of channels is defined, in order.
