### PR TITLE
internal/blobstore: implement RemoveUpload

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,6 @@
 github.com/ajstarks/svgo	git	89e3ac64b5b3e403a5e7c35ea4f98d45db7b4518	2014-10-04T21:11:59Z
 github.com/beorn7/perks	git	3ac7bf7a47d159a033b107610db8a1b6575507a4	2016-02-29T21:34:45Z
+github.com/gabriel-samfira/sys	git	9ddc60d56b511544223adecea68da1e4f2153beb	2015-06-08T13:21:19Z
 github.com/golang/protobuf	git	34a5f244f1c01cdfee8e60324258cfbb97a42aec	2015-05-26T01:21:09Z
 github.com/gorilla/handlers	git	a24b39a6a2c8a7af2fe664dd4573205c99904035	2015-04-12T18:40:04Z
 github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
@@ -34,8 +35,9 @@ github.com/prometheus/procfs	git	abf152e5f3e97f2fafac028d2cc06c1feb87ffa5	2016-0
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
+golang.org/x/sys	git	9bb9f0998d48b31547d975974935ae9b48c7a03c	2016-10-12T00:19:20Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
-gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
+gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
 gopkg.in/juju/charm.v6-unstable	git	e62786fbece4c6a74945d0d1d19140a69018c07d	2016-09-16T08:55:15Z
 gopkg.in/juju/charmrepo.v2-unstable	git	d8b2fa48bbfa115906b42405eced0c9871a09e13	2016-08-09T13:37:26Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z

--- a/internal/charmstore/resources_test.go
+++ b/internal/charmstore/resources_test.go
@@ -387,7 +387,7 @@ func (s *resourceSuite) TestPublishWithResourceNotInMetadata(c *gc.C) {
 	err = store.Publish(id, map[string]int{
 		"resource1": 0,
 	}, params.StableChannel)
-	c.Assert(err, gc.ErrorMatches, `charm published with incorrect resources: charm does not have resource "resource1"`)
+	c.Assert(err, gc.ErrorMatches, `charm does not have resource "resource1"`)
 	c.Assert(errgo.Cause(err), gc.Equals, ErrPublishResourceMismatch)
 }
 
@@ -403,7 +403,7 @@ func (s *resourceSuite) TestPublishWithResourceNotFound(c *gc.C) {
 	err = store.Publish(id, map[string]int{
 		"resource1": 0,
 	}, params.StableChannel)
-	c.Assert(err, gc.ErrorMatches, `charm published with incorrect resources: cs:~charmers/precise/wordpress-3 resource "resource1/0" not found`)
+	c.Assert(err, gc.ErrorMatches, `cs:~charmers/precise/wordpress-3 resource "resource1/0" not found`)
 	c.Assert(errgo.Cause(err), gc.Equals, ErrPublishResourceMismatch)
 }
 
