### PR TITLE
internal/charmstore: calculate next revision number differently

### DIFF
--- a/internal/mongodoc/doc.go
+++ b/internal/mongodoc/doc.go
@@ -201,6 +201,22 @@ type BaseEntity struct {
 	NoIngest bool `bson:",omitempty"`
 }
 
+// LatestRevision holds an entry in the revisions collection.
+type LatestRevision struct {
+	// URL holds the id that the latest revision is associated
+	// with. URL.Revision is always -1.
+	URL *charm.URL `bson:"_id"`
+
+	// BaseURL holds the reference URL of the charm or bundle
+	// (this omits the series from URL)
+	// e.g. cs:wordpress, cs:~user/foo
+	BaseURL *charm.URL
+
+	// Revision holds the latest known revision for the
+	// URL.
+	Revision int
+}
+
 // ResourceRevision specifies an association of a resource name to a
 // revision.
 type ResourceRevision struct {

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -314,12 +313,10 @@ func (s *ArchiveSuite) TestConcurrentUploads(c *gc.C) {
 
 	// Our strategy for testing concurrent uploads is as follows: We
 	// repeat uploading a bunch of simultaneous uploads to the same
-	// charm. Each upload should either succeed, or fail with an
-	// ErrDuplicateUpload error. We make sure that all replies are
-	// like this, and that at least one duplicate upload error is
-	// found, so that we know we've tested that error path.
+	// charm. Each upload should succeed. We make sure that all replies are
+	// like this.
 
-	errorBodies := make(chan io.ReadCloser)
+	tries := make(chan struct{})
 
 	// upload performs one upload of the testing charm.
 	// It sends the response body on the errorBodies channel when
@@ -336,11 +333,9 @@ func (s *ArchiveSuite) TestConcurrentUploads(c *gc.C) {
 		if !c.Check(err, gc.IsNil) {
 			return
 		}
-		if resp.StatusCode == http.StatusOK {
-			resp.Body.Close()
-			return
-		}
-		errorBodies <- resp.Body
+		defer resp.Body.Close()
+		c.Check(resp.StatusCode, gc.Equals, http.StatusOK)
+		tries <- struct{}{}
 	}
 
 	// The try loop continues concurrently uploading
@@ -360,52 +355,25 @@ func (s *ArchiveSuite) TestConcurrentUploads(c *gc.C) {
 			}
 			wg.Wait()
 		}
-		close(errorBodies)
+		close(tries)
 	}(try)
 
-	// We continue the loop until we have found an
-	// error (or the maximum iteration count has
-	// been exceeded).
-	foundError := false
 	count := 0
 loop:
 	for {
 		select {
-		case body, ok := <-errorBodies:
+		case _, ok := <-tries:
 			if !ok {
 				// The try loop has terminated,
 				// so we need to stop too.
 				break loop
 			}
-			dec := json.NewDecoder(body)
-			var errResp params.Error
-			err := dec.Decode(&errResp)
-			body.Close()
-			c.Assert(err, gc.IsNil)
-			c.Assert(errResp, jc.DeepEquals, params.Error{
-				Message: "duplicate upload",
-				Code:    params.ErrDuplicateUpload,
-			})
-			// We've found the error we're looking for,
-			// so we signal to the try loop that it can stop.
-			// We will process any outstanding error bodies,
-			// before seeing errorBodies closed and exiting
-			// the loop.
-			foundError = true
-			if try != nil {
+		case try <- struct{}{}:
+			if count++; count > 10 {
 				close(try)
 				try = nil
 			}
-		case try <- struct{}{}:
-			// In cases we've seen, the actual maximum value of
-			// count is 1, but let's allow for serious scheduler vagaries.
-			if count++; count > 200 {
-				c.Fatalf("200 tries with no duplicate error")
-			}
 		}
-	}
-	if !foundError {
-		c.Errorf("no duplicate-upload errors found")
 	}
 }
 

--- a/internal/v5/resources_test.go
+++ b/internal/v5/resources_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha512"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/errgo.v1"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"


### PR DESCRIPTION
Currently we calculate the next revision of a charm
or bundle by taking the maximum revision of all
the existing matching entities. This becomes a
problem if you want to delete entities because
there's no longer a way to find out what revision
number to assign next.

We change the logic to keep a separate revision
number collection instead so even when a charm
is deleted, we'll still be able to avoid duplicating
old revisions.

Still to come: the migration code.