### PR TITLE
internal/{charmstore,blobstore}: allow blobstore part sizes to be configured

### DIFF
--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -102,6 +102,9 @@ func serve(confPath string) error {
 		HTTPRequestWaitDuration: conf.RequestTimeout.Duration,
 		SearchCacheMaxAge:       conf.SearchCacheMaxAge.Duration,
 		PublicKeyLocator:        keyring,
+		MinUploadPartSize:       conf.MinUploadPartSize,
+		MaxUploadPartSize:       conf.MaxUploadPartSize,
+		MaxUploadParts:          conf.MaxUploadParts,
 	}
 
 	if conf.AuditLogFile != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,9 @@ type Config struct {
 	SearchCacheMaxAge DurationString  `yaml:"search-cache-max-age,omitempty"`
 	Database          string          `yaml:"database,omitempty"`
 	AccessLog         string          `yaml:"access-log"`
+	MinUploadPartSize int64           `json:"min-upload-part-size"`
+	MaxUploadPartSize int64           `json:"max-upload-part-size"`
+	MaxUploadParts    int             `json:"max-upload-parts"`
 }
 
 func (c *Config) validate() error {

--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -31,8 +31,11 @@ func NewHash() hash.Hash {
 // Store stores data blobs in mongodb, de-duplicating by
 // blob hash.
 type Store struct {
-	uploadc *mgo.Collection
-	mstore  blobstore.ManagedStorage
+	uploadc     *mgo.Collection
+	mstore      blobstore.ManagedStorage
+	minPartSize int64
+	maxParts    int
+	maxPartSize int64
 }
 
 // New returns a new blob store that writes to the given database,
@@ -40,8 +43,11 @@ type Store struct {
 func New(db *mgo.Database, prefix string) *Store {
 	rs := blobstore.NewGridFS(db.Name, prefix, db.Session)
 	return &Store{
-		uploadc: db.C(prefix + ".upload"),
-		mstore:  blobstore.NewManagedStorage(db, rs),
+		uploadc:     db.C(prefix + ".upload"),
+		mstore:      blobstore.NewManagedStorage(db, rs),
+		minPartSize: defaultMinPartSize,
+		maxParts:    defaultMaxParts,
+		maxPartSize: defaultMaxPartSize,
 	}
 }
 

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -110,7 +110,7 @@ func (s *BlobStoreSuite) TestPutPartNegativePart(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestPutPartNumberTooBig(c *gc.C) {
-	s.PatchValue(blobstore.MaxParts, 100)
+	s.store.SetMaxParts(100)
 
 	id := s.newUpload(c)
 	err := s.store.PutPart(id, 100, nil, 0, "")
@@ -124,7 +124,7 @@ func (s *BlobStoreSuite) TestPutPartSizeNonPositive(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestPutPartSizeTooBig(c *gc.C) {
-	s.PatchValue(blobstore.MaxPartSize, int64(5))
+	s.store.SetMaxPartSize(5)
 
 	id := s.newUpload(c)
 	err := s.store.PutPart(id, 0, strings.NewReader(""), 20, hashOf(""))
@@ -188,7 +188,7 @@ func (s *BlobStoreSuite) TestPutPartAgainWithSameHash(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestPutPartOutOfOrder(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	id := s.newUpload(c)
 
 	content1 := "123456789 123456789 "
@@ -211,7 +211,7 @@ func (s *BlobStoreSuite) TestPutPartOutOfOrder(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestPutPartTooSmall(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(100))
+	s.store.SetMinPartSize(100)
 	id := s.newUpload(c)
 
 	content0 := "abcdefghijklmnopqrstuvwxyz"
@@ -224,7 +224,7 @@ func (s *BlobStoreSuite) TestPutPartTooSmall(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestPutPartTooSmallOutOfOrder(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(100))
+	s.store.SetMinPartSize(100)
 	id := s.newUpload(c)
 
 	content1 := "abcdefghijklmnopqrstuvwxyz"
@@ -237,7 +237,7 @@ func (s *BlobStoreSuite) TestPutPartTooSmallOutOfOrder(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestPutPartSmallAtEnd(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	id := s.newUpload(c)
 
 	content0 := "1234"
@@ -287,7 +287,7 @@ func (s *BlobStoreSuite) TestPutPartNotFound(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestFinishUploadMismatchedPartCount(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	id := s.newUpload(c)
 
 	content0 := "123456789 123456789 "
@@ -307,7 +307,7 @@ func (s *BlobStoreSuite) TestFinishUploadMismatchedPartCount(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestFinishUploadMismatchedPartHash(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	id := s.newUpload(c)
 
 	content0 := "123456789 123456789 "
@@ -329,7 +329,7 @@ func (s *BlobStoreSuite) TestFinishUploadMismatchedPartHash(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestFinishUploadPartNotUploaded(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	id := s.newUpload(c)
 
 	content1 := "123456789 123456789 "
@@ -347,7 +347,7 @@ func (s *BlobStoreSuite) TestFinishUploadPartNotUploaded(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestFinishUploadPartIncomplete(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	id := s.newUpload(c)
 
 	content0 := "123456789 123456789 "
@@ -363,7 +363,7 @@ func (s *BlobStoreSuite) TestFinishUploadPartIncomplete(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestFinishUploadCheckSizes(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(50))
+	s.store.SetMinPartSize(50)
 	id := s.newUpload(c)
 	content := "123456789 123456789 "
 	// Upload two small parts concurrently.
@@ -401,7 +401,7 @@ func (s *BlobStoreSuite) TestFinishUploadCheckSizes(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestFinishUploadSuccess(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	id := s.newUpload(c)
 
 	content0 := "123456789 123456789 "
@@ -428,7 +428,6 @@ func (s *BlobStoreSuite) TestFinishUploadSuccess(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestFinishUploadSuccessOnePart(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
 	id := s.newUpload(c)
 
 	content0 := "123456789 123456789 "
@@ -454,7 +453,7 @@ func (s *BlobStoreSuite) TestFinishUploadNotFound(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestFinishUploadAgain(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	id := s.newUpload(c)
 
 	content0 := "123456789 123456789 "
@@ -487,7 +486,7 @@ func (s *BlobStoreSuite) TestFinishUploadAgain(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestFinishUploadRemovedWhenCalculatingHash(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	id := s.newUpload(c)
 
 	// We need at least two parts so that FinishUpload
@@ -532,7 +531,7 @@ func (s *BlobStoreSuite) TestFinishUploadRemovedWhenCalculatingHash(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestRemoveUploadSuccessWithNoPart(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	expires := time.Now().Add(time.Minute).UTC().Truncate(time.Millisecond)
 	id, err := s.store.NewUpload(expires)
 	c.Assert(err, gc.Equals, nil)
@@ -547,7 +546,7 @@ func (s *BlobStoreSuite) TestRemoveUploadOnNonExistingUpload(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestRemoveUploadSuccessWithParts(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	expires := time.Now().Add(time.Minute).UTC().Truncate(time.Millisecond)
 	id, err := s.store.NewUpload(expires)
 	c.Assert(err, gc.Equals, nil)
@@ -561,7 +560,7 @@ func (s *BlobStoreSuite) TestRemoveUploadSuccessWithParts(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestRemoveFinishedUploadDoesNotRemoveParts(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 
 	id, err := s.store.NewUpload(time.Now().Add(time.Minute))
 	c.Assert(err, gc.Equals, nil)
@@ -579,7 +578,7 @@ func (s *BlobStoreSuite) TestRemoveFinishedUploadDoesNotRemoveParts(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestRemoveExpires(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 
 	expireTimes := []time.Duration{-time.Minute, -time.Second, time.Minute, time.Hour}
 	ids := make([]string, len(expireTimes))
@@ -612,7 +611,7 @@ func (s *BlobStoreSuite) TestOpenEmptyMultipart(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestMultipartReadAll(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	part0 := "123456789 12345"
 	part1 := "abcdefghijklmnopqrstuvwxyz"
 	part2 := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -621,7 +620,7 @@ func (s *BlobStoreSuite) TestMultipartReadAll(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestMultipartSmallReads(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	part0 := "123456789 12345"
 	part1 := "abcdefghijklmnopqrstuvwxyz"
 	part2 := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -635,14 +634,14 @@ func (s *BlobStoreSuite) TestMultipartSmallReads(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestMultipartSinglePart(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	part0 := "123456789 12345"
 	id, idx := s.putMultipart(c, part0)
 	s.assertBlobContent(c, id, idx, part0)
 }
 
 func (s *BlobStoreSuite) TestMultipartCloseWithoutReading(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	part0 := "123456789 12345"
 	part1 := "abcdefghijklmnopqrstuvwxyz"
 	id, idx := s.putMultipart(c, part0, part1)
@@ -653,7 +652,7 @@ func (s *BlobStoreSuite) TestMultipartCloseWithoutReading(c *gc.C) {
 }
 
 func (s *BlobStoreSuite) TestUploadInfo(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	part0 := "123456789 12345"
 	part1 := "abcdefghijklmnopqrstuvwxyz"
 	part2 := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -721,7 +720,7 @@ var multipartSeekTests = []struct {
 }}
 
 func (s *BlobStoreSuite) TestMultipartSeek(c *gc.C) {
-	s.PatchValue(blobstore.MinPartSize, int64(10))
+	s.store.SetMinPartSize(10)
 	part0 := "123456789 12345"
 	part1 := "abcdefghijklmnopqrstuvwxyz"
 	part2 := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/internal/blobstore/export_test.go
+++ b/internal/blobstore/export_test.go
@@ -1,9 +1,3 @@
 package blobstore
 
 type UploadDoc uploadDoc
-
-var (
-	MaxParts    = &maxParts
-	MinPartSize = &minPartSize
-	MaxPartSize = &maxPartSize
-)

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -90,6 +90,19 @@ type ServerParams struct {
 	// RootKeyPolicy holds the default policy used when creating
 	// macaroon root keys.
 	RootKeyPolicy mgostorage.Policy
+
+	// MinUploadPartSize holds the minimum size of
+	// an upload part. If it's zero, a default value will be used.
+	MinUploadPartSize int64 `json:"min-upload-part-size"`
+
+	// MaxUploadPartSize holds the maximum size of
+	// an upload part. If it's zero, a default value will be used.
+	MaxUploadPartSize int64 `json:"max-upload-part-size"`
+
+	// MaxUploadParts holds the maximum number of upload
+	// parts that can be uploaded in a single upload.
+	// If it's zero, a default value will be used.
+	MaxUploadParts int `json:"max-upload-parts"`
 }
 
 const defaultRootKeyExpiryDuration = 24 * time.Hour

--- a/server.go
+++ b/server.go
@@ -107,6 +107,19 @@ type ServerParams struct {
 	// RootKeyPolicy holds the default policy used when creating
 	// macaroon root keys.
 	RootKeyPolicy mgostorage.Policy
+
+	// MinUploadPartSize holds the minimum size of
+	// an upload part. If it's zero, a default value will be used.
+	MinUploadPartSize int64 `json:"min-upload-part-size"`
+
+	// MaxUploadPartSize holds the maximum size of
+	// an upload part. If it's zero, a default value will be used.
+	MaxUploadPartSize int64 `json:"max-upload-part-size"`
+
+	// MaxUploadParts holds the maximum number of upload
+	// parts that can be uploaded in a single upload.
+	// If it's zero, a default value will be used.
+	MaxUploadParts int `json:"max-upload-parts"`
 }
 
 // NewServer returns a new handler that handles charm store requests and stores


### PR DESCRIPTION
This means we can configure min, max and max count
for uploaded parts (this is useful for tests in particular,
but also should be useful for tweaking in production).