@@ -421,7 +421,7 @@ func (s *resourceSuite) TestPublishWithoutAllRequiredResources(c *gc.C) {
 	err = store.Publish(id, map[string]int{
 		"resource2": 0,
 	}, params.StableChannel)
-	c.Assert(err, gc.ErrorMatches, `charm published with incorrect resources: resources are missing from publish request: resource1, resource3`)
+	c.Assert(err, gc.ErrorMatches, `resources are missing from publish request: resource1, resource3`)
 	c.Assert(errgo.Cause(err), gc.Equals, ErrPublishResourceMismatch)
 }
 

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -766,7 +766,7 @@ var routerGetTests = []struct {
 	expectStatus:              http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: `bad request: charm or bundle URL has invalid form: "~user/bad-wolf/wily/wordpress-42"`,
+		Message: `charm or bundle URL has invalid form: "~user/bad-wolf/wily/wordpress-42"`,
 	},
 	monitorKind: "meta",
 }, {
@@ -854,7 +854,7 @@ var routerGetTests = []struct {
 	expectStatus:              http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: `bad request: charm or bundle URL has invalid form: "staging/trusty/django"`,
+		Message: `charm or bundle URL has invalid form: "staging/trusty/django"`,
 	},
 	monitorKind: "meta",
 }, {
@@ -941,7 +941,7 @@ var routerGetTests = []struct {
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: `bad request: unexpected bool value "meh" (must be "0" or "1")`,
+		Message: `unexpected bool value "meh" (must be "0" or "1")`,
 	},
 	monitorKind: "meta",
 }, {
@@ -1082,7 +1082,7 @@ var routerGetTests = []struct {
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: `not found: URL has invalid charm or bundle name: "robots.txt"`,
+		Message: `URL has invalid charm or bundle name: "robots.txt"`,
 	},
 	monitorKind: "",
 }, {
@@ -1093,7 +1093,7 @@ var routerGetTests = []struct {
 	expectStatus:              http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: `bad request: URL has invalid charm or bundle name: "robots.txt"`,
+		Message: `URL has invalid charm or bundle name: "robots.txt"`,
 	},
 	monitorKind: "meta",
 }}

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -685,7 +685,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		s.assertPut(c, "precise/wordpress-23/meta/perm/read", []string{"bob"})
 		s.assertPut(c, "precise/wordpress-23/meta/perm/write", []string{"admin"})
 		// charmers no longer has permission.
-		s.assertGetIsUnauthorized(c, "precise/wordpress-23/meta/perm", `unauthorized: access denied for user "charmers"`)
+		s.assertGetIsUnauthorized(c, "precise/wordpress-23/meta/perm", `access denied for user "charmers"`)
 	})
 
 	// The permissions are only for bob now, so act as bob.
@@ -734,12 +734,12 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 	s.doAsUser("bob", func() {
 		// Check that we aren't allowed to put to the newly published entity as bob.
-		s.assertPutIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=edge", []string{}, `unauthorized: access denied for user "bob"`)
+		s.assertPutIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=edge", []string{}, `access denied for user "bob"`)
 	})
 
 	s.doAsUser("charmers", func() {
 		s.assertPut(c, "precise/wordpress-23/meta/perm/read", []string{"bob", "charlie"})
-		s.assertGetIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=edge", `unauthorized: access denied for user "charmers"`)
+		s.assertGetIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=edge", `access denied for user "charmers"`)
 	})
 
 	s.doAsUser("bob", func() {
@@ -924,15 +924,15 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			ExpectStatus: http.StatusUnauthorized,
 			ExpectBody: params.Error{
 				Code:    params.ErrUnauthorized,
-				Message: `unauthorized: access denied for user "doris"`,
+				Message: `access denied for user "doris"`,
 			},
 		})
 	})
 	// Now no-one except admin can do anything with trusty/wordpress-1.
 	for _, user := range []string{"charmers", "bob", "charlie", "doris", "admin"} {
 		s.doAsUser(user, func() {
-			s.assertGetIsUnauthorized(c, "wordpress/meta/perm", fmt.Sprintf("unauthorized: access denied for user %q", user))
-			s.assertPutIsUnauthorized(c, "wordpress/meta/perm", []string{}, fmt.Sprintf("unauthorized: access denied for user %q", user))
+			s.assertGetIsUnauthorized(c, "wordpress/meta/perm", fmt.Sprintf("access denied for user %q", user))
+			s.assertPutIsUnauthorized(c, "wordpress/meta/perm", []string{}, fmt.Sprintf("access denied for user %q", user))
 		})
 	}
 
