### PR TITLE
internal/charmstore: implement blobstore upload GC

### DIFF
--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -105,6 +105,7 @@ func serve(confPath string) error {
 		MinUploadPartSize:       conf.MinUploadPartSize,
 		MaxUploadPartSize:       conf.MaxUploadPartSize,
 		MaxUploadParts:          conf.MaxUploadParts,
+		RunBlobStoreGC:          true,
 	}
 
 	if conf.AuditLogFile != "" {

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -42,12 +42,14 @@ gopkg.in/juju/charm.v6-unstable	git	25231c01229677e02c5ea0e0ef1c89ee14a200ad	201
 gopkg.in/juju/charmrepo.v2-unstable	git	18f410ddb935b90bc64f4a5159c6867435cb274c	2017-02-23T10:53:47Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z
 gopkg.in/juju/names.v2	git	e38bc90539f22af61a9c656d35068bd5f0a5b30a	2016-05-25T23:07:23Z
+gopkg.in/juju/worker.v1	git	8b18096b52dc89d0160eea0a6484175f2b80aa0d	2016-10-03T16:17:01Z
 gopkg.in/macaroon-bakery.v1	git	b5d9ce5682b641993e27aad281d7d5881efd2a73	2016-11-15T16:02:13Z
 gopkg.in/macaroon-bakery.v2-unstable	git	5a131df02b2333d5d75c501743cbc2948ee9bbf0	2016-06-23T14:27:47Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/macaroon.v2-unstable	git	7d806ab8652997999d67d41b894beb0ffd549793	2016-06-14T11:13:15Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/natefinch/lumberjack.v2	git	514cbda263a734ae8caac038dadf05f8f3f9f738	2016-01-25T11:17:49Z
+gopkg.in/retry.v1	git	c09f6b86ba4d5d2cf5bdf0665364aec9fd4815db	2016-10-25T18:14:30Z
 gopkg.in/tomb.v1	git	dd632973f1e7218eb1089048e0798ec9ae7dceb8	2014-10-24T13:56:13Z
 gopkg.in/tomb.v2	git	14b3d72120e8d10ea6e6b7f87f7175734b1faab8	2014-06-26T14:46:23Z
 gopkg.in/yaml.v2	git	a83829b6f1293c91addabc89d0571c246397bbf4	2016-03-01T20:40:22Z

--- a/internal/charmstore/export_test.go
+++ b/internal/charmstore/export_test.go
@@ -3,7 +3,9 @@
 
 package charmstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 
-var TimeToStamp = timeToStamp
+var (
+	TimeToStamp = timeToStamp
+)
 
 // StatsCacheEvictAll removes everything from the stats cache.
 func StatsCacheEvictAll(s *Store) {

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -5,11 +5,18 @@ package charmstore // import "gopkg.in/juju/charmstore.v5-unstable/internal/char
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
+	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/juju/charm.v6-unstable"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/mgostorage"
+	"gopkg.in/retry.v1"
 
+	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
 )
@@ -93,7 +100,6 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 }
 
 func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
-
 	params := ServerParams{
 		AuthUsername:     "test-user",
 		AuthPassword:     "test-password",
@@ -143,10 +149,14 @@ func (s *ServerSuite) TestNewServerWithElasticSearch(c *gc.C) {
 			}),
 		}, nil
 	}
-	h, err := NewServer(s.Session.DB("foo"), &SearchIndex{s.ES, s.TestIndex}, params,
+	h, err := NewServer(
+		s.Session.DB("foo"),
+		&SearchIndex{s.ES, s.TestIndex},
+		params,
 		map[string]NewAPIHandlerFunc{
 			"version1": serveConfig,
-		})
+		},
+	)
 	c.Assert(err, gc.IsNil)
 	defer h.Close()
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -162,6 +172,64 @@ func (s *ServerSuite) TestNewServerWithElasticSearch(c *gc.C) {
 			},
 		},
 	})
