### PR TITLE
internal/monitoring: coarser grained request monitoring

### DIFF
--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -121,6 +121,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	defer rh.close()
+	rh.v4.Router.Monitor.Reset(req.Method, "legacy")
+	defer rh.v4.Router.Monitor.Done()
 	rh.mux.ServeHTTP(w, req)
 }
 
@@ -183,6 +185,7 @@ func charmStatsKey(url *charm.URL, kind string) []string {
 var errNotFound = fmt.Errorf("entry not found")
 
 func (h *reqHandler) serveCharmInfo(_ http.Header, req *http.Request) (interface{}, error) {
+	h.v4.Router.Monitor.SetKind("charm-info")
 	response := make(map[string]*charmrepo.InfoResponse)
 	for _, url := range req.Form["charms"] {
 		c := &charmrepo.InfoResponse{}
@@ -238,6 +241,7 @@ func (h *reqHandler) serveCharmInfo(_ http.Header, req *http.Request) (interface
 // "charms" query. In this implementation, the only supported event is
 // "published", required by the "juju publish" command.
 func (h *reqHandler) serveCharmEvent(_ http.Header, req *http.Request) (interface{}, error) {
+	h.v4.Router.Monitor.SetKind("charm-event")
 	response := make(map[string]*charmrepo.EventResponse)
 	for _, url := range req.Form["charms"] {
 		c := &charmrepo.EventResponse{}

--- a/internal/monitoring/monitoring.go
+++ b/internal/monitoring/monitoring.go
@@ -12,7 +12,7 @@ var (
 		Subsystem: "handler",
 		Name:      "request_duration",
 		Help:      "The duration of a web request in seconds.",
-	}, []string{"path_pattern"})
+	}, []string{"method", "root", "kind"})
 	uploadProcessingDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "charmstore",
 		Subsystem: "archive",

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -47,7 +47,7 @@ var routerGetTests = []struct {
 	resolveURL                func(*charm.URL) (*ResolvedURL, error)
 	authorize                 func(*ResolvedURL, *http.Request) error
 	exists                    func(*ResolvedURL, *http.Request) (bool, error)
-	monitorLabel              string
+	monitorKind               string
 }{{
 	about: "global handler",
 	handlers: Handlers{
@@ -67,7 +67,7 @@ var routerGetTests = []struct {
 		Method: "GET",
 		Path:   "",
 	},
-	monitorLabel: "/foo",
+	monitorKind: "foo",
 }, {
 	about: "global handler with sub-path and flags",
 	handlers: Handlers{
@@ -91,7 +91,7 @@ var routerGetTests = []struct {
 			"b": {"two"},
 		},
 	},
-	monitorLabel: "/foo/bar",
+	monitorKind: "foo/bar/",
 }, {
 	about:        "invalid form",
 	urlStr:       "/foo?a=%",
@@ -112,7 +112,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:precise/wordpress-34",
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "development id handler",
 	handlers: Handlers{
@@ -152,7 +152,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:win81/visualstudio-2012",
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "wily id handler",
 	handlers: Handlers{
@@ -166,7 +166,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:wily/wordpress-34",
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "id handler with no series in id",
 	handlers: Handlers{
@@ -180,7 +180,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:wordpress-34",
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "id handler with no revision in id",
 	handlers: Handlers{
@@ -194,7 +194,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:precise/wordpress",
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "id handler with channel and name only",
 	handlers: Handlers{
@@ -222,7 +222,7 @@ var routerGetTests = []struct {
 		CharmURL: "cs:precise/wordpress-34",
 		Path:     "/blah/arble",
 	},
-	monitorLabel: "/:id/foo//blah/arble",
+	monitorKind: "foo/",
 }, {
 	about: "id handler with allowed extra path but none given",
 	handlers: Handlers{
@@ -262,7 +262,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:~joe/precise/wordpress-34",
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "wily handler with user",
 	handlers: Handlers{
@@ -276,7 +276,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:~joe/wily/wordpress-34",
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "id handler with user and extra path",
 	handlers: Handlers{
@@ -291,7 +291,7 @@ var routerGetTests = []struct {
 		CharmURL: "cs:~joe/precise/wordpress-34",
 		Path:     "/blah/arble",
 	},
-	monitorLabel: "/:id/foo//blah/arble",
+	monitorKind: "foo/",
 }, {
 	about: "development id handler with user and extra path",
 	handlers: Handlers{
@@ -330,7 +330,7 @@ var routerGetTests = []struct {
 	expectBody: params.Error{
 		Message: "errorIdHandler error",
 	},
-	monitorLabel: "/:id/foo//blah/arble",
+	monitorKind: "foo/",
 }, {
 	about: "id handler that returns a not-found error",
 	handlers: Handlers{
@@ -346,7 +346,7 @@ var routerGetTests = []struct {
 		Message: "not found",
 		Code:    params.ErrNotFound,
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "id handler that returns some other kind of coded error",
 	handlers: Handlers{
@@ -362,7 +362,7 @@ var routerGetTests = []struct {
 		Message: "a message",
 		Code:    "foo",
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "id with unspecified series and revision, not resolved",
 	handlers: Handlers{
@@ -377,7 +377,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:~joe/wordpress",
 	},
-	monitorLabel: "/:id/foo",
+	monitorKind: "foo",
 }, {
 	about: "id with error on resolving",
 	handlers: Handlers{
@@ -419,7 +419,7 @@ var routerGetTests = []struct {
 	urlStr:       "/precise/wordpress-42/meta",
 	expectStatus: http.StatusOK,
 	expectBody:   []string{"bar", "baz", "foo"},
-	monitorLabel: ":id/meta",
+	monitorKind:  "meta",
 }, {
 	about: "meta list at root",
 	handlers: Handlers{
@@ -434,7 +434,7 @@ var routerGetTests = []struct {
 	urlStr:       "/meta",
 	expectStatus: http.StatusOK,
 	expectBody:   []string{"bar", "baz", "foo"},
-	monitorLabel: "/meta",
+	monitorKind:  "meta",
 }, {
 	about: "meta list at root with trailing /",
 	handlers: Handlers{
@@ -449,7 +449,7 @@ var routerGetTests = []struct {
 	urlStr:       "/meta/",
 	expectStatus: http.StatusOK,
 	expectBody:   []string{"bar", "baz", "foo"},
-	monitorLabel: "/meta",
+	monitorKind:  "meta",
 }, {
 	about: "meta handler",
 	handlers: Handlers{
@@ -463,7 +463,7 @@ var routerGetTests = []struct {
 	expectBody: &metaHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-42",
 	},
-	monitorLabel: "/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about: "meta handler with additional elements",
 	handlers: Handlers{
@@ -478,7 +478,7 @@ var routerGetTests = []struct {
 		CharmURL: "cs:precise/wordpress-42",
 		Path:     "/bar/baz",
 	},
-	monitorLabel: "/:meta/foo//bar/baz",
+	monitorKind: "meta",
 }, {
 	about: "meta handler with params",
 	handlers: Handlers{
@@ -496,7 +496,7 @@ var routerGetTests = []struct {
 			"two": {"b"},
 		},
 	},
-	monitorLabel: "/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:  "meta handler that's not found",
 	urlStr: "/precise/wordpress-42/meta/foo",
@@ -506,7 +506,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrNotFound,
 		Message: `unknown metadata "foo"`,
 	},
-	monitorLabel: "/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:  "meta sub-handler that's not found",
 	urlStr: "/precise/wordpress-42/meta/foo/bar",
@@ -516,7 +516,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrNotFound,
 		Message: `unknown metadata "foo/bar"`,
 	},
-	monitorLabel: "/:meta/foo//bar",
+	monitorKind: "meta",
 }, {
 	about: "meta handler with nil data",
 	handlers: Handlers{
@@ -531,7 +531,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrMetadataNotFound,
 		Message: "metadata not found",
 	},
-	monitorLabel: "/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about: "meta handler with typed nil data",
 	handlers: Handlers{
@@ -546,7 +546,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrMetadataNotFound,
 		Message: "metadata not found",
 	},
-	monitorLabel: "/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:  "meta handler with field selector",
 	urlStr: "/precise/wordpress-42/meta/foo",
@@ -566,7 +566,7 @@ var routerGetTests = []struct {
 		},
 		Id: newResolvedURL("cs:~charmers/precise/wordpress-42", 42),
 	},
-	monitorLabel: "/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:  "meta handler returning error with code",
 	urlStr: "/precise/wordpress-42/meta/foo",
@@ -581,7 +581,7 @@ var routerGetTests = []struct {
 		Code:    "arble",
 		Message: "a message",
 	},
-	monitorLabel: "/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:  "unauthorized meta handler",
 	urlStr: "/precise/wordpress-42/meta/foo",
@@ -604,7 +604,7 @@ var routerGetTests = []struct {
 	expectBody: params.MetaAnyResponse{
 		Id: charm.MustParseURL("cs:precise/wordpress-42"),
 	},
-	monitorLabel: "/:meta/any",
+	monitorKind: "meta",
 }, {
 	about:        "meta/any, no includes, id does not exist",
 	urlStr:       "/precise/wordpress/meta/any",
@@ -656,7 +656,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorLabel: "/:meta/any",
+	monitorKind: "meta",
 }, {
 	about:  "meta/any, includes with additional path elements",
 	urlStr: "/precise/wordpress-42/meta/any?include=item1/foo&include=item2/bar&include=item1",
@@ -701,7 +701,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorLabel: "/:meta/any",
+	monitorKind: "meta",
 }, {
 	about:  "meta/any, nil metadata omitted",
 	urlStr: "/precise/wordpress-42/meta/any?include=ok&include=nil",
@@ -722,7 +722,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorLabel: "/:meta/any",
+	monitorKind: "meta",
 }, {
 	about:  "meta/any, handler returns error with cause",
 	urlStr: "/precise/wordpress-42/meta/any?include=error",
@@ -737,7 +737,7 @@ var routerGetTests = []struct {
 		Code:    "foo",
 		Message: "a message",
 	},
-	monitorLabel: "/:meta/any",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler, single id",
 	urlStr: "/meta/foo?id=precise/wordpress-42",
@@ -753,7 +753,7 @@ var routerGetTests = []struct {
 			CharmURL: "cs:precise/wordpress-42",
 		},
 	},
-	monitorLabel: "/meta/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler, single id with invalid channel",
 	urlStr: "/meta/foo?id=~user/bad-wolf/wily/wordpress-42",
@@ -768,7 +768,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: `bad request: charm or bundle URL has invalid form: "~user/bad-wolf/wily/wordpress-42"`,
 	},
-	monitorLabel: "/meta",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler, several ids",
 	urlStr: "/meta/foo?id=precise/wordpress-42&id=utopic/foo-32&id=django",
@@ -790,7 +790,7 @@ var routerGetTests = []struct {
 			CharmURL: "cs:precise/django-0",
 		},
 	},
-	monitorLabel: "/meta/:meta/foo/:meta/foo/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta/any handler, several ids",
 	urlStr: "/meta/any?id=precise/wordpress-42&id=utopic/foo-32&id=django-47&include=foo&include=bar/something",
@@ -840,7 +840,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorLabel: "/meta/:meta/any/:meta/any/:meta/any",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta/any handler, several ids, invalid channel",
 	urlStr: "/meta/any?id=precise/wordpress-42&id=staging/trusty/django&include=foo&include=bar/something",
@@ -856,7 +856,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: `bad request: charm or bundle URL has invalid form: "staging/trusty/django"`,
 	},
-	monitorLabel: "/meta",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta/any handler, discharge required",
 	urlStr: "/meta/any?id=precise/wordpress-42&include=foo",
@@ -871,7 +871,7 @@ var routerGetTests = []struct {
 	expectBody: params.Error{
 		Message: "discharge required",
 	},
-	monitorLabel: "/meta",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta/any handler, discharge required, ignore authorization",
 	urlStr: "/meta/any?id=precise/wordpress-42&include=foo&ignore-auth=1",
@@ -884,7 +884,7 @@ var routerGetTests = []struct {
 	expectWillIncludeMetadata: []string{"foo"},
 	expectStatus:              http.StatusOK,
 	expectBody:                map[string]params.MetaAnyResponse{},
-	monitorLabel:              "/meta",
+	monitorKind:               "meta",
 }, {
 	about:  "bulk meta/any handler, some unauthorized, ignore authorization",
 	urlStr: "/meta/any?id=precise/wordpress-42&id=utopic/foo-32&include=foo&ignore-auth=1",
@@ -906,7 +906,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorLabel: "/meta/:meta/any",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta/any handler, unauthorized",
 	urlStr: "/meta/any?id=precise/wordpress-42&include=foo",
@@ -921,7 +921,7 @@ var routerGetTests = []struct {
 	expectBody: params.Error{
 		Message: "bad wolf",
 	},
-	monitorLabel: "/meta",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta/any handler, unauthorized, ignore authorization",
 	urlStr: "/meta/any?id=precise/wordpress-42&include=foo&ignore-auth=1",
@@ -934,7 +934,7 @@ var routerGetTests = []struct {
 	expectWillIncludeMetadata: []string{"foo"},
 	expectStatus:              http.StatusOK,
 	expectBody:                map[string]params.MetaAnyResponse{},
-	monitorLabel:              "/meta",
+	monitorKind:               "meta",
 }, {
 	about:        "bulk meta/any handler, invalid ignore-auth flag",
 	urlStr:       "/meta/any?id=precise/wordpress-42&include=foo&ignore-auth=meh",
@@ -943,7 +943,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: `bad request: unexpected bool value "meh" (must be "0" or "1")`,
 	},
-	monitorLabel: "/meta",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler with unresolved id",
 	urlStr: "/meta/foo/bar?id=wordpress",
@@ -961,7 +961,7 @@ var routerGetTests = []struct {
 			Path:     "/bar",
 		},
 	},
-	monitorLabel: "/meta/:meta/foo//bar",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler with extra flags",
 	urlStr: "/meta/foo/bar?id=wordpress&arble=bletch&z=w&z=p",
@@ -983,7 +983,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorLabel: "/meta/:meta/foo//bar",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler with no ids",
 	urlStr: "/meta/foo/bar",
@@ -997,7 +997,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: "no ids specified in meta request",
 	},
-	monitorLabel: "/meta",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler with unresolvable id",
 	urlStr: "/meta/foo?id=unresolved&id=~foo/precise/wordpress-23",
@@ -1019,7 +1019,7 @@ var routerGetTests = []struct {
 			CharmURL: "cs:precise/wordpress-99",
 		},
 	},
-	monitorLabel: "/meta/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler with id resolution error",
 	urlStr: "/meta/foo?id=resolveerror&id=precise/wordpress-23",
@@ -1039,7 +1039,7 @@ var routerGetTests = []struct {
 	expectBody: params.Error{
 		Message: "an error",
 	},
-	monitorLabel: "/meta",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler with some nil data",
 	urlStr: "/meta/foo?id=bundle/something-24&id=precise/wordpress-23",
@@ -1055,7 +1055,7 @@ var routerGetTests = []struct {
 	expectBody: map[string]string{
 		"bundle/something-24": "bundlefoo",
 	},
-	monitorLabel: "/meta/:meta/foo/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:  "bulk meta handler with entity not found",
 	urlStr: "/meta/foo?id=bundle/something-24&id=precise/wordpress-23",
@@ -1074,7 +1074,7 @@ var routerGetTests = []struct {
 	expectBody: map[string]string{
 		"bundle/something-24": "something",
 	},
-	monitorLabel: "/meta/:meta/foo/:meta/foo",
+	monitorKind: "meta",
 }, {
 	about:        "meta request with invalid entity reference",
 	urlStr:       "/robots.txt/meta/any",
@@ -1084,7 +1084,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrNotFound,
 		Message: `not found: URL has invalid charm or bundle name: "robots.txt"`,
 	},
-	monitorLabel: "",
+	monitorKind: "",
 }, {
 	about:                     "bulk meta handler, invalid id",
 	urlStr:                    "/meta/foo?id=robots.txt",
@@ -1095,7 +1095,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: `bad request: URL has invalid charm or bundle name: "robots.txt"`,
 	},
-	monitorLabel: "/meta",
+	monitorKind: "meta",
 }}
 
 // resolveTo returns a URL resolver that resolves
@@ -1176,7 +1176,7 @@ func (s *RouterSuite) TestRouterGet(c *gc.C) {
 		})
 		c.Assert(queryCount, gc.Equals, test.expectQueryCount)
 		c.Assert(includedMetadata, jc.DeepEquals, test.expectWillIncludeMetadata)
-		c.Assert(router.Monitor.Label(), gc.Equals, test.monitorLabel)
+		c.Assert(router.Monitor.Kind(), gc.Equals, test.monitorKind)
 	}
 }
 

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -60,7 +60,8 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	defer rh.Close()
-	rh.Router.Monitor.AppendLabel("/v4")
+	rh.Router.Monitor.Reset(req.Method, "v4")
+	defer rh.Router.Monitor.Done()
 	rh.ServeHTTP(w, req)
 }
 

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -323,8 +323,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	defer rh.Close()
-	rh.Router.Monitor.Reset()
-	rh.Router.Monitor.AppendLabel("/v5")
+	rh.Router.Monitor.Reset(req.Method, "v5")
+	defer rh.Router.Monitor.Done()
 	rh.ServeHTTP(w, req)
 }
 


### PR DESCRIPTION
As things were, we were monitoring requests with fairly detailed URL path
information in and this was causing a large number of summary histograms
to be created and hence taking a large amount of memory.

This changes the monitoring to use a coarser grained mechanism
that provides less information but does not allow clients to create
an arbitrary number of histograms.

We also make the Reset/ObserveMetric pairing more obvious,
fix what seems to be a bug where the v4 request monitor wasn't
reset, rename ObserveMetric to Done and add method information
to the request information.

The information recorded for a request now includes the
method, the root of the handler tree responsible for
serving the request, and some handler-specific information
about the request path. All metadata requests now appear
as "meta".