@@ -2909,7 +2909,7 @@ func (s *APISuite) TestMacaroon(c *gc.C) {
 		ExpectStatus: http.StatusUnauthorized,
 		ExpectBody: params.Error{
 			Code:    params.ErrUnauthorized,
-			Message: `unauthorized: access denied for user "who"`,
+			Message: `access denied for user "who"`,
 		},
 	})
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -3100,7 +3100,7 @@ var promulgateTests = []struct {
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: "bad request: invalid character ' ' in literal true (expecting 'e')",
+		Message: "invalid character ' ' in literal true (expecting 'e')",
 	},
 	expectEntities: []*mongodoc.Entity{
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
@@ -3204,7 +3204,7 @@ var promulgateTests = []struct {
 	groups:       []string{"yellow"},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
-		Message: `unauthorized: access denied for user "bob"`,
+		Message: `access denied for user "bob"`,
 		Code:    params.ErrUnauthorized,
 	},
 	expectEntities: []*mongodoc.Entity{
@@ -3310,7 +3310,7 @@ func (s *APISuite) TestTooManyConcurrentRequests(c *gc.C) {
 		URL:          storeURL("debug/status"),
 		ExpectStatus: http.StatusServiceUnavailable,
 		ExpectBody: params.Error{
-			Message: "service unavailable: too many mongo sessions in use",
+			Message: "too many mongo sessions in use",
 			Code:    params.ErrServiceUnavailable,
 		},
 	})

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1016,7 +1016,7 @@ var archiveFileErrorsTests = []struct {
 	about:         "no permissions",
 	path:          "~charmers/utopic/mysql-0/archive/metadata.yaml",
 	expectStatus:  http.StatusUnauthorized,
-	expectMessage: `unauthorized: access denied for user "bob"`,
+	expectMessage: `access denied for user "bob"`,
 	expectCode:    params.ErrUnauthorized,
 }}
 

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -100,7 +100,7 @@ func (s *commonSuite) testMacaroonAuth(c *gc.C, p httptesting.JSONCallParams) {
 	p.Username, p.Password = "", ""
 	p.ExpectStatus = http.StatusUnauthorized
 	p.ExpectBody = params.Error{
-		Message: `unauthorized: access denied for user "bob"`,
+		Message: `access denied for user "bob"`,
 		Code:    params.ErrUnauthorized,
 	}
 	p.Do = bakeryDo(client)
@@ -234,7 +234,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "picard"`,
+		Message: `access denied for user "picard"`,
 	},
 }, {
 	about:               "access denied for user",
@@ -243,7 +243,7 @@ var readAuthorizationTests = []struct {
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "everyone is authorized (user is member of groups)",
@@ -272,7 +272,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "picard"`,
+		Message: `access denied for user "picard"`,
 	},
 }, {
 	about:               "access denied for group",
@@ -282,7 +282,7 @@ var readAuthorizationTests = []struct {
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through edge channel",
@@ -300,7 +300,7 @@ var readAuthorizationTests = []struct {
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through stable channel",
@@ -321,7 +321,7 @@ var readAuthorizationTests = []struct {
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through edge channel, but charm on stable channel",
@@ -337,7 +337,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through unpublished ACL, but charm on stable channel",
@@ -352,7 +352,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through unpublished ACL, but charm on edge channel",
@@ -366,7 +366,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }}
 
@@ -470,7 +470,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "who"`,
+		Message: `access denied for user "who"`,
 	},
 }, {
 	about:                "specific user unauthorized",
@@ -479,7 +479,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access granted for group",
@@ -498,7 +498,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "picard"`,
+		Message: `access denied for user "picard"`,
 	},
 }, {
 	about:                "access denied for group",
@@ -508,7 +508,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through edge channel",
@@ -526,7 +526,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through stable channel",
@@ -547,7 +547,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through edge channel, but charm on stable channel",
@@ -563,7 +563,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through unpublished ACL, but charm on stable channel",
@@ -578,7 +578,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through unpublished ACL, but charm on edge channel",
@@ -592,7 +592,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }}
 
