### PR TITLE
internal: add zesty to series

### DIFF
--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -143,7 +143,7 @@ var searchEntities = map[string]searchEntity{
 	},
 	// Note: "squid-forwardproxy" shares a trigram "dpr" with "wordpress".
 	"squid-forwardproxy": {
-		entity:    newEntity("cs:~charmers/wily/squid-forwardproxy-3", 3),
+		entity:    newEntity("cs:~charmers/yakkety/squid-forwardproxy-3", 3),
 		charmMeta: &charm.Meta{},
 		acl:       []string{params.Everyone},
 		downloads: 2,
@@ -279,7 +279,7 @@ func (s *StoreSearchSuite) TestExportMultiSeriesCharmsCreateExpandedVersions(c *
 		[]string{"charmers"},
 		0,
 	)
-	charmArchive = storetesting.NewCharm(storetesting.MetaWithSupportedSeries(nil, "trusty", "xenial", "utopic", "vivid", "wily"))
+	charmArchive = storetesting.NewCharm(storetesting.MetaWithSupportedSeries(nil, "trusty", "xenial", "utopic", "vivid", "wily", "yakkety"))
 	url = router.MustNewResolvedURL("cs:~charmers/juju-gui-25", -1)
 	addCharmForSearch(
 		c,
@@ -844,17 +844,17 @@ func (s *StoreSearchSuite) TestSorting(c *gc.C) {
 			searchEntities["wordpress-simple"].entity,
 			searchEntities["wordpress"].entity,
 			searchEntities["cloud-controller-worker-v2"].entity,
-			searchEntities["squid-forwardproxy"].entity,
 			searchEntities["mysql"].entity,
 			searchEntities["varnish"].entity,
+			searchEntities["squid-forwardproxy"].entity,
 		},
 	}, {
 		about:     "series descending",
 		sortQuery: "-series,name",
 		results: Entities{
+			searchEntities["squid-forwardproxy"].entity,
 			searchEntities["mysql"].entity,
 			searchEntities["varnish"].entity,
-			searchEntities["squid-forwardproxy"].entity,
 			searchEntities["cloud-controller-worker-v2"].entity,
 			searchEntities["wordpress"].entity,
 			searchEntities["wordpress-simple"].entity,
@@ -1071,7 +1071,7 @@ func (s *StoreSearchSuite) TestUpdateConflict(c *gc.C) {
 }
 
 func (s *StoreSearchSuite) TestMultiSeriesCharmFiltersSeriesCorrectly(c *gc.C) {
-	charmArchive := storetesting.NewCharm(storetesting.MetaWithSupportedSeries(nil, "trusty", "xenial", "utopic", "vivid", "wily"))
+	charmArchive := storetesting.NewCharm(storetesting.MetaWithSupportedSeries(nil, "trusty", "xenial", "utopic", "vivid", "wily", "yakkety"))
 	url := router.MustNewResolvedURL("cs:~charmers/juju-gui-25", -1)
 	addCharmForSearch(
 		c,
@@ -1112,7 +1112,7 @@ func (s *StoreSearchSuite) TestMultiSeriesCharmFiltersSeriesCorrectly(c *gc.C) {
 }
 
 func (s *StoreSearchSuite) TestMultiSeriesCharmSortsSeriesCorrectly(c *gc.C) {
-	charmArchive := storetesting.NewCharm(storetesting.MetaWithSupportedSeries(nil, "trusty", "xenial", "utopic", "vivid", "wily"))
+	charmArchive := storetesting.NewCharm(storetesting.MetaWithSupportedSeries(nil, "trusty", "xenial", "utopic", "vivid", "wily", "yakkety"))
 	url := router.MustNewResolvedURL("cs:~charmers/juju-gui-25", -1)
 	addCharmForSearch(
 		c,
@@ -1128,10 +1128,10 @@ func (s *StoreSearchSuite) TestMultiSeriesCharmSortsSeriesCorrectly(c *gc.C) {
 	res, err := s.store.Search(sp)
 	c.Assert(err, gc.IsNil)
 	c.Assert(Entities(res.Results), jc.DeepEquals, Entities{
-		newEntity("cs:~charmers/juju-gui-25", -1, "trusty", "xenial", "utopic", "vivid", "wily"),
+		newEntity("cs:~charmers/yakkety/squid-forwardproxy-3", 3),
+		newEntity("cs:~charmers/juju-gui-25", -1, "trusty", "xenial", "utopic", "vivid", "wily", "yakkety"),
 		newEntity("cs:~foo/xenial/varnish-1", -1),
 		newEntity("cs:~openstack-charmers/xenial/mysql-7", 7),
-		newEntity("cs:~charmers/wily/squid-forwardproxy-3", 3),
 		searchEntities["cloud-controller-worker-v2"].entity,
 		newEntity("cs:~charmers/precise/wordpress-23", 23),
 		newEntity("cs:~charmers/bundle/wordpress-simple-4", 4),

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -644,6 +644,7 @@ var seriesScore = map[string]int{
 	"vivid":   5,
 	"wily":    6,
 	"yakkety": 7,
+	"zesty":   0, // TODO(mhilton) make this higher when zesty is released
 	// When we find a multi-series charm (no series) we
 	// will always choose it in preference to a series-specific
 	// charm

--- a/internal/series/series.go
+++ b/internal/series/series.go
@@ -47,9 +47,10 @@ var Series = map[string]SeriesInfo{
 	"trusty":  {true, Ubuntu, true, 1.125},
 	"utopic":  {true, Ubuntu, false, 0},
 	"vivid":   {true, Ubuntu, false, 0},
-	"wily":    {true, Ubuntu, true, 1.102},
+	"wily":    {true, Ubuntu, false, 1.102},
 	"xenial":  {true, Ubuntu, true, 1.1375},
 	"yakkety": {true, Ubuntu, true, 1.103},
+	"zesty":   {true, Ubuntu, true, 1.104},
 
 	// Windows
 	"win2012hvr2": {true, Windows, true, 1.1},

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1453,7 +1453,7 @@ func (s *ArchiveSearchSuite) TestGetSearchUpdate(c *gc.C) {
 		c.Skip("MongoDB JavaScript not available")
 	}
 
-	for i, id := range []string{"~charmers/wily/mysql-42", "~who/wily/mysql-42"} {
+	for i, id := range []string{"~charmers/yakkety/mysql-42", "~who/yakkety/mysql-42"} {
 		c.Logf("test %d: %s", i, id)
 		url := newResolvedURL(id, -1)
 

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -1653,7 +1653,7 @@ func (s *ArchiveSearchSuite) TestGetSearchUpdate(c *gc.C) {
 		c.Skip("MongoDB JavaScript not available")
 	}
 
-	for i, id := range []string{"~charmers/wily/mysql-42", "~who/wily/mysql-42"} {
+	for i, id := range []string{"~charmers/yakkety/mysql-42", "~who/yakkety/mysql-42"} {
 		c.Logf("test %d: %s", i, id)
 		url := newResolvedURL(id, -1)
 


### PR DESCRIPTION
Add "zesty" to the lists of series and remove the now unsupported "wily" from search results.
