### PR TITLE
internal/blobstore: implement NewParts and PutPart

### DIFF
--- a/cmd/charmdelete/main.go
+++ b/cmd/charmdelete/main.go
@@ -121,13 +121,13 @@ func run(confPath string) error {
 }
 
 func deleteEntity(entity *mongodoc.Entity, store *charmstore.Store) {
-	err := store.BlobStore.Remove(entity.BlobName)
+	err := store.BlobStore.Remove(entity.BlobName, nil)
 	if err != nil {
 		logger.Errorf("could not remove blob for charm %s %s", entity.URL, err)
 	} else if *verbose {
 		fmt.Printf("deleted blob %s\n", entity.BlobName)
 	}
-	err = store.BlobStore.Remove(entity.BlobName + ".pre-v5-suffix")
+	err = store.BlobStore.Remove(entity.BlobName+".pre-v5-suffix", nil)
 	if err != nil {
 		logger.Errorf("could not remove .pre-v5-suffix blob for charm %s %s", entity.URL, err)
 	} else if *verbose {
@@ -136,7 +136,7 @@ func deleteEntity(entity *mongodoc.Entity, store *charmstore.Store) {
 
 	if entity.CharmMeta != nil && entity.CharmMeta.Resources != nil {
 		for _, r := range entity.CharmMeta.Resources {
-			err = store.BlobStore.Remove(r.Name)
+			err = store.BlobStore.Remove(r.Name, nil)
 			if err != nil {
 				logger.Errorf("could not remove %s resource blob for charm %s %s", r.Name, entity.URL, err)
 			} else if *verbose {

--- a/cmd/cshash256/main.go
+++ b/cmd/cshash256/main.go
@@ -94,7 +94,7 @@ func update(store *charmstore.Store) error {
 	counter := 0
 	for iter.Next(&entity) {
 		// Retrieve the archive contents.
-		r, _, err := store.BlobStore.Open(entity.BlobName)
+		r, _, err := store.BlobStore.Open(entity.BlobName, nil)
 		if err != nil {
 			return errgo.Notef(err, "cannot open archive data for %s", entity.URL)
 		}

--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -5,13 +5,10 @@ package blobstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/blobs
 
 import (
 	"crypto/sha512"
-	"fmt"
 	"hash"
 	"io"
-	"strconv"
 
 	"github.com/juju/blobstore"
-	"github.com/juju/errors"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2"
 )
@@ -22,63 +19,16 @@ type ReadSeekCloser interface {
 	io.Closer
 }
 
-// ContentChallengeError holds a proof-of-content
-// challenge produced by a blobstore.
-type ContentChallengeError struct {
-	Req ContentChallenge
-}
-
-func (e *ContentChallengeError) Error() string {
-	return "cannot upload because proof of content ownership is required"
-}
-
-// ContentChallenge holds a proof-of-content challenge
-// produced by a blobstore. A client can satisfy the request
-// by producing a ContentChallengeResponse containing
-// the same request id and a hash of RangeLength bytes
-// of the content starting at RangeStart.
-type ContentChallenge struct {
-	RequestId   string
-	RangeStart  int64
-	RangeLength int64
-}
-
-// ContentChallengeResponse holds a response to a ContentChallenge.
-type ContentChallengeResponse struct {
-	RequestId string
-	Hash      string
-}
-
 // NewHash is used to calculate checksums for the blob store.
 func NewHash() hash.Hash {
 	return sha512.New384()
 }
 
-// NewContentChallengeResponse can be used by a client to respond to a content
-// challenge. The returned value should be passed to BlobStorage.Put
-// when the client retries the request.
-func NewContentChallengeResponse(chal *ContentChallenge, r io.ReadSeeker) (*ContentChallengeResponse, error) {
-	_, err := r.Seek(chal.RangeStart, 0)
-	if err != nil {
-		return nil, errgo.Mask(err)
-	}
-	hash := NewHash()
-	nw, err := io.CopyN(hash, r, chal.RangeLength)
-	if err != nil {
-		return nil, errgo.Mask(err)
-	}
-	if nw != chal.RangeLength {
-		return nil, errgo.Newf("content is not long enough")
-	}
-	return &ContentChallengeResponse{
-		RequestId: chal.RequestId,
-		Hash:      fmt.Sprintf("%x", hash.Sum(nil)),
-	}, nil
-}
-
 // Store stores data blobs in mongodb, de-duplicating by
 // blob hash.
 type Store struct {
+	db     *mgo.Database
+	prefix string
 	mstore blobstore.ManagedStorage
 }
 
@@ -87,73 +37,38 @@ type Store struct {
 func New(db *mgo.Database, prefix string) *Store {
 	rs := blobstore.NewGridFS(db.Name, prefix, db.Session)
 	return &Store{
+		db:     db,
+		prefix: prefix,
 		mstore: blobstore.NewManagedStorage(db, rs),
 	}
 }
 
-func (s *Store) challengeResponse(resp *ContentChallengeResponse) error {
-	id, err := strconv.ParseInt(resp.RequestId, 10, 64)
-	if err != nil {
-		return errgo.Newf("invalid request id %q", id)
-	}
-	return s.mstore.ProofOfAccessResponse(blobstore.NewPutResponse(id, resp.Hash))
-}
-
-// Put tries to stream the content from the given reader into blob
+// Put streams the content from the given reader into blob
 // storage, with the provided name. The content should have the given
-// size and hash. If the content is already in the store, a
-// ContentChallengeError is returned containing a challenge that must be
-// satisfied by a client to prove that they have access to the content.
-// If the proof has already been acquired, it should be passed in as the
-// proof argument.
-func (s *Store) Put(r io.Reader, name string, size int64, hash string, proof *ContentChallengeResponse) (*ContentChallenge, error) {
-	if proof != nil {
-		err := s.challengeResponse(proof)
-		if err == nil {
-			return nil, nil
-		}
-		if err != blobstore.ErrResourceDeleted {
-			return nil, errgo.Mask(err)
-		}
-		// The blob has been deleted since the challenge
-		// was created, so continue on with uploading
-		// the content as if there was no previous challenge.
-	}
-	resp, err := s.mstore.PutForEnvironmentRequest("", name, hash)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			if err := s.mstore.PutForEnvironmentAndCheckHash("", name, r, size, hash); err != nil {
-				return nil, errgo.Mask(err)
-			}
-			return nil, nil
-		}
-		return nil, err
-	}
-	return &ContentChallenge{
-		RequestId:   fmt.Sprint(resp.RequestId),
-		RangeStart:  resp.RangeStart,
-		RangeLength: resp.RangeLength,
-	}, nil
-}
-
-// PutUnchallenged stream the content from the given reader into blob
-// storage, with the provided name. The content should have the given
-// size and hash. In this case a challenge is never returned and a proof
-// is not required.
-func (s *Store) PutUnchallenged(r io.Reader, name string, size int64, hash string) error {
+// size and hash.
+func (s *Store) Put(r io.Reader, name string, size int64, hash string) error {
 	return s.mstore.PutForEnvironmentAndCheckHash("", name, r, size, hash)
 }
 
 // Open opens the entry with the given name.
-func (s *Store) Open(name string) (ReadSeekCloser, int64, error) {
-	r, length, err := s.mstore.GetForEnvironment("", name)
-	if err != nil {
-		return nil, 0, errgo.Mask(err)
+func (s *Store) Open(name string, index *MultipartIndex) (ReadSeekCloser, int64, error) {
+	if index == nil {
+		r, length, err := s.mstore.GetForEnvironment("", name)
+		if err != nil {
+			return nil, 0, errgo.Mask(err)
+		}
+		return r.(ReadSeekCloser), length, nil
 	}
-	return r.(ReadSeekCloser), length, nil
+	return nil, 0, errgo.New("open of multipart blob not yet implemented")
+	// TODO
+	//	return &multipartReader{
+	//		store: s,
+	//		name: name,
+	//		index: index,
+	//	}
 }
 
 // Remove the given name from the Store.
-func (s *Store) Remove(name string) error {
+func (s *Store) Remove(name string, index *MultipartIndex) error {
 	return s.mstore.RemoveForEnvironment("", name)
 }

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -9,10 +9,14 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
 )
@@ -23,51 +27,26 @@ func TestPackage(t *testing.T) {
 
 type BlobStoreSuite struct {
 	jujutesting.IsolatedMgoSuite
+	store *blobstore.Store
 }
 
 var _ = gc.Suite(&BlobStoreSuite{})
 
-func (s *BlobStoreSuite) TestPutOpen(c *gc.C) {
-	store := blobstore.New(s.Session.DB("db"), "blobstore")
-	content := "some data"
-	chal, err := store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(chal, gc.IsNil)
-
-	rc, length, err := store.Open("x")
-	c.Assert(err, gc.IsNil)
-	defer rc.Close()
-	c.Assert(length, gc.Equals, int64(len(content)))
-
-	data, err := ioutil.ReadAll(rc)
-	c.Assert(err, gc.IsNil)
-	c.Assert(string(data), gc.Equals, content)
-
-	// Putting the resource again should generate a challenge.
-	chal, err = store.Put(strings.NewReader(content), "y", int64(len(content)), hashOf(content), nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(chal, gc.NotNil)
-
-	resp, err := blobstore.NewContentChallengeResponse(chal, strings.NewReader(content))
-	c.Assert(err, gc.IsNil)
-
-	chal, err = store.Put(strings.NewReader(content), "y", int64(len(content)), hashOf(content), resp)
-	c.Assert(err, gc.IsNil)
-	c.Assert(chal, gc.IsNil)
+func (s *BlobStoreSuite) SetUpTest(c *gc.C) {
+	s.IsolatedMgoSuite.SetUpTest(c)
+	s.store = blobstore.New(s.Session.DB("db"), "blobstore")
 }
 
 func (s *BlobStoreSuite) TestPutTwice(c *gc.C) {
-	store := blobstore.New(s.Session.DB("db"), "blobstore")
-
 	content := "some data"
-	err := store.PutUnchallenged(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
+	err := s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
 	c.Assert(err, gc.IsNil)
 
 	content = "some different data"
-	err = store.PutUnchallenged(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
+	err = s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
 	c.Assert(err, gc.IsNil)
 
-	rc, length, err := store.Open("x")
+	rc, length, err := s.store.Open("x", nil)
 	c.Assert(err, gc.IsNil)
 	defer rc.Close()
 	c.Assert(length, gc.Equals, int64(len(content)))
@@ -75,55 +54,38 @@ func (s *BlobStoreSuite) TestPutTwice(c *gc.C) {
 	data, err := ioutil.ReadAll(rc)
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(data), gc.Equals, content)
+}
+
+func (s *BlobStoreSuite) TestPut(c *gc.C) {
+	content := "some data"
+	err := s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
+	c.Assert(err, gc.IsNil)
+
+	rc, length, err := s.store.Open("x", nil)
+	c.Assert(err, gc.IsNil)
+	defer rc.Close()
+	c.Assert(length, gc.Equals, int64(len(content)))
+
+	data, err := ioutil.ReadAll(rc)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Equals, content)
+
+	err = s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
+	c.Assert(err, gc.IsNil)
 }
 
 func (s *BlobStoreSuite) TestPutInvalidHash(c *gc.C) {
-	store := blobstore.New(s.Session.DB("db"), "blobstore")
 	content := "some data"
-	chal, err := store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf("wrong"), nil)
-	c.Assert(err, gc.ErrorMatches, "hash mismatch")
-	c.Assert(chal, gc.IsNil)
-
-	rc, length, err := store.Open("x")
-	c.Assert(err, gc.ErrorMatches, "resource.*not found")
-	c.Assert(rc, gc.Equals, nil)
-	c.Assert(length, gc.Equals, int64(0))
-}
-
-func (s *BlobStoreSuite) TestPutUnchallenged(c *gc.C) {
-	store := blobstore.New(s.Session.DB("db"), "blobstore")
-
-	content := "some data"
-	err := store.PutUnchallenged(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
-	c.Assert(err, gc.IsNil)
-
-	rc, length, err := store.Open("x")
-	c.Assert(err, gc.IsNil)
-	defer rc.Close()
-	c.Assert(length, gc.Equals, int64(len(content)))
-
-	data, err := ioutil.ReadAll(rc)
-	c.Assert(err, gc.IsNil)
-	c.Assert(string(data), gc.Equals, content)
-
-	err = store.PutUnchallenged(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
-	c.Assert(err, gc.IsNil)
-}
-
-func (s *BlobStoreSuite) TestPutUnchallengedInvalidHash(c *gc.C) {
-	store := blobstore.New(s.Session.DB("db"), "blobstore")
-	content := "some data"
-	err := store.PutUnchallenged(strings.NewReader(content), "x", int64(len(content)), hashOf("wrong"))
+	err := s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf("wrong"))
 	c.Assert(err, gc.ErrorMatches, "hash mismatch")
 }
 
 func (s *BlobStoreSuite) TestRemove(c *gc.C) {
-	store := blobstore.New(s.Session.DB("db"), "blobstore")
 	content := "some data"
-	err := store.PutUnchallenged(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
+	err := s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
 	c.Assert(err, gc.IsNil)
 
-	rc, length, err := store.Open("x")
+	rc, length, err := s.store.Open("x", nil)
 	c.Assert(err, gc.IsNil)
 	defer rc.Close()
 	c.Assert(length, gc.Equals, int64(len(content)))
@@ -131,31 +93,207 @@ func (s *BlobStoreSuite) TestRemove(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(string(data), gc.Equals, content)
 
-	err = store.Remove("x")
+	err = s.store.Remove("x", nil)
 	c.Assert(err, gc.IsNil)
 
-	rc, length, err = store.Open("x")
+	rc, length, err = s.store.Open("x", nil)
 	c.Assert(err, gc.ErrorMatches, `resource at path "[^"]+" not found`)
 }
 
-func (s *BlobStoreSuite) TestLarge(c *gc.C) {
-	store := blobstore.New(s.Session.DB("db"), "blobstore")
-	size := int64(20 * 1024 * 1024)
-	newContent := func() io.Reader {
-		return newDataSource(123, size)
+func (s *BlobStoreSuite) TestNewParts(c *gc.C) {
+	expires := time.Now().Add(time.Minute).UTC().Truncate(time.Millisecond)
+	id, err := s.store.NewUpload(expires)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(id, gc.Not(gc.Equals), "")
+
+	// Verify that the new record looks like we expect.
+	var udoc blobstore.UploadDoc
+	db := s.Session.DB("db")
+	err = db.C("blobstore.upload").FindId(id).One(&udoc)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(udoc, jc.DeepEquals, blobstore.UploadDoc{
+		Id:      id,
+		Expires: expires,
+	})
+}
+
+func (s *BlobStoreSuite) TestPutPartNegativePart(c *gc.C) {
+	id := s.newUpload(c)
+
+	err := s.store.PutPart(id, -1, nil, 0, "")
+	c.Assert(err, gc.ErrorMatches, "negative part number")
+}
+
+func (s *BlobStoreSuite) TestPutPartNumberTooBig(c *gc.C) {
+	s.PatchValue(blobstore.MaxParts, 100)
+
+	id := s.newUpload(c)
+	err := s.store.PutPart(id, 100, nil, 0, "")
+	c.Assert(err, gc.ErrorMatches, `part number 100 too big \(maximum 99\)`)
+}
+
+func (s *BlobStoreSuite) TestPutPartSingle(c *gc.C) {
+	id := s.newUpload(c)
+
+	content := "123456789 12345"
+	err := s.store.PutPart(id, 0, strings.NewReader(content), int64(len(content)), hashOf(content))
+	c.Assert(err, gc.Equals, nil)
+
+	r, size, err := s.store.Open(id+"/0", nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(size, gc.Equals, int64(len(content)))
+	c.Assert(hashOfReader(c, r), gc.Equals, hashOf(content))
+}
+
+func (s *BlobStoreSuite) TestPutPartAgain(c *gc.C) {
+	id := s.newUpload(c)
+
+	content := "123456789 12345"
+
+	// Perform a Put with mismatching content. This should leave the part in progress
+	// but not completed.
+	err := s.store.PutPart(id, 0, strings.NewReader("something different"), int64(len(content)), hashOf(content))
+	c.Assert(err, gc.ErrorMatches, `cannot upload part ".+": hash mismatch`)
+
+	// Try again with the correct content this time.
+	err = s.store.PutPart(id, 0, strings.NewReader(content), int64(len(content)), hashOf(content))
+	c.Assert(err, gc.Equals, nil)
+
+	r, size, err := s.store.Open(id+"/0", nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(size, gc.Equals, int64(len(content)))
+	c.Assert(hashOfReader(c, r), gc.Equals, hashOf(content))
+}
+
+func (s *BlobStoreSuite) TestPutPartAgainWithDifferentHash(c *gc.C) {
+	id := s.newUpload(c)
+
+	content := "123456789 12345"
+	err := s.store.PutPart(id, 0, strings.NewReader(content), int64(len(content)), hashOf(content))
+	c.Assert(err, gc.Equals, nil)
+
+	content1 := "abcdefghijklmnopqrstuvwxyz"
+	err = s.store.PutPart(id, 0, strings.NewReader(content1), int64(len(content1)), hashOf(content1))
+	c.Assert(err, gc.ErrorMatches, `hash mismatch for already uploaded part`)
+}
+
+func (s *BlobStoreSuite) TestPutPartAgainWithSameHash(c *gc.C) {
+	id := s.newUpload(c)
+
+	content := "123456789 12345"
+	err := s.store.PutPart(id, 0, strings.NewReader(content), int64(len(content)), hashOf(content))
+	c.Assert(err, gc.Equals, nil)
+
+	err = s.store.PutPart(id, 0, strings.NewReader(content), int64(len(content)), hashOf(content))
+	c.Assert(err, gc.Equals, nil)
+}
+
+func (s *BlobStoreSuite) TestPutPartOutOfOrder(c *gc.C) {
+	s.PatchValue(blobstore.MinPartSize, int64(10))
+	id := s.newUpload(c)
+
+	content1 := "123456789 123456789 "
+	err := s.store.PutPart(id, 1, strings.NewReader(content1), int64(len(content1)), hashOf(content1))
+	c.Assert(err, gc.Equals, nil)
+
+	content0 := "abcdefghijklmnopqrstuvwxyz"
+	err = s.store.PutPart(id, 0, strings.NewReader(content0), int64(len(content0)), hashOf(content0))
+	c.Assert(err, gc.Equals, nil)
+
+	r, size, err := s.store.Open(id+"/0", nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(size, gc.Equals, int64(len(content0)))
+	c.Assert(hashOfReader(c, r), gc.Equals, hashOf(content0))
+
+	r, size, err = s.store.Open(id+"/1", nil)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(size, gc.Equals, int64(len(content1)))
+	c.Assert(hashOfReader(c, r), gc.Equals, hashOf(content1))
+}
+
+func (s *BlobStoreSuite) TestPutPartTooSmall(c *gc.C) {
+	s.PatchValue(blobstore.MinPartSize, int64(100))
+	id := s.newUpload(c)
+
+	content0 := "abcdefghijklmnopqrstuvwxyz"
+	err := s.store.PutPart(id, 0, strings.NewReader(content0), int64(len(content0)), hashOf(content0))
+	c.Assert(err, gc.Equals, nil)
+
+	content1 := "123456789 123456789 "
+	err = s.store.PutPart(id, 1, strings.NewReader(content1), int64(len(content1)), hashOf(content1))
+	c.Assert(err, gc.ErrorMatches, `part 0 was too small \(need at least 100 bytes, got 26\)`)
+}
+
+func (s *BlobStoreSuite) TestPutPartTooSmallOutOfOrder(c *gc.C) {
+	s.PatchValue(blobstore.MinPartSize, int64(100))
+	id := s.newUpload(c)
+
+	content1 := "abcdefghijklmnopqrstuvwxyz"
+	err := s.store.PutPart(id, 1, strings.NewReader(content1), int64(len(content1)), hashOf(content1))
+	c.Assert(err, gc.Equals, nil)
+
+	content0 := "123456789 123456789 "
+	err = s.store.PutPart(id, 0, strings.NewReader(content0), int64(len(content0)), hashOf(content0))
+	c.Assert(err, gc.ErrorMatches, `part too small \(need at least 100 bytes, got 20\)`)
+}
+
+func (s *BlobStoreSuite) TestPutPartSmallAtEnd(c *gc.C) {
+	s.PatchValue(blobstore.MinPartSize, int64(10))
+	id := s.newUpload(c)
+
+	content0 := "1234"
+	err := s.store.PutPart(id, 0, strings.NewReader(content0), int64(len(content0)), hashOf(content0))
+	c.Assert(err, gc.Equals, nil)
+
+	content1 := "abc"
+	err = s.store.PutPart(id, 1, strings.NewReader(content1), int64(len(content1)), hashOf(content1))
+	c.Assert(err, gc.ErrorMatches, `part 0 was too small \(need at least 10 bytes, got 4\)`)
+}
+
+func (s *BlobStoreSuite) TestPutPartConcurrent(c *gc.C) {
+	id := s.newUpload(c)
+	var hash [3]string
+	const size = 5 * 1024 * 1024
+	for i := range hash {
+		hash[i] = hashOfReader(c, newDataSource(int64(i+1), size))
 	}
-	hash := hashOfReader(c, newContent())
+	var wg sync.WaitGroup
+	for i := range hash {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Make a copy of the session so we get independent
+			// mongo sockets and more concurrency.
+			db := s.Session.Copy().DB("db")
+			defer db.Session.Close()
+			store := blobstore.New(db, "blobstore")
+			err := store.PutPart(id, i, newDataSource(int64(i+1), size), size, hash[i])
+			c.Check(err, gc.IsNil)
+		}()
+	}
+	wg.Wait()
+	for i := range hash {
+		r, size, err := s.store.Open(fmt.Sprintf("%s/%d", id, i), nil)
+		c.Assert(err, gc.Equals, nil)
+		c.Assert(size, gc.Equals, size)
+		c.Assert(hashOfReader(c, r), gc.Equals, hash[i])
+	}
+}
 
-	chal, err := store.Put(newContent(), "x", size, hash, nil)
-	c.Assert(err, gc.IsNil)
-	c.Assert(chal, gc.IsNil)
+func (s *BlobStoreSuite) TestPutPartNotFound(c *gc.C) {
 
-	rc, length, err := store.Open("x")
-	c.Assert(err, gc.IsNil)
-	defer rc.Close()
-	c.Assert(length, gc.Equals, size)
+	err := s.store.PutPart("unknownblob", 0, strings.NewReader(""), 0, hashOf(""))
+	c.Assert(err, gc.ErrorMatches, `upload id "unknownblob" not found`)
+	c.Assert(errgo.Cause(err), gc.Equals, blobstore.ErrNotFound)
+}
 
-	c.Assert(hashOfReader(c, rc), gc.Equals, hash)
+// newUpload returns the id of a new upload instance.
+func (s *BlobStoreSuite) newUpload(c *gc.C) string {
+	expires := time.Now().Add(time.Minute).UTC()
+	id, err := s.store.NewUpload(expires)
+	c.Assert(err, gc.Equals, nil)
+	return id
 }
 
 func hashOfReader(c *gc.C, r io.Reader) string {

--- a/internal/blobstore/export_test.go
+++ b/internal/blobstore/export_test.go
@@ -1,0 +1,8 @@
+package blobstore
+
+type UploadDoc uploadDoc
+
+var (
+	MaxParts    = &maxParts
+	MinPartSize = &minPartSize
+)

--- a/internal/blobstore/multipart.go
+++ b/internal/blobstore/multipart.go
@@ -1,0 +1,250 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package blobstore
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var (
+	maxParts          = 400
+	minPartSize int64 = 5 * 1024 * 1024
+)
+
+var ErrNotFound = errgo.New("blob not found")
+
+// uploadDoc describes the record that's held
+// for a pending multipart upload.
+type uploadDoc struct {
+	// Id holds the upload id. The blob for each
+	// part in the underlying blobstore will be named
+	// $id/$partnumber.
+	Id string `bson:"_id"`
+
+	// Hash holds the SHA384 hash of all the
+	// concatenated parts. It is empty until
+	// after FinishUpload is called.
+	Hash string `bson:"hash,omitempty"`
+
+	// Expires holds the expiry time of the upload.
+	Expires time.Time
+
+	// Parts holds all the currently uploaded parts.
+	Parts []*uploadPart
+}
+
+// uploadPart represents one part of an on-going upload.
+type uploadPart struct {
+	// Hash holds the SHA384 hash of the part.
+	Hash string
+	// Size holds the size of the part.
+	Size int64
+	// Complete holds whether the part has been
+	// successfully uploaded.
+	Complete bool
+}
+
+// NewUpload created a new multipart entry to track a multipart upload.
+// It returns an uploadId that can be used to refer to it. After
+// creating the upload, each part must be uploaded individually, and
+// then the whole completed by calling FinishUpload and DeleteUpload.
+func (s *Store) NewUpload(expires time.Time) (uploadId string, err error) {
+	// TODO this makes an upload id that's 78 bytes.
+	// A base64-encoded 256 bit random number would
+	// only be 45 bytes and secure enough that we could
+	// probably dispense with ownership checking.
+	uploadId = fmt.Sprintf("%x", bson.NewObjectId())
+	if err := s.uploadC().Insert(uploadDoc{
+		Id:      uploadId,
+		Expires: expires,
+	}); err != nil {
+		return "", errgo.Notef(err, "cannot create new upload")
+	}
+	return uploadId, nil
+}
+
+// PutPart uploads a part to the given upload id. The part number
+// is specified with the part parameter; its content will be read from r
+// and is expected to have the given size and hex-encoded SHA384 hash.
+// A given part may not be uploaded more than once with a different hash.
+//
+// If the upload id was not found (for example, because it's expired),
+// PutPart returns an error with an ErrNotFound cause.
+func (s *Store) PutPart(uploadId string, part int, r io.Reader, size int64, hash string) error {
+	if part < 0 {
+		return errgo.Newf("negative part number")
+	}
+	if part >= maxParts {
+		return errgo.Newf("part number %d too big (maximum %d)", part, maxParts-1)
+	}
+	uploadc := s.uploadC()
+	var udoc uploadDoc
+	if err := uploadc.FindId(uploadId).One(&udoc); err != nil {
+		if err == mgo.ErrNotFound {
+			return errgo.WithCausef(nil, ErrNotFound, "upload id %q not found", uploadId)
+		}
+		return errgo.Notef(err, "cannot get upload id %q", uploadId)
+	}
+	if err := checkPartSizes(udoc.Parts, part, size); err != nil {
+		return errgo.Mask(err)
+	}
+	partElem := fmt.Sprintf("parts.%d", part)
+	if part < len(udoc.Parts) && udoc.Parts[part] != nil {
+		// There's already a (possibly complete) part record stored.
+		p := udoc.Parts[part]
+		if p.Hash != hash {
+			return errgo.Newf("hash mismatch for already uploaded part")
+		}
+		if p.Complete {
+			// It's already uploaded, then we can use the existing uploaded part.
+			return nil
+		}
+		// Someone else made the part record, but it's not complete
+		// perhaps because a previous part upload failed.
+	} else {
+		// No part record. Make one, not marked as complete
+		// before we put the part so that DeleteExpiredParts
+		// knows to delete the part.
+		if err := initializePart(uploadc, uploadId, part, hash, size); err != nil {
+			return errgo.Mask(err)
+		}
+	}
+	// The part record has been updated successfully, so
+	// we can actually upload the part now.
+	partName := uploadPartName(uploadId, part)
+	if err := s.Put(r, partName, size, hash); err != nil {
+		return errgo.Notef(err, "cannot upload part %q", partName)
+	}
+
+	// We've put the part document, so we can now mark the part as
+	// complete. Note: we update the entire part rather than just
+	// setting $partElem.complete=true because of a bug in MongoDB
+	// 2.4 which fails in that case.
+	err := uploadc.UpdateId(uploadId, bson.D{{
+		"$set", bson.D{{
+			partElem,
+			uploadPart{
+				Hash:     hash,
+				Size:     size,
+				Complete: true,
+			},
+		}},
+	}})
+	if err != nil {
+		return errgo.Notef(err, "cannot mark part as complete")
+	}
+	return nil
+}
+
+// checkPartSizes checks part sizes as much as we can.
+// As the last part is allowed to be small, we can
+// only check previously uploaded parts unless we're
+// uploading an out-of-order part.
+func checkPartSizes(parts []*uploadPart, part int, size int64) error {
+	if part < len(parts)-1 && size < minPartSize {
+		return errgo.Newf("part too small (need at least %d bytes, got %d)", minPartSize, size)
+	}
+	for i, p := range parts {
+		if i != part && p != nil && p.Size < minPartSize {
+			return errgo.Newf("part %d was too small (need at least %d bytes, got %d)", i, minPartSize, p.Size)
+		}
+	}
+	return nil
+}
+
+// ListUpload returns all the parts associated with the given
+// upload id. It returns ErrNotFound if the upload has been
+// deleted or finished.
+func (s *Store) ListUpload(uploadId string) ([]Part, error) {
+	return nil, errgo.New(" not implemented yet")
+	// TODO
+	// read multipart metadata
+	// return parts from that, omitting parts that are currently in progress
+}
+
+// uploadPartName returns the blob name of the part with the given
+// uploadId and part number.
+func uploadPartName(uploadId string, part int) string {
+	return fmt.Sprintf("%s/%d", uploadId, part)
+}
+
+// initializePart creates the initial record for a part.
+func initializePart(uploadc *mgo.Collection, uploadId string, part int, hash string, size int64) error {
+	partElem := fmt.Sprintf("parts.%d", part)
+	err := uploadc.Update(bson.D{
+		{"_id", uploadId},
+		{"$or", []bson.D{{{
+			partElem, bson.D{{"$exists", false}},
+		}}, {{
+			partElem, bson.D{{"$eq", nil}},
+		}}}},
+	},
+		bson.D{{
+			"$set", bson.D{{partElem, uploadPart{
+				Hash: hash,
+				Size: size,
+			}}},
+		}},
+	)
+	if err == nil || err != mgo.ErrNotFound {
+		return nil
+	}
+	return errgo.New("cannot update initial part record - concurrent upload of the same part?")
+}
+
+// FinishUpload completes a multipart upload by joining all the given
+// parts into one blob. The resulting blob can be opened by passing
+// uploadId and the returned multipart index to Open.
+//
+// The part numbers used will be from 0 to len(parts)-1.
+//
+// This does not delete the multipart metadata, which should still be
+// deleted explicitly by calling DeleteUpload after the index data is
+// stored.
+func (s *Store) FinishUpload(uploadId string, parts []Part) (idx *MultipartIndex, hash string, err error) {
+	// TODO read metadata
+	// if parts don't match uploaded parts, return error.
+	// read all parts in sequence to hash them.
+	// return index derived from metadata and calculated hash.
+	return nil, "", errgo.New("not implemented yet")
+}
+
+// DeleteExpiredUploads deletes any multipart entries
+// that have passed their expiry date.
+func (s *Store) DeleteExpiredUploads() error {
+	return errgo.New("not implemented yet")
+}
+
+// DeleteUpload deletes all the parts associated with the
+// given upload id. It is a no-op if called twice on the
+// same upload id.
+func (s *Store) DeleteUpload(uploadId string) error {
+	// TODO
+	// read multipart metadata
+	// delete all parts referenced in that
+	// delete multipart metadata
+	return errgo.New("not implemented yet")
+}
+
+// MultipartIndex holds the index of all the parts of a multipart blob.
+// It should be stored in an external document along with the
+// blob name so that the blob can be downloaded.
+type MultipartIndex struct {
+	Sizes []uint32
+}
+
+// Part represents one part of a multipart blob.
+type Part struct {
+	Hash string
+}
+
+func (s *Store) uploadC() *mgo.Collection {
+	return s.db.C(s.prefix + ".upload")
+}

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -397,7 +397,7 @@ func (s *AddEntitySuite) checkAddCharm(c *gc.C, ch charm.Charm, url *router.Reso
 	}))
 
 	// The charm archive has been properly added to the blob store.
-	r, obtainedSize, err := store.BlobStore.Open(doc.BlobName)
+	r, obtainedSize, err := store.BlobStore.Open(doc.BlobName, nil)
 	c.Assert(err, gc.IsNil)
 	defer r.Close()
 	c.Assert(obtainedSize, gc.Equals, size)
@@ -460,7 +460,7 @@ func (s *AddEntitySuite) checkAddBundle(c *gc.C, bundle charm.Bundle, url *route
 	}))
 
 	// The bundle archive has been properly added to the blob store.
-	r, obtainedSize, err := store.BlobStore.Open(doc.BlobName)
+	r, obtainedSize, err := store.BlobStore.Open(doc.BlobName, nil)
 	c.Assert(err, gc.IsNil)
 	defer r.Close()
 	c.Assert(obtainedSize, gc.Equals, size)

--- a/internal/charmstore/archive.go
+++ b/internal/charmstore/archive.go
@@ -58,7 +58,7 @@ func (s *Store) openBlob(id *router.ResolvedURL, preV5 bool) (*Blob, error) {
 	if err != nil {
 		return nil, errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
-	r, size, err := s.BlobStore.Open(entity.BlobName)
+	r, size, err := s.BlobStore.Open(entity.BlobName, nil)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot open archive data for %s", id)
 	}
@@ -67,7 +67,7 @@ func (s *Store) openBlob(id *router.ResolvedURL, preV5 bool) (*Blob, error) {
 	if entity.PreV5BlobHash != entity.BlobHash && preV5 {
 		// The v5 blob is different so we open the blob suffix that
 		// contains the metadata hack.
-		r2, size2, err := s.BlobStore.Open(preV5CompatibilityBlobName(entity.BlobName))
+		r2, size2, err := s.BlobStore.Open(preV5CompatibilityBlobName(entity.BlobName), nil)
 		if err != nil {
 			r.Close()
 			return nil, errgo.Notef(err, "cannot find pre-v5 hack blob")
@@ -163,7 +163,7 @@ func (s *Store) OpenCachedBlobFile(
 	if ok && !zipf.IsValid() {
 		return nil, errgo.WithCausef(nil, params.ErrNotFound, "")
 	}
-	blob, size, err := s.BlobStore.Open(entity.BlobName)
+	blob, size, err := s.BlobStore.Open(entity.BlobName, nil)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot open archive blob")
 	}

--- a/internal/charmstore/resources.go
+++ b/internal/charmstore/resources.go
@@ -164,7 +164,7 @@ func (s *Store) UploadResource(id *router.ResolvedURL, name string, blob io.Read
 		UploadTime: time.Now().UTC(),
 	})
 	if err != nil {
-		if err := s.BlobStore.Remove(blobName); err != nil {
+		if err := s.BlobStore.Remove(blobName, nil); err != nil {
 			logger.Errorf("cannot remove blob %s after error: %v", blobName, err)
 		}
 		return nil, errgo.Mask(err)
@@ -255,7 +255,7 @@ func charmHasResource(meta *charm.Meta, name string) bool {
 
 // OpenResourceBlob returns the blob associated with the given resource.
 func (s *Store) OpenResourceBlob(res *mongodoc.Resource) (*Blob, error) {
-	r, size, err := s.BlobStore.Open(res.BlobName)
+	r, size, err := s.BlobStore.Open(res.BlobName, nil)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot open archive data for %s resource %q", res.BaseURL, fmt.Sprintf("%s/%d", res.Name, res.Revision))
 	}

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -1130,12 +1130,12 @@ func (s *Store) DeleteEntity(id *router.ResolvedURL) error {
 		return errgo.Mask(err, errgo.Is(params.ErrNotFound))
 	}
 	// Remove the reference to the archive from the blob store.
-	if err := s.BlobStore.Remove(entity.BlobName); err != nil {
+	if err := s.BlobStore.Remove(entity.BlobName, nil); err != nil {
 		return errgo.Notef(err, "cannot remove blob %s", entity.BlobName)
 	}
 	if entity.BlobHash != entity.PreV5BlobHash {
 		name := preV5CompatibilityBlobName(entity.BlobName)
-		if err := s.BlobStore.Remove(name); err != nil {
+		if err := s.BlobStore.Remove(name, nil); err != nil {
 			return errgo.Notef(err, "cannot remove compatibility blob %s", name)
 		}
 	}

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -3286,7 +3286,7 @@ func (s *StoreSuite) TestCopyCopiesSessions(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	// Also check the blob store, as it has its own session reference.
-	r, _, err := store1.BlobStore.Open(entity.BlobName)
+	r, _, err := store1.BlobStore.Open(entity.BlobName, nil)
 	c.Assert(err, gc.IsNil)
 	r.Close()
 

--- a/internal/mongodoc/resource.go
+++ b/internal/mongodoc/resource.go
@@ -33,8 +33,13 @@ type Resource struct {
 	Size int64 `bson:"size"`
 
 	// BlobName holds the name that the resource blob is given in the
-	// blob store.
+	// blob store, or the name prefix for multipart blobs.
 	BlobName string
+
+	// TODO add this:
+	// BlobMultipart stores the multipart index when the blob
+	// is composed of several parts.
+	// BlobMultipart *blobstore.MultipartIndex
 
 	// UploadTime is the is the time the resource file was stored in
 	// the blob store.

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -2809,7 +2809,7 @@ func zipGetter(get func(*zip.Reader) interface{}) metaEndpointExpectedValueGette
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}
-		blob, size, err := store.BlobStore.Open(doc.BlobName)
+		blob, size, err := store.BlobStore.Open(doc.BlobName, nil)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}

--- a/internal/v4/list_test.go
+++ b/internal/v4/list_test.go
@@ -279,7 +279,7 @@ func (s *ListSuite) TestListIncludeError(c *gc.C) {
 	// work, but only return a single result.
 	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
 	c.Assert(err, gc.IsNil)
-	err = s.store.BlobStore.Remove(entity.BlobName)
+	err = s.store.BlobStore.Remove(entity.BlobName, nil)
 	c.Assert(err, gc.IsNil)
 
 	// Now list again - we should get one result less

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -438,7 +438,7 @@ func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
 	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
 
 	c.Assert(err, gc.IsNil)
-	err = s.store.BlobStore.Remove(entity.BlobName)
+	err = s.store.BlobStore.Remove(entity.BlobName, nil)
 	c.Assert(err, gc.IsNil)
 
 	// Now search again - we should get one result less

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -664,7 +664,7 @@ func bundleCount(x *int) interface{} {
 // GET id/meta/manifest
 // https://github.com/juju/charmstore/blob/v5-unstable/docs/API.md#get-idmetamanifest
 func (h *ReqHandler) metaManifest(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
-	r, size, err := h.Store.BlobStore.Open(entity.BlobName)
+	r, size, err := h.Store.BlobStore.Open(entity.BlobName, nil)
 	if err != nil {
 		return nil, errgo.Notef(err, "cannot open archive data for %s", id)
 	}

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -3540,7 +3540,7 @@ func zipGetter(get func(*zip.Reader) interface{}) metaEndpointExpectedValueGette
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}
-		blob, size, err := store.BlobStore.Open(doc.BlobName)
+		blob, size, err := store.BlobStore.Open(doc.BlobName, nil)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -1072,7 +1072,7 @@ func (s *commonArchiveSuite) assertUpload(c *gc.C, p uploadParams) (id *charm.UR
 
 	// Test that the expected entry has been created
 	// in the blob store.
-	r, _, err := s.store.BlobStore.Open(entity.BlobName)
+	r, _, err := s.store.BlobStore.Open(entity.BlobName, nil)
 	c.Assert(err, gc.IsNil)
 	r.Close()
 

--- a/internal/v5/list_test.go
+++ b/internal/v5/list_test.go
@@ -273,7 +273,7 @@ func (s *ListSuite) TestListIncludeError(c *gc.C) {
 	// work, but only return a single result.
 	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
 	c.Assert(err, gc.IsNil)
-	err = s.store.BlobStore.Remove(entity.BlobName)
+	err = s.store.BlobStore.Remove(entity.BlobName, nil)
 	c.Assert(err, gc.IsNil)
 
 	// Now list again - we should get one result less

--- a/internal/v5/search_test.go
+++ b/internal/v5/search_test.go
@@ -583,7 +583,7 @@ func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
 	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
 
 	c.Assert(err, gc.IsNil)
-	err = s.store.BlobStore.Remove(entity.BlobName)
+	err = s.store.BlobStore.Remove(entity.BlobName, nil)
 	c.Assert(err, gc.IsNil)
 
 	// Now search again - we should get one result less


### PR DESCRIPTION
This is first stage of multipart support in the blobstore
implementation. The intention is that the resource document
will store the parts index directly in its document rather
than having an intermediate collection to store multipart
data.

We remove the unused blobstore Put method and rename
PutUnchallenged to Put, and change the Open and Remove
methods to take the multipart index.