@@ -705,7 +705,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "sisko"`,
+		Message: `access denied for user "sisko"`,
 	},
 }, {
 	about:        "unauthorized: user does not match",
@@ -714,7 +714,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:        "unauthorized: group does not match",
@@ -724,7 +724,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:        "unauthorized: specific group and promulgated entity",
@@ -735,7 +735,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "janeway"`,
+		Message: `access denied for user "janeway"`,
 	},
 }, {
 	about:        "unauthorized: published entity no published permissions",
@@ -745,7 +745,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "picard"`,
+		Message: `access denied for user "picard"`,
 	},
 }}
 

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -1039,7 +1039,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		s.assertPut(c, "precise/wordpress-23/meta/perm/read", []string{"bob"})
 		s.assertPut(c, "precise/wordpress-23/meta/perm/write", []string{"admin"})
 		// charmers no longer has permission.
-		s.assertGetIsUnauthorized(c, "precise/wordpress-23/meta/perm", `unauthorized: access denied for user "charmers"`)
+		s.assertGetIsUnauthorized(c, "precise/wordpress-23/meta/perm", `access denied for user "charmers"`)
 	})
 
 	// The permissions are only for bob now, so act as bob.
@@ -1088,12 +1088,12 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 	s.doAsUser("bob", func() {
 		// Check that we aren't allowed to put to the newly published entity as bob.
-		s.assertPutIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=edge", []string{}, `unauthorized: access denied for user "bob"`)
+		s.assertPutIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=edge", []string{}, `access denied for user "bob"`)
 	})
 
 	s.doAsUser("charmers", func() {
 		s.assertPut(c, "precise/wordpress-23/meta/perm/read", []string{"bob", "charlie"})
-		s.assertGetIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=edge", `unauthorized: access denied for user "charmers"`)
+		s.assertGetIsUnauthorized(c, "~charmers/precise/wordpress/meta/perm/read?channel=edge", `access denied for user "charmers"`)
 	})
 
 	s.doAsUser("bob", func() {
@@ -1279,15 +1279,15 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			ExpectStatus: http.StatusUnauthorized,
 			ExpectBody: params.Error{
 				Code:    params.ErrUnauthorized,
-				Message: `unauthorized: access denied for user "doris"`,
+				Message: `access denied for user "doris"`,
 			},
 		})
 	})
 	// Now no-one except admin can do anything with trusty/wordpress-1.
 	for _, user := range []string{"charmers", "bob", "charlie", "doris", "admin"} {
 		s.doAsUser(user, func() {
-			s.assertGetIsUnauthorized(c, "wordpress/meta/perm", fmt.Sprintf("unauthorized: access denied for user %q", user))
-			s.assertPutIsUnauthorized(c, "wordpress/meta/perm", []string{}, fmt.Sprintf("unauthorized: access denied for user %q", user))
+			s.assertGetIsUnauthorized(c, "wordpress/meta/perm", fmt.Sprintf("access denied for user %q", user))
+			s.assertPutIsUnauthorized(c, "wordpress/meta/perm", []string{}, fmt.Sprintf("access denied for user %q", user))
 		})
 	}
 
@@ -3084,7 +3084,7 @@ var publishErrorsTests = []struct {
 	}),
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
-		Message: `bad request: charm published with incorrect resources: charm does not have resource "unknown"`,
+		Message: `charm does not have resource "unknown"`,
 		Code:    params.ErrBadRequest,
 	},
 }}
@@ -3236,7 +3236,7 @@ func (s *APISuite) TestPublishAuthorization(c *gc.C) {
 				ExpectStatus: http.StatusUnauthorized,
 				ExpectBody: params.Error{
 					Code:    params.ErrUnauthorized,
-					Message: `unauthorized: access denied for user "bob"`,
+					Message: `access denied for user "bob"`,
 				},
 			})
 			continue
@@ -3601,7 +3601,7 @@ func (s *APISuite) TestMacaroon(c *gc.C) {
 		ExpectStatus: http.StatusUnauthorized,
 		ExpectBody: params.Error{
 			Code:    params.ErrUnauthorized,
-			Message: `unauthorized: access denied for user "who"`,
+			Message: `access denied for user "who"`,
 		},
 	})
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -3792,7 +3792,7 @@ var promulgateTests = []struct {
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: "bad request: invalid character ' ' in literal true (expecting 'e')",
+		Message: "invalid character ' ' in literal true (expecting 'e')",
 	},
 	expectEntities: []*mongodoc.Entity{
 		storetesting.NewEntity("~charmers/trusty/wordpress-0").WithPromulgatedURL("trusty/wordpress-0").Build(),
@@ -3896,7 +3896,7 @@ var promulgateTests = []struct {
 	groups:       []string{"yellow"},
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
-		Message: `unauthorized: access denied for user "bob"`,
+		Message: `access denied for user "bob"`,
 		Code:    params.ErrUnauthorized,
 	},
 	expectEntities: []*mongodoc.Entity{
@@ -4026,7 +4026,7 @@ func (s *APISuite) TestTooManyConcurrentRequests(c *gc.C) {
 		URL:          storeURL("debug/status"),
 		ExpectStatus: http.StatusServiceUnavailable,
 		ExpectBody: params.Error{
-			Message: "service unavailable: too many mongo sessions in use",
+			Message: "too many mongo sessions in use",
 			Code:    params.ErrServiceUnavailable,
 		},
 	})

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -1165,7 +1165,7 @@ var archiveFileErrorsTests = []struct {
 	about:         "no permissions",
 	path:          "~charmers/utopic/mysql-0/archive/metadata.yaml",
 	expectStatus:  http.StatusUnauthorized,
-	expectMessage: `unauthorized: access denied for user "bob"`,
+	expectMessage: `access denied for user "bob"`,
 	expectCode:    params.ErrUnauthorized,
 }}
 

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -102,7 +102,7 @@ func (s *commonSuite) testMacaroonAuth(c *gc.C, p httptesting.JSONCallParams) {
 	p.Username, p.Password = "", ""
 	p.ExpectStatus = http.StatusUnauthorized
 	p.ExpectBody = params.Error{
-		Message: `unauthorized: access denied for user "bob"`,
+		Message: `access denied for user "bob"`,
 		Code:    params.ErrUnauthorized,
 	}
 	p.Do = bakeryDo(client)
@@ -213,7 +213,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "picard"`,
+		Message: `access denied for user "picard"`,
 	},
 }, {
 	about:               "access denied for user",
@@ -222,7 +222,7 @@ var readAuthorizationTests = []struct {
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "everyone is authorized (user is member of groups)",
@@ -251,7 +251,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "picard"`,
+		Message: `access denied for user "picard"`,
 	},
 }, {
 	about:               "access denied for group",
@@ -261,7 +261,7 @@ var readAuthorizationTests = []struct {
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through edge channel",
@@ -279,7 +279,7 @@ var readAuthorizationTests = []struct {
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through stable channel",
@@ -300,7 +300,7 @@ var readAuthorizationTests = []struct {
 	expectStatus:        http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through edge channel, but charm on stable channel",
@@ -316,7 +316,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through unpublished ACL, but charm on stable channel",
@@ -331,7 +331,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:               "access provided through unpublished ACL, but charm on edge channel",
@@ -345,7 +345,7 @@ var readAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }}
 
@@ -441,7 +441,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "who"`,
+		Message: `access denied for user "who"`,
 	},
 }, {
 	about:                "specific user unauthorized",
@@ -450,7 +450,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access granted for group",
@@ -469,7 +469,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "picard"`,
+		Message: `access denied for user "picard"`,
 	},
 }, {
 	about:                "access denied for group",
@@ -479,7 +479,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through edge channel",
@@ -497,7 +497,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through stable channel",
@@ -518,7 +518,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus:         http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through edge channel, but charm on stable channel",
@@ -534,7 +534,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through unpublished ACL, but charm on stable channel",
@@ -549,7 +549,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:                "access provided through unpublished ACL, but charm on edge channel",
@@ -563,7 +563,7 @@ var writeAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }}
 
@@ -676,7 +676,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "sisko"`,
+		Message: `access denied for user "sisko"`,
 	},
 }, {
 	about:        "unauthorized: user does not match",
@@ -685,7 +685,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:        "unauthorized: group does not match",
@@ -695,7 +695,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "kirk"`,
+		Message: `access denied for user "kirk"`,
 	},
 }, {
 	about:        "unauthorized: specific group and promulgated entity",
@@ -706,7 +706,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "janeway"`,
+		Message: `access denied for user "janeway"`,
 	},
 }, {
 	about:        "unauthorized: entity no permissions",
@@ -716,7 +716,7 @@ var uploadEntityAuthorizationTests = []struct {
 	expectStatus: http.StatusUnauthorized,
 	expectBody: params.Error{
 		Code:    params.ErrUnauthorized,
-		Message: `unauthorized: access denied for user "picard"`,
+		Message: `access denied for user "picard"`,
 	},
 }}
 
