### PR TITLE
Remove uses of  charm.URL.Channel

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -32,7 +32,7 @@ golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:0
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
-gopkg.in/juju/charm.v6-unstable	git	a3bb92d047b0892452b6a39ece59b4d3a2ac35b9	2016-07-22T08:34:31Z
+gopkg.in/juju/charm.v6-unstable	git	e62786fbece4c6a74945d0d1d19140a69018c07d	2016-09-16T08:55:15Z
 gopkg.in/juju/charmrepo.v2-unstable	git	d8b2fa48bbfa115906b42405eced0c9871a09e13	2016-08-09T13:37:26Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
 gopkg.in/juju/names.v2	git	e38bc90539f22af61a9c656d35068bd5f0a5b30a	2016-05-25T23:07:23Z

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -925,7 +925,7 @@ func MustParseResolvedURL(urlStr string) *router.ResolvedURL {
 		panic("resolved URL with no revision")
 	}
 	return &router.ResolvedURL{
-		URL:                 *url.WithChannel(""),
+		URL:                 *url,
 		PromulgatedRevision: promRev,
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -893,8 +893,5 @@ func parseURL(s string) (*charm.URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	if u.Channel != "" {
-		return nil, errgo.Newf("charmstore ids must not contain a channel")
-	}
 	return u, nil
 }

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -671,7 +671,7 @@ func mustParseResolvedURL(urlStr string) *router.ResolvedURL {
 		panic(fmt.Sprintf("resolved URL %q does not contain user", urlStr))
 	}
 	return &router.ResolvedURL{
-		URL:                 *url.WithChannel(""),
+		URL:                 *url,
 		PromulgatedRevision: promRev,
 	}
 }

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -183,9 +183,7 @@ func (h *ReqHandler) servePostArchive(id *charm.URL, w http.ResponseWriter, req 
 			PromulgatedId: oldURL.PromulgatedURL(),
 		})
 	}
-	rid := &router.ResolvedURL{
-		URL: *id.WithChannel(""),
-	}
+	rid := &router.ResolvedURL{URL: *id}
 	// Choose the next revision number for the upload.
 	if oldURL == nil {
 		rid.URL.Revision = 0
@@ -254,7 +252,7 @@ func (h *ReqHandler) servePutArchive(id *charm.URL, w http.ResponseWriter, req *
 		chans = append(chans, c)
 	}
 	rid := &router.ResolvedURL{
-		URL:                 *id.WithChannel(""),
+		URL:                 *id,
 		PromulgatedRevision: -1,
 	}
 	// Get the PromulgatedURL from the request parameters. When ingesting

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -700,7 +700,7 @@ func mustParseResolvedURL(urlStr string) *router.ResolvedURL {
 		panic(fmt.Sprintf("resolved URL %q does not contain user", urlStr))
 	}
 	return &router.ResolvedURL{
-		URL:                 *url.WithChannel(""),
+		URL:                 *url,
 		PromulgatedRevision: promRev,
 	}
 }


### PR DESCRIPTION
This has been removed from charm.URL in the process of implementing http://pad.lv/1584193.

The only uses were checking that the url had no channel or removing the channel from a url.

Updated charm.v6-unstable dependency. This is arguably unnecessary, but it's safer - otherwise someone could pass in a charm url with a channel and this code would no longer strip it out.
