### PR TITLE
internal/v[45]: return error from handler functions

### DIFF
--- a/internal/charmstore/migrations_integration_test.go
+++ b/internal/charmstore/migrations_integration_test.go
@@ -702,8 +702,8 @@ func checkBaseEntityInvariants(c *gc.C, e *mongodoc.BaseEntity, store *Store) {
 // runMigrations starts a new server which will cause all migrations
 // to be triggered.
 func (s *migrationsIntegrationSuite) runMigrations(db *mgo.Database) error {
-	apiHandler := func(p *Pool, config ServerParams, _ string) HTTPCloseHandler {
-		return nopCloseHandler{http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})}
+	apiHandler := func(p *Pool, config ServerParams, _ string) (HTTPCloseHandler, error) {
+		return nopCloseHandler{http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})}, nil
 	}
 	srv, err := NewServer(db, nil, serverParams, map[string]NewAPIHandlerFunc{
 		"version1": apiHandler,

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -30,8 +30,8 @@ func (s *migrationsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *migrationsSuite) newServer(c *gc.C) error {
-	apiHandler := func(p *Pool, config ServerParams, _ string) HTTPCloseHandler {
-		return nopCloseHandler{http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})}
+	apiHandler := func(p *Pool, config ServerParams, _ string) (HTTPCloseHandler, error) {
+		return nopCloseHandler{http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})}, nil
 	}
 	srv, err := NewServer(s.db.Database, nil, serverParams, map[string]NewAPIHandlerFunc{
 		"version1": apiHandler,

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -40,7 +40,7 @@ type versionResponse struct {
 func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	db := s.Session.DB("foo")
 	serveVersion := func(vers string) NewAPIHandlerFunc {
-		return func(p *Pool, config ServerParams, _ string) HTTPCloseHandler {
+		return func(p *Pool, config ServerParams, _ string) (HTTPCloseHandler, error) {
 			return nopCloseHandler{
 				router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 					return versionResponse{
@@ -48,7 +48,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 						Path:    req.URL.Path,
 					}, nil
 				}),
-			}
+			}, nil
 		}
 	}
 
@@ -99,12 +99,12 @@ func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
 		AuthPassword:     "test-password",
 		IdentityLocation: "http://0.1.2.3/",
 	}
-	serveConfig := func(p *Pool, config ServerParams, _ string) HTTPCloseHandler {
+	serveConfig := func(p *Pool, config ServerParams, _ string) (HTTPCloseHandler, error) {
 		return nopCloseHandler{
 			router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 				return config, nil
 			}),
-		}
+		}, nil
 	}
 	h, err := NewServer(s.Session.DB("foo"), nil, params, map[string]NewAPIHandlerFunc{
 		"version1": serveConfig,
@@ -136,12 +136,12 @@ func (s *ServerSuite) TestNewServerWithElasticSearch(c *gc.C) {
 		AuthPassword:   "test-password",
 		IdentityAPIURL: "http://0.1.2.3",
 	}
-	serveConfig := func(p *Pool, config ServerParams, _ string) HTTPCloseHandler {
+	serveConfig := func(p *Pool, config ServerParams, _ string) (HTTPCloseHandler, error) {
 		return nopCloseHandler{
 			router.HandleJSON(func(_ http.Header, req *http.Request) (interface{}, error) {
 				return config, nil
 			}),
-		}
+		}, nil
 	}
 	h, err := NewServer(s.Session.DB("foo"), &SearchIndex{s.ES, s.TestIndex}, params,
 		map[string]NewAPIHandlerFunc{

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -103,10 +103,14 @@ var reqHandlerPool = mempool.Pool{
 	},
 }
 
-func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string) charmstore.HTTPCloseHandler {
-	return &Handler{
-		v4: v4.New(pool, config, rootPath),
+func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string) (charmstore.HTTPCloseHandler, error) {
+	h, err := v4.New(pool, config, rootPath)
+	if err != nil {
+		return nil, errgo.Mask(err)
 	}
+	return &Handler{
+		v4: h,
+	}, nil
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -43,10 +43,14 @@ type ReqHandler struct {
 	*v5.ReqHandler
 }
 
-func New(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string) Handler {
-	return Handler{
-		Handler: v5.New(pool, config, rootPath),
+func New(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string) (Handler, error) {
+	h, err := v5.New(pool, config, rootPath)
+	if err != nil {
+		return Handler{}, errgo.Mask(err)
 	}
+	return Handler{
+		Handler: h,
+	}, nil
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -60,8 +64,12 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	rh.ServeHTTP(w, req)
 }
 
-func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string) charmstore.HTTPCloseHandler {
-	return New(pool, config, rootPath)
+func NewAPIHandler(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string) (charmstore.HTTPCloseHandler, error) {
+	h, err := New(pool, config, rootPath)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return h, nil
 }
 
 // The v4 resolvedURL function also requires SupportedSeries.

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -234,7 +234,8 @@ func (s *commonSuite) setPerms(c *gc.C, readACLs map[string][]string) {
 // used to invoke private methods. The caller
 // is responsible for calling Put on the returned handler.
 func (s *commonSuite) handler(c *gc.C) v4.ReqHandler {
-	h := v4.New(s.store.Pool(), s.srvParams, "")
+	h, err := v4.New(s.store.Pool(), s.srvParams, "")
+	c.Assert(err, gc.IsNil)
 	defer h.Close()
 	rh, err := h.NewReqHandler(new(http.Request))
 	c.Assert(err, gc.IsNil)

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -270,7 +270,8 @@ func (s *commonSuite) setPerms(c *gc.C, readACLs map[string][]string) {
 // used to invoke private methods. The caller
 // is responsible for calling Put on the returned handler.
 func (s *commonSuite) handler(c *gc.C) *v5.ReqHandler {
-	h := v5.New(s.store.Pool(), s.srvParams, "")
+	h, err := v5.New(s.store.Pool(), s.srvParams, "")
+	c.Assert(err, gc.IsNil)
 	defer h.Close()
 	rh, err := h.NewReqHandler(new(http.Request))
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
This means we can avoid the unlikely but possible panic
when creating an identity client.