@@ -992,7 +992,7 @@ func (s *authSuite) TestDelegatableMacaroonWithIds(c *gc.C) {
 			Do:           bakeryDo(nil),
 			ExpectStatus: http.StatusUnauthorized,
 			ExpectBody: params.Error{
-				Message: `unauthorized: access denied for user "bob"`,
+				Message: `access denied for user "bob"`,
 				Code:    params.ErrUnauthorized,
 			},
 		})
@@ -1024,7 +1024,7 @@ func (s *authSuite) TestDelegatableMacaroonWithIds(c *gc.C) {
 			Header:       macaroonHeader(nil, macaroon.Slice{m}),
 			ExpectStatus: http.StatusUnauthorized,
 			ExpectBody: params.Error{
-				Message: `unauthorized: access denied for user "bob"`,
+				Message: `access denied for user "bob"`,
 				Code:    params.ErrUnauthorized,
 			},
 		})
@@ -1037,7 +1037,7 @@ func (s *authSuite) TestDelegatableMacaroonWithIds(c *gc.C) {
 			Header:       macaroonHeader(nil, macaroon.Slice{m}),
 			ExpectStatus: http.StatusUnauthorized,
 			ExpectBody: params.Error{
-				Message: `unauthorized: access denied for user "bob"`,
+				Message: `access denied for user "bob"`,
 				Code:    params.ErrUnauthorized,
 			},
 		})
