### PR TITLE
internal/blobstore: fix removing of blobs

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -18,7 +18,7 @@ github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02
 github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
 github.com/juju/testing	git	b8689951f6db31943dd8c3d540b8c4dd368cf850	2016-10-31T10:37:13Z
 github.com/juju/txn	git	99ec629d0066a4d73c54d8e021a7fc1dc07df614	2015-06-09T16:58:27Z
-github.com/juju/utils	git	ff639f825faac294524c2fff065f58fed5bcd77e	2016-11-01T02:02:32Z
+github.com/juju/utils	git	2c7a521b0a6ba1b4d0c29a1670a1d92bbdc23610	2017-02-08T11:46:50Z
 github.com/juju/version	git	ef897ad7f130870348ce306f61332f5335355063	2015-11-27T20:34:00Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z
@@ -38,8 +38,8 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 golang.org/x/sys	git	9bb9f0998d48b31547d975974935ae9b48c7a03c	2016-10-12T00:19:20Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
-gopkg.in/juju/charm.v6-unstable	git	e62786fbece4c6a74945d0d1d19140a69018c07d	2016-09-16T08:55:15Z
-gopkg.in/juju/charmrepo.v2-unstable	git	ebfc20f167247dab5cd4e5161bad2b11477a2321	2017-02-21T12:04:53Z
+gopkg.in/juju/charm.v6-unstable	git	25231c01229677e02c5ea0e0ef1c89ee14a200ad	2017-02-22T13:11:15Z
+gopkg.in/juju/charmrepo.v2-unstable	git	18f410ddb935b90bc64f4a5159c6867435cb274c	2017-02-23T10:53:47Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
 gopkg.in/juju/names.v2	git	e38bc90539f22af61a9c656d35068bd5f0a5b30a	2016-05-25T23:07:23Z
 gopkg.in/macaroon-bakery.v1	git	b5d9ce5682b641993e27aad281d7d5881efd2a73	2016-11-15T16:02:13Z

--- a/internal/blobstore/export_test.go
+++ b/internal/blobstore/export_test.go
@@ -1,3 +1,5 @@
 package blobstore
 
 type UploadDoc uploadDoc
+
+var RemoveExpiredUploads = (*Store).removeExpiredUploads

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -421,7 +421,7 @@ var serveCharmEventErrorsTests = []struct {
 }{{
 	about: "invalid charm URL",
 	url:   "no-such:charm",
-	err:   `invalid charm URL: charm or bundle URL has invalid schema: "no-such:charm"`,
+	err:   `invalid charm URL: cannot parse URL "no-such:charm": schema "no-such" not valid`,
 }, {
 	about: "revision specified",
 	url:   "cs:utopic/django-42",

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1076,13 +1076,13 @@ var routerGetTests = []struct {
 	},
 	monitorKind: "meta",
 }, {
-	about:        "meta request with invalid entity reference",
+	about:        `cannot parse URL "robots.txt": name "robots.txt" not valid`,
 	urlStr:       "/robots.txt/meta/any",
 	handlers:     Handlers{},
 	expectStatus: http.StatusNotFound,
 	expectBody: params.Error{
 		Code:    params.ErrNotFound,
-		Message: `URL has invalid charm or bundle name: "robots.txt"`,
+		Message: `cannot parse URL "robots.txt": name "robots.txt" not valid`,
 	},
 	monitorKind: "",
 }, {
@@ -1093,7 +1093,7 @@ var routerGetTests = []struct {
 	expectStatus:              http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: `URL has invalid charm or bundle name: "robots.txt"`,
+		Message: `cannot parse URL "robots.txt": name "robots.txt" not valid`,
 	},
 	monitorKind: "meta",
 }}
@@ -2060,7 +2060,7 @@ var splitIdTests = []struct {
 	expectURL: "cs:~user/wordpress",
 }, {
 	path:        "",
-	expectError: `URL has invalid charm or bundle name: ""`,
+	expectError: `cannot parse URL "": name "" not valid`,
 }, {
 	path:        "~foo-bar-/wordpress",
 	expectError: `charm or bundle URL has invalid user name: "~foo-bar-/wordpress"`,
@@ -2071,7 +2071,7 @@ func (s *RouterSuite) TestSplitId(c *gc.C) {
 		c.Logf("test %d: %s", i, test.path)
 		url, rest, err := splitId(test.path)
 		if test.expectError != "" {
-			c.Assert(err, gc.ErrorMatches, test.expectError)
+			c.Assert(err, gc.ErrorMatches, test.expectError, gc.Commentf("details: %v", errgo.Details(err)))
 			c.Assert(url, gc.IsNil)
 			c.Assert(rest, gc.Equals, "")
 			continue

--- a/internal/v4/log_test.go
+++ b/internal/v4/log_test.go
@@ -306,7 +306,7 @@ var getLogsErrorsTests = []struct {
 	about:         "invalid id",
 	querystring:   "?id=no-such:reference",
 	expectStatus:  http.StatusBadRequest,
-	expectMessage: `invalid id value: charm or bundle URL has invalid schema: "no-such:reference"`,
+	expectMessage: `invalid id value: cannot parse URL "no-such:reference": schema "no-such" not valid`,
 	expectCode:    params.ErrBadRequest,
 }, {
 	about:         "invalid log level",

--- a/internal/v5/log_test.go
+++ b/internal/v5/log_test.go
@@ -310,7 +310,7 @@ var getLogsErrorsTests = []struct {
 	about:         "invalid id",
 	querystring:   "?id=no-such:reference",
 	expectStatus:  http.StatusBadRequest,
-	expectMessage: `invalid id value: charm or bundle URL has invalid schema: "no-such:reference"`,
+	expectMessage: `invalid id value: cannot parse URL "no-such:reference": schema "no-such" not valid`,
 	expectCode:    params.ErrBadRequest,
 }, {
 	about:         "invalid log level",


### PR DESCRIPTION
Previously, we refused to remove a multipart blob if it was a completed
upload. That doesn't fit with the way that they're used - an upload is
created and then another step associates that upload with a document.

This change changes things so that each upload may be associated with an
"owner" (the thing that's going to refer to the data) and that's set
before actually doing the association.

This means that we can avoid the same blob being used for two different
entities as well as meaning that we have a better idea of when we can
remove orphaned blob data.