+}
+
+func (s *ServerSuite) TestServerStartsBlobstoreGC(c *gc.C) {
+	store := s.newStore(c, "juju_test")
+	defer store.Close()
+
+	uploadIds := make(map[string]int)
+
+	// Create an unowned upload that's immediately out of date.
+	uploadId0 := putMultipart(c, store.BlobStore, time.Now(), "abcdefghijklmnopqrstuvwxy")
+	uploadIds[uploadId0] = 0
+
+	// Create an owned upload that's immediately out of date.
+	uploadId1 := putMultipart(c, store.BlobStore, time.Now(), "abcdefghijklmnopqrstuvwxy")
+	err := store.BlobStore.SetOwner(uploadId1, resourceUploadOwner(&mongodoc.Resource{
+		BaseURL:  charm.MustParseURL("cs:precise/wordpress"),
+		Name:     "something",
+		Revision: 2,
+	}), time.Now())
+	c.Assert(err, gc.Equals, nil)
+	uploadIds[uploadId1] = 1
+
+	// We'd like to create an owned upload that's owned by
+	// a resource, but that involves a bunch of duplicated
+	// logic (we'd need to insert the resource doc manually)
+	// so doesn't give us that much extra confidence.
+	// Instead, we rely on StoreSuite.TestIsUploadOwnedBy
+	// to check the connection between the resource owner
+	// and isUploadOwnedBy.
+
+	params := ServerParams{
+		AuthUsername:   "test-user",
+		AuthPassword:   "test-password",
+		IdentityAPIURL: "http://0.1.2.3",
+		RunBlobStoreGC: true,
+	}
+	h, err := NewServer(s.Session.DB("juju_test"), nil, params, nopAPI)
+	c.Assert(err, gc.IsNil)
+	defer h.Close()
+
+	// The blob should be garbage-collected immediately but because
+	// it's running asynchronously, it may be delayed.
+	attempt := retry.Regular{
+		Total: 1 * time.Second,
+		Delay: 50 * time.Millisecond,
+	}
+	for a := attempt.Start(nil); len(uploadIds) > 0 && a.Next(); {
+		for id := range uploadIds {
+			_, err := store.BlobStore.UploadInfo(id)
+			if err != nil {
+				c.Assert(errgo.Cause(err), gc.Equals, blobstore.ErrNotFound, gc.Commentf("err: %v", err))
+				delete(uploadIds, id)
+			}
+		}
+	}
+	if len(uploadIds) > 0 {
+		c.Fatalf("not all uploads removed; remaining: %v", uploadIds)
+	}
 }
 
 func assertServesVersion(c *gc.C, h http.Handler, vers string) {
@@ -192,4 +260,20 @@ type nopCloseHandler struct {
 }
 
 func (nopCloseHandler) Close() {
+}
+
+var nopAPI = map[string]NewAPIHandlerFunc{
+	"unused": func(*Pool, ServerParams, string) (HTTPCloseHandler, error) {
+		return nopCloseHandler{http.NewServeMux()}, nil
+	},
+}
+
+func (s *ServerSuite) newStore(c *gc.C, dbName string) *Store {
+	p, err := NewPool(s.Session.DB(dbName), nil, &bakery.NewServiceParams{}, ServerParams{
+		MinUploadPartSize: 10,
+	})
+	c.Assert(err, gc.IsNil)
+	store := p.Store()
+	defer p.Close()
+	return store
 }

--- a/server.go
+++ b/server.go
@@ -120,6 +120,10 @@ type ServerParams struct {
 	// parts that can be uploaded in a single upload.
 	// If it's zero, a default value will be used.
 	MaxUploadParts int `json:"max-upload-parts"`
+
+	// RunBlobStoreGC holds whether the server will run
+	// the blobstore garbage collector worker.
+	RunBlobStoreGC bool
 }
 
 // NewServer returns a new handler that handles charm store requests and stores


### PR DESCRIPTION
We start a worker that will sporadically delete uploads that
have passed their expiry date.