@@ -1172,7 +1172,7 @@ func (s *authSuite) TestDelegatableMacaroonCannotBeUsedForWriting(c *gc.C) {
 			ExpectStatus: http.StatusUnauthorized,
 			ExpectBody: params.Error{
 				Code:    params.ErrUnauthorized,
-				Message: `unauthorized: access denied for user "bob"`,
+				Message: `access denied for user "bob"`,
 			},
 		})
 	})

--- a/internal/v5/resources_test.go
+++ b/internal/v5/resources_test.go
@@ -330,7 +330,7 @@ func (s *ResourceSuite) TestDownloadBadResourceRevision(c *gc.C) {
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
 			Code:    params.ErrNotFound,
-			Message: `not found: malformed revision number`,
+			Message: `malformed revision number`,
 		},
 	})
 }
@@ -383,7 +383,7 @@ func (s *ResourceSuite) TestDownloadPrivateCharmResource(c *gc.C) {
 		ExpectStatus: http.StatusUnauthorized,
 		ExpectBody: params.Error{
 			Code:    params.ErrUnauthorized,
-			Message: `unauthorized: access denied for user "bob"`,
+			Message: `access denied for user "bob"`,
 		},
 		Do: s.bakeryDoAsUser("bob"),
 	})


### PR DESCRIPTION
We have to be careful that we (probably RemoveExpiredUploads)
can't remove the parts for an upload just as someone has added the
upload to the store. Unfortunately this case is hard to test, because
it needs the FinishUpload to happen between RemoveUpload retrieving
the document and trying to remove it.