### PR TITLE
all: use Equals nil not NotNil for error checks

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,7 +56,7 @@ func (s *ConfigSuite) readConfig(c *gc.C, content string) (*config.Config, error
 	// Write the configuration content to file.
 	path := path.Join(c.MkDir(), "charmd.conf")
 	err := ioutil.WriteFile(path, []byte(content), 0666)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Read the configuration.
 	return config.Read(path)
@@ -64,7 +64,7 @@ func (s *ConfigSuite) readConfig(c *gc.C, content string) (*config.Config, error
 
 func (s *ConfigSuite) TestRead(c *gc.C) {
 	conf, err := s.readConfig(c, testConfig)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(conf, jc.DeepEquals, &config.Config{
 		AuditLogFile:     "/var/log/charmstore/audit.log",
 		AuditLogMaxAge:   1,

--- a/elasticsearch/elasticsearch_test.go
+++ b/elasticsearch/elasticsearch_test.go
@@ -69,11 +69,11 @@ func (s *Suite) TestSuccessfulPostDocument(c *gc.C) {
 		"a": "b",
 	}
 	id, err := s.ES.PostDocument(s.TestIndex, "testtype", doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(id, gc.NotNil)
 	var result map[string]string
 	err = s.ES.GetDocument(s.TestIndex, "testtype", id, &result)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *Suite) TestSuccessfulPutNewDocument(c *gc.C) {
@@ -82,15 +82,15 @@ func (s *Suite) TestSuccessfulPutNewDocument(c *gc.C) {
 	}
 	// Show that no document with this id exists.
 	exists, err := s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, false)
 	err = s.ES.PutDocument(s.TestIndex, "testtype", "a", doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	var result map[string]string
 	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
 	c.Assert(result["a"], gc.Equals, "b")
 	exists, err = s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, true)
 }
 
@@ -99,10 +99,10 @@ func (s *Suite) TestSuccessfulPutUpdatedDocument(c *gc.C) {
 		"a": "b",
 	}
 	err := s.ES.PutDocument(s.TestIndex, "testtype", "a", doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doc["a"] = "c"
 	err = s.ES.PutDocument(s.TestIndex, "testtype", "a", doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	var result map[string]string
 	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
 	c.Assert(result["a"], gc.Equals, "c")
@@ -114,15 +114,15 @@ func (s *Suite) TestPutVersionWithTypeNewDocument(c *gc.C) {
 	}
 	// Show that no document with this id exists.
 	exists, err := s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, false)
 	err = s.ES.PutDocumentVersionWithType(s.TestIndex, "testtype", "a", 1, es.ExternalGTE, doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	var result map[string]string
 	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
 	c.Assert(result["a"], gc.Equals, "b")
 	exists, err = s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, true)
 }
 
@@ -132,18 +132,18 @@ func (s *Suite) TestPutVersionWithTypeUpdateCurrentDocumentVersion(c *gc.C) {
 	}
 	// Show that no document with this id exists.
 	exists, err := s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, false)
 	err = s.ES.PutDocumentVersionWithType(s.TestIndex, "testtype", "a", 1, es.ExternalGTE, doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doc["a"] = "c"
 	err = s.ES.PutDocumentVersionWithType(s.TestIndex, "testtype", "a", 1, es.ExternalGTE, doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	var result map[string]string
 	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
 	c.Assert(result["a"], gc.Equals, "c")
 	exists, err = s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, true)
 }
 
@@ -153,18 +153,18 @@ func (s *Suite) TestPutVersionWithTypeUpdateLaterDocumentVersion(c *gc.C) {
 	}
 	// Show that no document with this id exists.
 	exists, err := s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, false)
 	err = s.ES.PutDocumentVersionWithType(s.TestIndex, "testtype", "a", 1, es.ExternalGTE, doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doc["a"] = "c"
 	err = s.ES.PutDocumentVersionWithType(s.TestIndex, "testtype", "a", 3, es.ExternalGTE, doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	var result map[string]string
 	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
 	c.Assert(result["a"], gc.Equals, "c")
 	exists, err = s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, true)
 }
 
@@ -174,10 +174,10 @@ func (s *Suite) TestPutVersionWithTypeUpdateEarlierDocumentVersion(c *gc.C) {
 	}
 	// Show that no document with this id exists.
 	exists, err := s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, false)
 	err = s.ES.PutDocumentVersionWithType(s.TestIndex, "testtype", "a", 3, es.ExternalGTE, doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doc["a"] = "c"
 	err = s.ES.PutDocumentVersionWithType(s.TestIndex, "testtype", "a", 1, es.ExternalGTE, doc)
 	c.Assert(err, gc.Equals, es.ErrConflict)
@@ -185,7 +185,7 @@ func (s *Suite) TestPutVersionWithTypeUpdateEarlierDocumentVersion(c *gc.C) {
 	err = s.ES.GetDocument(s.TestIndex, "testtype", "a", &result)
 	c.Assert(result["a"], gc.Equals, "b")
 	exists, err = s.ES.HasDocument(s.TestIndex, "testtype", "a")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(exists, gc.Equals, true)
 }
 
@@ -194,9 +194,9 @@ func (s *Suite) TestDelete(c *gc.C) {
 		"a": "b",
 	}
 	_, err := s.ES.PostDocument(s.TestIndex, "testtype", doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.ES.DeleteIndex(s.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *Suite) TestDeleteErrorOnNonExistingIndex(c *gc.C) {
@@ -208,9 +208,9 @@ func (s *Suite) TestDeleteErrorOnNonExistingIndex(c *gc.C) {
 func (s *Suite) TestIndexesCreatedAutomatically(c *gc.C) {
 	doc := map[string]string{"a": "b"}
 	_, err := s.ES.PostDocument(s.TestIndex, "testtype", doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	indexes, err := s.ES.ListAllIndexes()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(indexes, gc.Not(gc.HasLen), 0)
 	found := false
 	for _, index2 := range indexes {
@@ -223,7 +223,7 @@ func (s *Suite) TestIndexesCreatedAutomatically(c *gc.C) {
 
 func (s *Suite) TestHealthIsWorking(c *gc.C) {
 	result, err := s.ES.Health()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(result.ClusterName, gc.NotNil)
 	c.Assert(result.ActivePrimaryShards, gc.NotNil)
 	c.Assert(result.ActiveShards, gc.NotNil)
@@ -239,17 +239,17 @@ func (s *Suite) TestHealthIsWorking(c *gc.C) {
 func (s *Suite) TestSearch(c *gc.C) {
 	doc := map[string]string{"foo": "bar"}
 	_, err := s.ES.PostDocument(s.TestIndex, "testtype", doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doc["foo"] = "baz"
 	id2, err := s.ES.PostDocument(s.TestIndex, "testtype", doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.ES.RefreshIndex(s.TestIndex)
 	q := es.QueryDSL{
 		Query:  es.TermQuery{Field: "foo", Value: "baz"},
 		Fields: []string{"foo"},
 	}
 	results, err := s.ES.Search(s.TestIndex, "testtype", q)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(results.Hits.Total, gc.Equals, 1)
 	c.Assert(results.Hits.Hits[0].ID, gc.Equals, id2)
 	c.Assert(results.Hits.Hits[0].Fields.GetString("foo"), gc.Equals, "baz")
@@ -266,7 +266,7 @@ func (s *Suite) TestPutMapping(c *gc.C) {
 		},
 	}
 	err := s.ES.PutMapping(s.TestIndex, "testtype", mapping)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *Suite) TestEscapeRegexp(c *gc.C) {
@@ -428,7 +428,7 @@ func (S *Suite) TestDecodingHealthStatus(c *gc.C) {
 
 	var h es.ClusterHealth
 	err := json.Unmarshal([]byte(health_message), &h)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(h.ClusterName, gc.Equals, "elasticsearch")
 	c.Assert(h.Status, gc.Equals, "green")
 	c.Assert(h.TimedOut, gc.Equals, true)

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -42,11 +42,11 @@ func (s *BlobStoreSuite) SetUpTest(c *gc.C) {
 func (s *BlobStoreSuite) TestPutTwice(c *gc.C) {
 	content := "some data"
 	err := s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	content = "some different data"
 	err = s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	s.assertBlobContent(c, "x", nil, content)
 }
@@ -54,12 +54,12 @@ func (s *BlobStoreSuite) TestPutTwice(c *gc.C) {
 func (s *BlobStoreSuite) TestPut(c *gc.C) {
 	content := "some data"
 	err := s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	s.assertBlobContent(c, "x", nil, content)
 
 	err = s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *BlobStoreSuite) TestPutInvalidHash(c *gc.C) {
@@ -71,12 +71,12 @@ func (s *BlobStoreSuite) TestPutInvalidHash(c *gc.C) {
 func (s *BlobStoreSuite) TestRemove(c *gc.C) {
 	content := "some data"
 	err := s.store.Put(strings.NewReader(content), "x", int64(len(content)), hashOf(content))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	s.assertBlobContent(c, "x", nil, content)
 
 	err = s.store.Remove("x", nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	s.assertBlobDoesNotExist(c, "x")
 }
@@ -269,7 +269,7 @@ func (s *BlobStoreSuite) TestPutPartConcurrent(c *gc.C) {
 			defer db.Session.Close()
 			store := blobstore.New(db, "blobstore")
 			err := store.PutPart(id, i, newDataSource(int64(i+1), size), size, hash[i])
-			c.Check(err, gc.IsNil)
+			c.Check(err, gc.Equals, nil)
 		}()
 	}
 	wg.Wait()
@@ -813,7 +813,7 @@ func (s *BlobStoreSuite) TestUploadInfo(c *gc.C) {
 	part2 := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	id, _ := s.putMultipartNoRemove(c, part0, part1, part2)
 	info, err := s.store.UploadInfo(id)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	if want := time.Now().Add(50 * time.Second); !info.Expires.After(want) {
 		c.Errorf("unexpected expiry time %v, want at least %v", info.Expires, want)
 	}
@@ -954,7 +954,7 @@ func (s *BlobStoreSuite) assertBlobDoesNotExist(c *gc.C, name string) {
 
 func (s *BlobStoreSuite) assertBlobContent(c *gc.C, name string, idx *mongodoc.MultipartIndex, content string) {
 	r, size, err := s.store.Open(name, idx)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer r.Close()
 	c.Assert(err, gc.Equals, nil)
 	c.Assert(size, gc.Equals, int64(len(content)))
@@ -981,7 +981,7 @@ func isOwnedByNotCalled(c *gc.C) func(_, _ string) (bool, error) {
 func hashOfReader(c *gc.C, r io.Reader) string {
 	h := blobstore.NewHash()
 	_, err := io.Copy(h, r)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -21,27 +21,27 @@ var _ = gc.Suite(&suite{})
 func (*suite) TestSimpleGet(c *gc.C) {
 	p := cache.New(time.Hour)
 	v, err := p.Get("a", fetchValue(2))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, 2)
 }
 
 func (*suite) TestSimpleRefresh(c *gc.C) {
 	p := cache.New(time.Hour)
 	v, err := p.Get("a", fetchValue(2))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, 2)
 
 	v, err = p.Get("a", fetchValue(4))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, 2)
 
 	p.Evict("a")
 	v, err = p.Get("a", fetchValue(3))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, 3)
 
 	v, err = p.Get("a", fetchValue(4))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, 3)
 }
 
@@ -57,11 +57,11 @@ func (*suite) TestFetchError(c *gc.C) {
 func (*suite) TestFetchOnlyOnce(c *gc.C) {
 	p := cache.New(time.Hour)
 	v, err := p.Get("a", fetchValue(2))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, 2)
 
 	v, err = p.Get("a", fetchError(errUnexpectedFetch))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, 2)
 }
 
@@ -69,12 +69,12 @@ func (*suite) TestEntryExpiresAfterMaxEntryAge(c *gc.C) {
 	now := time.Now()
 	p := cache.New(time.Minute)
 	v, err := cache.GetAtTime(p, "a", fetchValue(2), now)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, 2)
 
 	// Entry is definitely not expired before half the entry expiry time.
 	v, err = cache.GetAtTime(p, "a", fetchError(errUnexpectedFetch), now.Add(time.Minute/2-1))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, 2)
 
 	// Entry is definitely expired after the entry expiry time
@@ -88,14 +88,14 @@ func (*suite) TestEntriesRemovedWhenNotRetrieved(c *gc.C) {
 
 	// Populate the cache with an initial entry.
 	v, err := cache.GetAtTime(p, "a", fetchValue("a"), now)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, "a")
 	c.Assert(p.Len(), gc.Equals, 1)
 
 	// Fetch another item after the expiry time,
 	// causing current entries to be moved to old.
 	v, err = cache.GetAtTime(p, "b", fetchValue("b"), now.Add(time.Minute+1))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, "b")
 	c.Assert(p.Len(), gc.Equals, 2)
 
@@ -103,7 +103,7 @@ func (*suite) TestEntriesRemovedWhenNotRetrieved(c *gc.C) {
 	// causing the old entries to be discarded because
 	// nothing has fetched them.
 	v, err = cache.GetAtTime(p, "b", fetchValue("b"), now.Add(time.Minute*2+2))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, "b")
 	c.Assert(p.Len(), gc.Equals, 1)
 }
@@ -116,27 +116,27 @@ func (*suite) TestRefreshedEntry(c *gc.C) {
 
 	// Populate the cache with an initial entry.
 	v, err := cache.GetAtTime(p, "a", fetchValue("a"), now)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, "a")
 	c.Assert(p.Len(), gc.Equals, 1)
 
 	// Fetch another item very close to the expiry time.
 	v, err = cache.GetAtTime(p, "b", fetchValue("b"), now.Add(time.Minute-1))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, "b")
 	c.Assert(p.Len(), gc.Equals, 2)
 
 	// Fetch it again just after the expiry time,
 	// which should move it into the new map.
 	v, err = cache.GetAtTime(p, "b", fetchError(errUnexpectedFetch), now.Add(time.Minute+1))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, "b")
 	c.Assert(p.Len(), gc.Equals, 2)
 
 	// Fetch another item, causing "a" to be removed from the cache
 	// and keeping "b" in there.
 	v, err = cache.GetAtTime(p, "c", fetchValue("c"), now.Add(time.Minute*2+2))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(v, gc.Equals, "c")
 	c.Assert(p.Len(), gc.Equals, 2)
 }
@@ -151,14 +151,14 @@ func (*suite) TestConcurrentFetch(c *gc.C) {
 	go func() {
 		defer wg.Done()
 		v, err := p.Get("a", fetchValue("a"))
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(v, gc.Equals, "a")
 	}()
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		v, err := p.Get("b", fetchValue("b"))
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(v, gc.Equals, "b")
 	}()
 	wg.Wait()
@@ -171,7 +171,7 @@ func (*suite) TestRefreshSpread(c *gc.C) {
 	const N = 100
 	for i := 0; i < N; i++ {
 		v, err := cache.GetAtTime(p, fmt.Sprint(i), fetchValue(i), now)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(v, gc.Equals, i)
 	}
 	counts := make([]int, time.Minute/time.Millisecond/10+1)

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -39,7 +39,7 @@ func (s *AddEntitySuite) TestAddCharmWithUser(c *gc.C) {
 	wordpress := storetesting.Charms.CharmDir("wordpress")
 	url := router.MustNewResolvedURL("cs:~who/precise/wordpress-23", -1)
 	err := store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertBaseEntity(c, store, mongodoc.BaseURL(&url.URL), false)
 }
 
@@ -73,7 +73,7 @@ func (s *AddEntitySuite) TestAddBundleArchive(c *gc.C) {
 		storetesting.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
 	)
 	s.addRequiredCharms(c, bundleArchive)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.checkAddBundle(c, bundleArchive, router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", 3))
 }
 
@@ -86,7 +86,7 @@ func (s *AddEntitySuite) TestAddUserOwnedBundleArchive(c *gc.C) {
 	bundleArchive, err := charm.ReadBundleArchive(
 		storetesting.Charms.BundleArchivePath(c.MkDir(), "wordpress-simple"),
 	)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.checkAddBundle(c, bundleArchive, router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-1", -1))
 }
 
@@ -105,13 +105,13 @@ func (s *AddEntitySuite) TestAddCharmWithMultiSeries(c *gc.C) {
 	s.checkAddCharm(c, ch, router.MustNewResolvedURL("~charmers/multi-series-1", 1))
 	// Make sure it can be accessed with a number of names
 	e, err := store.FindBestEntity(charm.MustParseURL("~charmers/multi-series-1"), params.UnpublishedChannel, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e.URL.String(), gc.Equals, "cs:~charmers/multi-series-1")
 	e, err = store.FindBestEntity(charm.MustParseURL("~charmers/trusty/multi-series-1"), params.UnpublishedChannel, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e.URL.String(), gc.Equals, "cs:~charmers/multi-series-1")
 	e, err = store.FindBestEntity(charm.MustParseURL("~charmers/wily/multi-series-1"), params.UnpublishedChannel, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e.URL.String(), gc.Equals, "cs:~charmers/multi-series-1")
 	_, err = store.FindBestEntity(charm.MustParseURL("~charmers/precise/multi-series-1"), params.UnpublishedChannel, nil)
 	c.Assert(err, gc.ErrorMatches, "no matching charm or bundle for cs:~charmers/precise/multi-series-1")
@@ -123,7 +123,7 @@ func (s *AddEntitySuite) TestAddCharmWithSeriesWhenThereIsAnExistingMultiSeriesV
 	defer store.Close()
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), "multi-series")
 	err := store.AddCharmWithArchive(router.MustNewResolvedURL("~charmers/multi-series-1", -1), ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	ch = storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	err = store.AddCharmWithArchive(router.MustNewResolvedURL("~charmers/trusty/multi-series-2", -1), ch)
 	c.Assert(err, gc.ErrorMatches, `charm name duplicates multi-series charm name cs:~charmers/multi-series-1`)
@@ -141,7 +141,7 @@ func (s *AddEntitySuite) TestAddBundleDuplicatingCharm(c *gc.C) {
 	defer store.Close()
 	ch := storetesting.Charms.CharmDir("wordpress")
 	err := store.AddCharmWithArchive(router.MustNewResolvedURL("~tester/precise/wordpress-2", -1), ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	b := storetesting.Charms.BundleDir("wordpress-simple")
 	s.addRequiredCharms(c, b)
@@ -156,7 +156,7 @@ func (s *AddEntitySuite) TestAddCharmDuplicatingBundle(c *gc.C) {
 	b := storetesting.Charms.BundleDir("wordpress-simple")
 	s.addRequiredCharms(c, b)
 	err := store.AddBundleWithArchive(router.MustNewResolvedURL("~charmers/bundle/wordpress-simple-2", -1), b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	ch := storetesting.Charms.CharmDir("wordpress")
 	err = store.AddCharmWithArchive(router.MustNewResolvedURL("~charmers/precise/wordpress-simple-5", -1), ch)
@@ -301,7 +301,7 @@ func (s *AddEntitySuite) TestUploadEntityErrors(c *gc.C) {
 		c.Logf("test %d: %s", i, test.about)
 		var buf bytes.Buffer
 		err := test.upload.ArchiveTo(&buf)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if test.blobHash == "" {
 			h := blobstore.NewHash()
 			h.Write(buf.Bytes())
@@ -344,15 +344,15 @@ services:
 	file := filepath.Join(c.MkDir(), "bundle.zip")
 	ioutil.WriteFile(file, blob.Bytes(), 0666)
 	bundle, err := charm.ReadBundle(file)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(bundle.Data().Applications, gc.HasLen, 2)
 
 	url := router.MustNewResolvedURL("cs:~who/bundle/wordpress-bundle-33", 33)
 	s.addRequiredCharms(c, bundle)
 	err = store.AddBundleWithArchive(url, bundle)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	entity, err := store.FindEntity(url, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(entity.BundleData.Applications, gc.DeepEquals, bundle.Data().Applications)
 }
 
@@ -363,12 +363,12 @@ func (s *AddEntitySuite) checkAddCharm(c *gc.C, ch charm.Charm, url *router.Reso
 	// Add the charm to the store.
 	beforeAdding := time.Now()
 	err := store.AddCharmWithArchive(url, ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	afterAdding := time.Now()
 
 	var doc *mongodoc.Entity
 	err = store.DB.Entities().FindId(&url.URL).One(&doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// The entity doc has been correctly added to the mongo collection.
 	size, hash, hash256 := getSizeAndHashes(ch)
@@ -398,13 +398,13 @@ func (s *AddEntitySuite) checkAddCharm(c *gc.C, ch charm.Charm, url *router.Reso
 
 	// The charm archive has been properly added to the blob store.
 	r, obtainedSize, err := store.BlobStore.Open(doc.BlobName, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer r.Close()
 	c.Assert(obtainedSize, gc.Equals, size)
 	data, err := ioutil.ReadAll(r)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	charmArchive, err := charm.ReadCharmArchiveBytes(data)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(charmArchive.Meta(), jc.DeepEquals, ch.Meta())
 	c.Assert(charmArchive.Config(), jc.DeepEquals, ch.Config())
 	c.Assert(charmArchive.Actions(), jc.DeepEquals, ch.Actions())
@@ -426,12 +426,12 @@ func (s *AddEntitySuite) checkAddBundle(c *gc.C, bundle charm.Bundle, url *route
 	beforeAdding := time.Now()
 	s.addRequiredCharms(c, bundle)
 	err := store.AddBundleWithArchive(url, bundle)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	afterAdding := time.Now()
 
 	var doc *mongodoc.Entity
 	err = store.DB.Entities().FindId(&url.URL).One(&doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	sort.Sort(orderedURLs(doc.BundleCharms))
 
 	// Check the upload time and then reset it to its zero value
@@ -461,13 +461,13 @@ func (s *AddEntitySuite) checkAddBundle(c *gc.C, bundle charm.Bundle, url *route
 
 	// The bundle archive has been properly added to the blob store.
 	r, obtainedSize, err := store.BlobStore.Open(doc.BlobName, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer r.Close()
 	c.Assert(obtainedSize, gc.Equals, size)
 	data, err := ioutil.ReadAll(r)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	bundleArchive, err := charm.ReadBundleArchiveBytes(data)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(bundleArchive.Data(), jc.DeepEquals, bundle.Data())
 	c.Assert(bundleArchive.ReadMe(), jc.DeepEquals, bundle.ReadMe())
 
@@ -526,7 +526,7 @@ func assertBlobFields(c *gc.C, doc *mongodoc.Entity, url *router.ResolvedURL, ha
 
 func assertBaseEntity(c *gc.C, store *Store, url *charm.URL, promulgated bool) {
 	baseEntity, err := store.FindBaseEntity(url, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	acls := mongodoc.ACL{
 		Read:  []string{url.User},
 		Write: []string{url.User},

--- a/internal/charmstore/common_test.go
+++ b/internal/charmstore/common_test.go
@@ -34,7 +34,7 @@ func (s *commonSuite) newStore(c *gc.C, withElasticSearch bool) *Store {
 	p, err := NewPool(s.Session.DB("juju_test"), si, &bakery.NewServiceParams{}, ServerParams{
 		MinUploadPartSize: 10,
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	store := p.Store()
 	defer p.Close()
 	return store
@@ -62,8 +62,8 @@ func addRequiredCharms(c *gc.C, store *Store, bundle charm.Bundle) {
 			rurl.PromulgatedRevision = -1
 		}
 		err := store.AddCharmWithArchive(&rurl, ch)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = store.Publish(&rurl, nil, params.StableChannel)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }

--- a/internal/charmstore/migrations_integration_test.go
+++ b/internal/charmstore/migrations_integration_test.go
@@ -46,10 +46,10 @@ func (s *migrationsIntegrationSuite) dump(c *gc.C) {
 	// environment variables which are needed for
 	// dumpMigrationHistory to run.
 	session, err := jujutesting.MgoServer.Dial()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer session.Close()
 	err = dumpMigrationHistory(session, earliestDeployedVersion, migrationHistory)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 var migrationHistory = []versionSpec{{
@@ -587,9 +587,9 @@ var migrationFromDumpBaseEntityTests = []struct {
 func (s *migrationsIntegrationSuite) TestMigrationFromDump(c *gc.C) {
 	db := s.Session.DB("juju_test")
 	err := createDatabaseAtVersion(db, migrationHistory[len(migrationHistory)-1].version)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.runMigrations(db)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	store := s.newStore(c, false)
 	defer store.Close()
@@ -600,7 +600,7 @@ func (s *migrationsIntegrationSuite) TestMigrationFromDump(c *gc.C) {
 		c.Logf("test %d: entity %v", i, test.id)
 
 		e, err := store.FindEntity(MustParseResolvedURL(test.id), nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		for j, check := range test.checkers {
 			c.Logf("test %d: entity %v; check %d", i, test.id, j)
 			check(c, e)
@@ -611,7 +611,7 @@ func (s *migrationsIntegrationSuite) TestMigrationFromDump(c *gc.C) {
 		c.Logf("test %d: base entity %v", i, test.id)
 
 		e, err := store.FindBaseEntity(charm.MustParseURL(test.id), nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		for j, check := range test.checkers {
 			c.Logf("test %d: base entity %v; check %d", i, test.id, j)
 			check(c, e)
@@ -661,7 +661,7 @@ func checkAllEntityInvariants(c *gc.C, store *Store) {
 	var entities []*mongodoc.Entity
 
 	err := store.DB.Entities().Find(nil).All(&entities)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	for _, e := range entities {
 		c.Logf("check entity invariants %v", e.URL)
 		checkEntityInvariants(c, e, store)
@@ -669,7 +669,7 @@ func checkAllEntityInvariants(c *gc.C, store *Store) {
 
 	var baseEntities []*mongodoc.BaseEntity
 	err = store.DB.BaseEntities().Find(nil).All(&baseEntities)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	for _, e := range baseEntities {
 		c.Logf("check base entity invariants %v", e.URL)
 		checkBaseEntityInvariants(c, e, store)
@@ -737,15 +737,15 @@ func checkEntityInvariants(c *gc.C, e *mongodoc.Entity, store *Store) {
 
 	// Check that the blobs exist.
 	r, err := store.OpenBlob(EntityResolvedURL(e))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Close()
 	r, err = store.OpenBlobPreV5(EntityResolvedURL(e))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Close()
 
 	// Check that the base entity exists.
 	_, err = store.FindBaseEntity(e.URL, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func stringInSlice(s string, ss []string) bool {
@@ -774,7 +774,7 @@ func checkBaseEntityInvariants(c *gc.C, e *mongodoc.BaseEntity, store *Store) {
 				c.Assert(url.Series, gc.Equals, series)
 			}
 			ce, err := store.FindEntity(MustParseResolvedURL(url.String()), nil)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			if !params.ValidChannels[ch] {
 				c.Fatalf("unknown channel %q found", ch)
 			}

--- a/internal/charmstore/migrations_test.go
+++ b/internal/charmstore/migrations_test.go
@@ -71,7 +71,7 @@ func (s *migrationsSuite) TestMigrate(c *gc.C) {
 
 	// Start the server.
 	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// The two migrations have been correctly executed in order.
 	c.Assert(s.executed, jc.DeepEquals, names)
@@ -81,7 +81,7 @@ func (s *migrationsSuite) TestMigrate(c *gc.C) {
 
 	// Restart the server again and check migrations this time are not run.
 	err = s.newServer(c)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(s.executed, jc.DeepEquals, names)
 	s.checkExecuted(c, names...)
 }
@@ -92,7 +92,7 @@ func (s *migrationsSuite) TestMigrateNoMigrations(c *gc.C) {
 
 	// Start the server.
 	err := s.newServer(c)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// No migrations were executed.
 	c.Assert(s.executed, gc.HasLen, 0)
@@ -102,16 +102,16 @@ func (s *migrationsSuite) TestMigrateNoMigrations(c *gc.C) {
 func (s *migrationsSuite) TestMigrateNewMigration(c *gc.C) {
 	// Simulate two migrations were already run.
 	err := setExecuted(s.db, "migr-1")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = setExecuted(s.db, "migr-2")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Create migrations.
 	s.makeMigrations(c, "migr-1", "migr-2", "migr-3")
 
 	// Start the server.
 	err = s.newServer(c)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Only one migration has been executed.
 	c.Assert(s.executed, jc.DeepEquals, []mongodoc.MigrationName{"migr-3"})
@@ -123,7 +123,7 @@ func (s *migrationsSuite) TestMigrateNewMigration(c *gc.C) {
 func (s *migrationsSuite) TestMigrateErrorUnknownMigration(c *gc.C) {
 	// Simulate that a migration was already run.
 	err := setExecuted(s.db, "migr-1")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Create migrations, without including the already executed one.
 	s.makeMigrations(c, "migr-2", "migr-3")
@@ -186,7 +186,7 @@ func (s *migrationsSuite) checkExecuted(c *gc.C, expected ...mongodoc.MigrationN
 	var obtained []mongodoc.MigrationName
 	var doc mongodoc.Migration
 	if err := s.db.Migrations().Find(nil).One(&doc); err != mgo.ErrNotFound {
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		obtained = doc.Executed
 	}
 	c.Assert(obtained, jc.SameContents, expected)

--- a/internal/charmstore/resources_test.go
+++ b/internal/charmstore/resources_test.go
@@ -44,7 +44,7 @@ func (s *resourceSuite) TestInsert(c *gc.C) {
 
 	// First insert works correctly.
 	err := store.DB.Resources().Insert(r)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Attempting to insert the same revision fails.
 	r.BlobHash = "78910"
@@ -54,7 +54,7 @@ func (s *resourceSuite) TestInsert(c *gc.C) {
 	// Inserting a different revision succeeds.
 	r.Revision = 1
 	err = store.DB.Resources().Insert(r)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 var newResourceQueryTests = []struct {
@@ -102,20 +102,20 @@ func (s *resourceSuite) TestNewResourceQuery(c *gc.C) {
 	} {
 		parts := strings.SplitN(r, "|", 3)
 		rev, err := strconv.Atoi(parts[2])
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = store.DB.Resources().Insert(&mongodoc.Resource{
 			BaseURL:  charm.MustParseURL(parts[0]),
 			Name:     parts[1],
 			Revision: rev,
 		})
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	for i, test := range newResourceQueryTests {
 		c.Logf("%d. %s", i, test.about)
 		q := newResourceQuery(test.url, test.name, test.revision)
 		var results []*mongodoc.Resource
 		err := store.DB.Resources().Find(q).All(&results)
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(err, gc.Equals, nil)
 		sortResources(test.expectResources)
 		sortResources(results)
 		c.Assert(results, jc.DeepEquals, test.expectResources)
@@ -129,17 +129,17 @@ func (s *resourceSuite) TestListResourcesCharmWithResources(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	meta := storetesting.MetaWithResources(nil, "resource1", "resource2")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	uploadResources(c, store, id, "")
 
 	err = store.Publish(id, map[string]int{
 		"resource1": 0,
 		"resource2": 0,
 	}, params.StableChannel)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	docs, err := store.ListResources(id, params.StableChannel)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	checkResourceDocs(c, store, id, []string{"resource1/0", "resource2/0"}, docs)
 }
@@ -150,10 +150,10 @@ func (s *resourceSuite) TestListResourcesCharmWithoutResources(c *gc.C) {
 
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(nil))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	resources, err := store.ListResources(id, params.StableChannel)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	c.Check(resources, gc.HasLen, 0)
 }
@@ -164,7 +164,7 @@ func (s *resourceSuite) TestListResourcesWithNoChannel(c *gc.C) {
 
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(nil))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	resources, err := store.ListResources(id, "")
 	c.Assert(err, gc.ErrorMatches, "no channel specified")
@@ -185,10 +185,10 @@ func (s *resourceSuite) TestListResourcesBundle(c *gc.C) {
 	})
 	s.addRequiredCharms(c, b)
 	err := store.AddBundleWithArchive(id, b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	resources, err := store.ListResources(id, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(resources, gc.HasLen, 0)
 }
 
@@ -198,13 +198,13 @@ func (s *resourceSuite) TestListResourcesResourceNotFound(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	ch := storetesting.NewCharm(storetesting.MetaWithResources(nil, "resource1", "resource2"))
 	err := store.AddCharmWithArchive(id, ch)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	uploadResource(c, store, id, "resource1", "something")
 
 	// A resource exists for resource1, but not resource2. Expect a
 	// placeholder to be returned for resource2.
 	docs, err := store.ListResources(id, params.UnpublishedChannel)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	checkResourceDocs(c, store, id, []string{"resource1/0", "resource2/-1"}, docs)
 }
@@ -216,12 +216,12 @@ func (s *resourceSuite) TestUploadResource(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	meta := storetesting.MetaWithResources(nil, "someResource")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	now := time.Now()
 	blob := "content 1"
 	res, err := store.UploadResource(id, "someResource", strings.NewReader(blob), hashOfString(blob), int64(len(blob)))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	if res.UploadTime.Before(now) {
 		c.Fatalf("upload time earlier than expected; want > %v; got %v", now, res.UploadTime)
 	}
@@ -229,7 +229,7 @@ func (s *resourceSuite) TestUploadResource(c *gc.C) {
 
 	blob = "content 2"
 	res, err = store.UploadResource(id, "someResource", strings.NewReader(blob), hashOfString(blob), int64(len(blob)))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	checkResourceDocs(c, store, id, []string{"someResource/1"}, []*mongodoc.Resource{res})
 }
 
@@ -240,7 +240,7 @@ func (s *resourceSuite) TestAddResourceWithUploadId(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	meta := storetesting.MetaWithResources(nil, "someResource")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	contents := []string{
 		"123456789 123456789 ",
@@ -249,7 +249,7 @@ func (s *resourceSuite) TestAddResourceWithUploadId(c *gc.C) {
 	uid := putMultipart(c, store.BlobStore, time.Time{}, contents...)
 
 	res, err := store.AddResourceWithUploadId(id, "someResource", uid)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Check that the upload document has been removed.
 	_, err = store.BlobStore.UploadInfo(uid)
@@ -258,12 +258,12 @@ func (s *resourceSuite) TestAddResourceWithUploadId(c *gc.C) {
 	checkResourceDocs(c, store, id, []string{"someResource/0"}, []*mongodoc.Resource{res})
 	allContents := strings.Join(contents, "")
 	blob, err := store.OpenResourceBlob(res)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer blob.Close()
 	c.Assert(blob.Size, gc.Equals, int64(len(allContents)))
 	c.Assert(blob.Hash, gc.Equals, hashOfString(allContents))
 	data, err := ioutil.ReadAll(blob)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(data), gc.Equals, allContents)
 }
 
@@ -274,7 +274,7 @@ func (s *resourceSuite) TestAddResourceWithSharedUploadId(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	meta := storetesting.MetaWithResources(nil, "someResource")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	contents := []string{
 		"123456789 123456789 ",
@@ -352,7 +352,7 @@ func (s *resourceSuite) TestUploadResourceErrors(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	meta := storetesting.MetaWithResources(nil, "someResource")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	for i, test := range uploadResourceErrorTests {
 		c.Logf("%d. %s", i, test.about)
@@ -434,24 +434,24 @@ func (s *resourceSuite) TestResolveResource(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	meta := storetesting.MetaWithResources(nil, "someResource")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Upload three version of the resource.
 	for i := 0; i < 3; i++ {
 		content := fmt.Sprintf("content%d", i)
 		_, err := store.UploadResource(id, "someResource", strings.NewReader(content), hashOfString(content), int64(len(content)))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	// Publish the charm to different channels with the different resources.
 	err = store.Publish(id, map[string]int{
 		"someResource": 0,
 	}, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	err = store.Publish(id, map[string]int{
 		"someResource": 1,
 	}, params.EdgeChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	for i, test := range resolveResourceTests {
 		c.Logf("%d. %s", i, test.about)
@@ -461,7 +461,7 @@ func (s *resourceSuite) TestResolveResource(c *gc.C) {
 			c.Assert(errgo.Cause(err), gc.Equals, test.expectErrorCause)
 			continue
 		}
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(err, gc.Equals, nil)
 		checkResourceDocs(c, store, id, []string{fmt.Sprintf("someResource/%d", test.expectResource)}, []*mongodoc.Resource{res})
 	}
 }
@@ -472,7 +472,7 @@ func (s *resourceSuite) TestPublishWithResourceNotInMetadata(c *gc.C) {
 
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(nil))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	err = store.Publish(id, map[string]int{
 		"resource1": 0,
@@ -488,7 +488,7 @@ func (s *resourceSuite) TestPublishWithResourceNotFound(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	meta := storetesting.MetaWithResources(nil, "resource1")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	err = store.Publish(id, map[string]int{
 		"resource1": 0,
@@ -504,7 +504,7 @@ func (s *resourceSuite) TestPublishWithoutAllRequiredResources(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	meta := storetesting.MetaWithResources(nil, "resource1", "resource2", "resource3")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	uploadResource(c, store, id, "resource2", "content")
 
@@ -522,21 +522,21 @@ func (s *resourceSuite) TestOpenResourceBlob(c *gc.C) {
 	meta := storetesting.MetaWithResources(nil, "someResource")
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	content := "some content"
 	uploadResource(c, store, id, "someResource", content)
 
 	res, err := store.ResolveResource(id, "someResource", -1, params.UnpublishedChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	blob, err := store.OpenResourceBlob(res)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer blob.Close()
 	c.Assert(blob.Size, gc.Equals, int64(len(content)))
 	c.Assert(blob.Hash, gc.Equals, hashOfString(content))
 	data, err := ioutil.ReadAll(blob)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(data), gc.Equals, content)
 
 	// Change the blob name so that it's invalid so that we can
@@ -551,20 +551,20 @@ func (s *resourceSuite) TestOpenResourceBlob(c *gc.C) {
 // followed by the given content suffix.
 func uploadResources(c *gc.C, store *Store, id *router.ResolvedURL, contentSuffix string) {
 	entity, err := store.FindEntity(id, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	for name := range entity.CharmMeta.Resources {
 		c.Logf("uploading resource %v", name)
 		content := name + contentSuffix
 		hash := hashOfString(content)
 		r := strings.NewReader(content)
 		_, err := store.UploadResource(id, name, r, hash, int64(len(content)))
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
 func uploadResource(c *gc.C, store *Store, id *router.ResolvedURL, name string, blob string) {
 	_, err := store.UploadResource(id, name, strings.NewReader(blob), hashOfString(blob), int64(len(blob)))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func resourceRevisions(resources []*mongodoc.Resource) map[string]int {
@@ -596,7 +596,7 @@ func checkResourceDocs(c *gc.C, store *Store, id *router.ResolvedURL, expectReso
 			continue
 		}
 		expectDoc, err := store.ResolveResource(id, rid.Name, rid.Revision, params.UnpublishedChannel)
-		c.Assert(err, gc.IsNil, gc.Commentf("resource %v/%d", rid.Name, rid.Revision))
+		c.Assert(err, gc.Equals, nil, gc.Commentf("resource %v/%d", rid.Name, rid.Revision))
 
 		// Mongo's time stamps are only accurate to a millisecond.
 		// If we're checking against a document that's been created

--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -33,11 +33,11 @@ func (s *StoreSearchSuite) SetUpTest(c *gc.C) {
 	s.index = SearchIndex{s.ES, s.TestIndex}
 	s.ES.RefreshIndex(".versions")
 	pool, err := NewPool(s.Session.DB("foo"), &s.index, nil, ServerParams{})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.pool = pool
 	s.store = pool.Store()
 	s.addEntities(c)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *StoreSearchSuite) TearDownTest(c *gc.C) {
@@ -187,17 +187,17 @@ func (s *StoreSearchSuite) addEntities(c *gc.C) {
 	}
 	s.store.pool.statsCache.EvictAll()
 	err := s.store.syncSearch()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *StoreSearchSuite) TestSuccessfulExport(c *gc.C) {
 	s.store.pool.statsCache.EvictAll()
 	for _, ent := range searchEntities {
 		entity, err := s.store.FindEntity(EntityResolvedURL(ent.entity), nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		var actual json.RawMessage
 		err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL), &actual)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		series := entity.SupportedSeries
 		if ent.bundleData != nil {
 			series = []string{"bundle"}
@@ -227,15 +227,15 @@ func (s *StoreSearchSuite) TestNoExportDeprecated(c *gc.C) {
 	)
 	var entity *mongodoc.Entity
 	err := s.store.DB.Entities().FindId("cs:~openstack-charmers/xenial/mysql-7").One(&entity)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	present, err := s.store.ES.HasDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(present, gc.Equals, true)
 
 	err = s.store.DB.Entities().FindId("cs:~charmers/saucy/mysql-4").One(&entity)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	present, err = s.store.ES.HasDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(present, gc.Equals, false)
 }
 
@@ -253,11 +253,11 @@ func (s *StoreSearchSuite) TestExportOnlyLatest(c *gc.C) {
 	var expected, old *mongodoc.Entity
 	var actual json.RawMessage
 	err := s.store.DB.Entities().FindId("cs:~charmers/precise/wordpress-23").One(&old)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.DB.Entities().FindId("cs:~charmers/precise/wordpress-24").One(&expected)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(old.URL), &actual)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doc := SearchDoc{
 		Entity:       expected,
 		ReadACLs:     []string{"charmers", params.Everyone},
@@ -292,11 +292,11 @@ func (s *StoreSearchSuite) TestExportMultiSeriesCharmsCreateExpandedVersions(c *
 	var expected, old *mongodoc.Entity
 	var actual json.RawMessage
 	err := s.store.DB.Entities().FindId("cs:~charmers/xenial/juju-gui-24").One(&old)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.DB.Entities().FindId("cs:~charmers/juju-gui-25").One(&expected)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(expected.URL), &actual)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doc := SearchDoc{
 		Entity:       expected,
 		ReadACLs:     []string{"charmers"},
@@ -306,7 +306,7 @@ func (s *StoreSearchSuite) TestExportMultiSeriesCharmsCreateExpandedVersions(c *
 	}
 	c.Assert(string(actual), jc.JSONEquals, doc)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(old.URL), &actual)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	expected.URL.Series = old.URL.Series
 	doc = SearchDoc{
 		Entity:       expected,
@@ -322,12 +322,12 @@ func (s *StoreSearchSuite) TestExportSearchDocument(c *gc.C) {
 	var entity *mongodoc.Entity
 	var actual json.RawMessage
 	err := s.store.DB.Entities().FindId("cs:~charmers/precise/wordpress-23").One(&entity)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doc := SearchDoc{Entity: entity, TotalDownloads: 4000}
 	err = s.store.ES.update(&doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(entity.URL), &actual)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(actual), jc.JSONEquals, doc)
 }
 
@@ -737,7 +737,7 @@ func (s *StoreSearchSuite) TestSearches(c *gc.C) {
 	for i, test := range searchTests {
 		c.Logf("test %d: %s", i, test.about)
 		res, err := s.store.Search(test.sp)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		sort.Sort(resolvedURLsByString(res.Results))
 		sort.Sort(resolvedURLsByString(test.results))
 		c.Check(Entities(res.Results), jc.DeepEquals, test.results)
@@ -761,26 +761,26 @@ func (r resolvedURLsByString) Len() int {
 
 func (s *StoreSearchSuite) TestPaginatedSearch(c *gc.C) {
 	err := s.store.ES.Database.RefreshIndex(s.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	sp := SearchParams{
 		Text: "wordpress",
 		Skip: 1,
 	}
 	res, err := s.store.Search(sp)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(res.Results, gc.HasLen, 1)
 	c.Assert(res.Total, gc.Equals, 2)
 }
 
 func (s *StoreSearchSuite) TestLimitTestSearch(c *gc.C) {
 	err := s.store.ES.Database.RefreshIndex(s.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	sp := SearchParams{
 		Text:  "wordpress",
 		Limit: 1,
 	}
 	res, err := s.store.Search(sp)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(res.Results, gc.HasLen, 1)
 }
 
@@ -802,7 +802,7 @@ func (s *StoreSearchSuite) TestPromulgatedRank(c *gc.C) {
 		},
 	}
 	res, err := s.store.Search(sp)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(Entities(res.Results), jc.DeepEquals, Entities{
 		ent,
 		searchEntities["varnish"].entity,
@@ -908,9 +908,9 @@ func (s *StoreSearchSuite) TestSorting(c *gc.C) {
 		c.Logf("test %d. %s", i, test.about)
 		var sp SearchParams
 		err := sp.ParseSortFields(test.sortQuery)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		res, err := s.store.Search(sp)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(Entities(res.Results), jc.DeepEquals, test.results)
 		c.Assert(res.Total, gc.Equals, len(test.results))
 	}
@@ -920,7 +920,7 @@ func (s *StoreSearchSuite) TestBoosting(c *gc.C) {
 	s.store.ES.Database.RefreshIndex(s.TestIndex)
 	var sp SearchParams
 	res, err := s.store.Search(sp)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(Entities(res.Results), jc.DeepEquals, Entities{
 		searchEntities["wordpress-simple"].entity,
 		searchEntities["mysql"].entity,
@@ -1101,7 +1101,7 @@ func (s *StoreSearchSuite) TestMultiSeriesCharmFiltersSeriesCorrectly(c *gc.C) {
 				"series": {test.series},
 			},
 		})
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if test.notFound {
 			c.Assert(res.Results, gc.HasLen, 0)
 			continue
@@ -1126,7 +1126,7 @@ func (s *StoreSearchSuite) TestMultiSeriesCharmSortsSeriesCorrectly(c *gc.C) {
 	var sp SearchParams
 	sp.ParseSortFields("-series", "owner")
 	res, err := s.store.Search(sp)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(Entities(res.Results), jc.DeepEquals, Entities{
 		newEntity("cs:~charmers/yakkety/squid-forwardproxy-3", 3),
 		newEntity("cs:~charmers/juju-gui-25", -1, "trusty", "xenial", "utopic", "vivid", "wily", "yakkety"),
@@ -1144,37 +1144,37 @@ func (s *StoreSearchSuite) TestOnlyIndexStableCharms(c *gc.C) {
 	})
 	id := router.MustNewResolvedURL("~test/xenial/test-0", -1)
 	err := s.store.AddCharmWithArchive(id, ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.SetPerms(&id.URL, "read", "test", params.Everyone)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.SetPerms(&id.URL, "edge.read", "test", params.Everyone)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.SetPerms(&id.URL, "stable.read", "test", params.Everyone)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	var actual json.RawMessage
 
 	err = s.store.UpdateSearch(id)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(&id.URL), &actual)
 	c.Assert(err, gc.ErrorMatches, "elasticsearch document not found")
 
 	err = s.store.Publish(id, nil, params.EdgeChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.UpdateSearch(id)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(&id.URL), &actual)
 	c.Assert(err, gc.ErrorMatches, "elasticsearch document not found")
 
 	err = s.store.Publish(id, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.UpdateSearch(id)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.ES.GetDocument(s.TestIndex, typeName, s.store.ES.getID(&id.URL), &actual)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	entity, err := s.store.FindEntity(id, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doc := SearchDoc{
 		Entity:       entity,
 		ReadACLs:     []string{"test", params.Everyone},
@@ -1190,15 +1190,15 @@ func (s *StoreSearchSuite) TestOnlyIndexStableCharms(c *gc.C) {
 // automatically published on the stable channel.
 func addCharmForSearch(c *gc.C, s *Store, id *router.ResolvedURL, ch charm.Charm, acl []string, downloads int) {
 	err := s.AddCharmWithArchive(id, ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	for i := 0; i < downloads; i++ {
 		err := s.IncrementDownloadCounts(id)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	err = s.SetPerms(&id.URL, "stable.read", acl...)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.Publish(id, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 // addBundleForSearch adds a bundle to the specified store such that it
@@ -1206,15 +1206,15 @@ func addCharmForSearch(c *gc.C, s *Store, id *router.ResolvedURL, ch charm.Charm
 // automatically published on the stable channel.
 func addBundleForSearch(c *gc.C, s *Store, id *router.ResolvedURL, b charm.Bundle, acl []string, downloads int) {
 	err := s.AddBundleWithArchive(id, b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	for i := 0; i < downloads; i++ {
 		err := s.IncrementDownloadCounts(id)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	err = s.SetPerms(&id.URL, "stable.read", acl...)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.Publish(id, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 type Entities []*mongodoc.Entity

--- a/internal/charmstore/server_test.go
+++ b/internal/charmstore/server_test.go
@@ -62,7 +62,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	h, err := NewServer(db, nil, serverParams, map[string]NewAPIHandlerFunc{
 		"version1": serveVersion("version1"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	assertServesVersion(c, h, "version1")
 	assertDoesNotServeVersion(c, h, "version2")
@@ -72,7 +72,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 		"version1": serveVersion("version1"),
 		"version2": serveVersion("version2"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	assertServesVersion(c, h, "version1")
 	assertServesVersion(c, h, "version2")
@@ -83,7 +83,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 		"version2": serveVersion("version2"),
 		"version3": serveVersion("version3"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	assertServesVersion(c, h, "version1")
 	assertServesVersion(c, h, "version2")
@@ -93,7 +93,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 		"version1": serveVersion("version1"),
 		"":         serveVersion(""),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	assertServesVersion(c, h, "")
 	assertServesVersion(c, h, "version1")
@@ -115,7 +115,7 @@ func (s *ServerSuite) TestNewServerWithConfig(c *gc.C) {
 	h, err := NewServer(s.Session.DB("foo"), nil, params, map[string]NewAPIHandlerFunc{
 		"version1": serveConfig,
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 
 	// The IdentityLocation field is filled out from the IdentityAPIURL
@@ -157,7 +157,7 @@ func (s *ServerSuite) TestNewServerWithElasticSearch(c *gc.C) {
 			"version1": serveConfig,
 		},
 	)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: h,
@@ -209,7 +209,7 @@ func (s *ServerSuite) TestServerStartsBlobstoreGC(c *gc.C) {
 		RunBlobStoreGC: true,
 	}
 	h, err := NewServer(s.Session.DB("juju_test"), nil, params, nopAPI)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 
 	// The blob should be garbage-collected immediately but because
@@ -272,7 +272,7 @@ func (s *ServerSuite) newStore(c *gc.C, dbName string) *Store {
 	p, err := NewPool(s.Session.DB(dbName), nil, &bakery.NewServiceParams{}, ServerParams{
 		MinUploadPartSize: 10,
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	store := p.Store()
 	defer p.Close()
 	return store

--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -131,7 +131,7 @@ func (s *StoreSuite) testURLFinding(c *gc.C, check func(store *Store, expand *ch
 	for i, test := range urlFindingTests {
 		c.Logf("test %d: %q from %q", i, test.expand, test.inStore)
 		_, err := store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		urls := MustParseResolvedURLs(test.inStore)
 		for _, url := range urls {
 			name := url.URL.Name
@@ -139,7 +139,7 @@ func (s *StoreSuite) testURLFinding(c *gc.C, check func(store *Store, expand *ch
 				charms[name] = storetesting.Charms.CharmDir(name)
 			}
 			err := store.AddCharmWithArchive(url, charms[name])
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		check(store, charm.MustParseURL(test.expand), MustParseResolvedURLs(test.expect))
 	}
@@ -151,19 +151,19 @@ func (s *StoreSuite) TestRequestStore(c *gc.C) {
 		MaxMgoSessions:          1,
 	}
 	p, err := NewPool(s.Session.DB("juju_test"), nil, nil, config)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer p.Close()
 
 	// Instances within the limit can be acquired
 	// instantly without error.
 	store, err := p.RequestStore()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	store.Close()
 
 	// Check that when we get another instance,
 	// we reuse the original.
 	store1, err := p.RequestStore()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer store1.Close()
 	c.Assert(store1, gc.Equals, store)
 
@@ -185,10 +185,10 @@ func (s *StoreSuite) TestRequestStoreSatisfiedWithinTimeout(c *gc.C) {
 		MaxMgoSessions:          1,
 	}
 	p, err := NewPool(s.Session.DB("juju_test"), nil, nil, config)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer p.Close()
 	store, err := p.RequestStore()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Start a goroutine that will close the Store after a short period.
 	go func() {
@@ -196,7 +196,7 @@ func (s *StoreSuite) TestRequestStoreSatisfiedWithinTimeout(c *gc.C) {
 		store.Close()
 	}()
 	store1, err := p.RequestStore()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(store1, gc.Equals, store)
 	store1.Close()
 }
@@ -207,10 +207,10 @@ func (s *StoreSuite) TestRequestStoreLimitCanBeExceeded(c *gc.C) {
 		MaxMgoSessions:          1,
 	}
 	p, err := NewPool(s.Session.DB("juju_test"), nil, nil, config)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer p.Close()
 	store, err := p.RequestStore()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer store.Close()
 
 	store1 := store.Copy()
@@ -228,7 +228,7 @@ func (s *StoreSuite) TestRequestStoreFailsWhenPoolIsClosed(c *gc.C) {
 		MaxMgoSessions:          1,
 	}
 	p, err := NewPool(s.Session.DB("juju_test"), nil, nil, config)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	p.Close()
 	store, err := p.RequestStore()
 	c.Assert(err, gc.ErrorMatches, "charm store has been closed")
@@ -241,18 +241,18 @@ func (s *StoreSuite) TestRequestStoreLimitMaintained(c *gc.C) {
 		MaxMgoSessions:          1,
 	}
 	p, err := NewPool(s.Session.DB("juju_test"), nil, nil, config)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer p.Close()
 
 	// Acquire an instance.
 	store, err := p.RequestStore()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer store.Close()
 
 	// Acquire another instance, exceeding the limit,
 	// and put it back.
 	store1 := p.Store()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	store1.Close()
 
 	// We should still be unable to acquire another
@@ -264,7 +264,7 @@ func (s *StoreSuite) TestRequestStoreLimitMaintained(c *gc.C) {
 
 func (s *StoreSuite) TestPoolDoubleClose(c *gc.C) {
 	p, err := NewPool(s.Session.DB("juju_test"), nil, nil, ServerParams{})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	p.Close()
 	p.Close()
 
@@ -277,7 +277,7 @@ func (s *StoreSuite) TestFindEntities(c *gc.C) {
 	s.testURLFinding(c, func(store *Store, expand *charm.URL, expect []*router.ResolvedURL) {
 		// Check FindEntities works when just retrieving the id and promulgated id.
 		gotEntities, err := store.FindEntities(expand, FieldSelector("_id", "promulgated-url"))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if expand.User == "" {
 			sort.Sort(entitiesByPromulgatedURL(gotEntities))
 		} else {
@@ -293,7 +293,7 @@ func (s *StoreSuite) TestFindEntities(c *gc.C) {
 
 		// check FindEntities works when retrieving all fields.
 		gotEntities, err = store.FindEntities(expand, nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if expand.User == "" {
 			sort.Sort(entitiesByPromulgatedURL(gotEntities))
 		} else {
@@ -303,7 +303,7 @@ func (s *StoreSuite) TestFindEntities(c *gc.C) {
 		for i, url := range expect {
 			var entity mongodoc.Entity
 			err := store.DB.Entities().FindId(&url.URL).One(&entity)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(gotEntities[i], jc.DeepEquals, &entity)
 		}
 	})
@@ -315,16 +315,16 @@ func (s *StoreSuite) TestFindEntity(c *gc.C) {
 
 	rurl := MustParseResolvedURL("cs:~charmers/precise/wordpress-5")
 	err := store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("wordpress"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	entity0, err := store.FindEntity(rurl, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(entity0, gc.NotNil)
 	c.Assert(entity0.Size, gc.Not(gc.Equals), 0)
 
 	// Check that the field selector works.
 	entity2, err := store.FindEntity(rurl, FieldSelector("blobhash"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(entity2.BlobHash, gc.Equals, entity0.BlobHash)
 	c.Assert(entity2.Size, gc.Equals, int64(0))
 
@@ -433,7 +433,7 @@ func (s *StoreSuite) TestFindBaseEntity(c *gc.C) {
 		// Add initial charms to the store.
 		for _, url := range MustParseResolvedURLs(test.stored) {
 			err := store.AddCharmWithArchive(url, ch)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 
 		// Find the entity.
@@ -444,15 +444,15 @@ func (s *StoreSuite) TestFindBaseEntity(c *gc.C) {
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
 			c.Assert(baseEntity, gc.IsNil)
 		} else {
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(storetesting.NormalizeBaseEntity(baseEntity), jc.DeepEquals, storetesting.NormalizeBaseEntity(test.expect))
 		}
 
 		// Remove all the entities from the store.
 		_, err = store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -464,15 +464,15 @@ func (s *StoreSuite) TestAddCharmsWithTheSameBaseEntity(c *gc.C) {
 	ch := storetesting.Charms.CharmDir("wordpress")
 	url := router.MustNewResolvedURL("~charmers/trusty/wordpress-12", 12)
 	err := store.AddCharmWithArchive(url, ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Add a second charm to the database, sharing the same base URL.
 	err = store.AddCharmWithArchive(router.MustNewResolvedURL("~charmers/utopic/wordpress-13", -1), ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Ensure a single base entity has been created.
 	num, err := store.DB.BaseEntities().Count()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(num, gc.Equals, 1)
 }
 
@@ -560,12 +560,12 @@ func (s *StoreSuite) TestBundleUnitCount(c *gc.C) {
 		b := storetesting.NewBundle(test.data)
 		s.addRequiredCharms(c, b)
 		err := store.AddBundleWithArchive(url, b)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// Retrieve the bundle from the database.
 		var doc mongodoc.Entity
 		err = entities.FindId(&url.URL).One(&doc)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		c.Assert(*doc.BundleUnitCount, gc.Equals, test.expectUnits)
 	}
@@ -876,17 +876,17 @@ func (s *StoreSuite) TestBundleMachineCount(c *gc.C) {
 		url.URL.Revision = i
 		url.PromulgatedRevision = i
 		err := test.data.Verify(nil, nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		// Add the bundle used for this test.
 		b := storetesting.NewBundle(test.data)
 		s.addRequiredCharms(c, b)
 		err = store.AddBundleWithArchive(url, b)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// Retrieve the bundle from the database.
 		var doc mongodoc.Entity
 		err = entities.FindId(&url.URL).One(&doc)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		c.Assert(*doc.BundleMachineCount, gc.Equals, test.expectMachines)
 	}
@@ -898,22 +898,22 @@ func (s *StoreSuite) TestOpenBlob(c *gc.C) {
 	defer store.Close()
 	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-23", 23)
 	err := store.AddCharmWithArchive(url, charmArchive)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	f, err := os.Open(charmArchive.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer f.Close()
 	expectHash := hashOfReader(f)
 
 	blob, err := store.OpenBlob(url)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer blob.Close()
 
 	c.Assert(hashOfReader(blob), gc.Equals, expectHash)
 	c.Assert(blob.Hash, gc.Equals, expectHash)
 
 	info, err := f.Stat()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(blob.Size, gc.Equals, info.Size())
 }
 
@@ -924,16 +924,16 @@ func (s *StoreSuite) TestOpenBlobPreV5(c *gc.C) {
 
 	url := router.MustNewResolvedURL("cs:~charmers/multi-series-23", 23)
 	err := store.AddCharmWithArchive(url, ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	blob, err := store.OpenBlobPreV5(url)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer blob.Close()
 
 	data, err := ioutil.ReadAll(blob)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	preV5Ch, err := charm.ReadCharmArchiveBytes(data)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Check that the hashes and sizes are consistent with the data
 	// we've read.
@@ -941,7 +941,7 @@ func (s *StoreSuite) TestOpenBlobPreV5(c *gc.C) {
 	c.Assert(blob.Size, gc.Equals, int64(len(data)))
 
 	entity, err := store.FindEntity(url, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	c.Assert(entity.PreV5BlobHash, gc.Equals, blob.Hash)
 	c.Assert(entity.PreV5BlobHash256, gc.Equals, fmt.Sprintf("%x", sha256.Sum256(data)))
@@ -951,14 +951,14 @@ func (s *StoreSuite) TestOpenBlobPreV5(c *gc.C) {
 
 	// Sanity check that the series really are in the post-v5 blob.
 	blob, err = store.OpenBlob(url)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer blob.Close()
 
 	data, err = ioutil.ReadAll(blob)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	postV5Ch, err := charm.ReadCharmArchiveBytes(data)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	c.Assert(postV5Ch.Meta().Series, jc.DeepEquals, []string{"trusty", "precise"})
 }
@@ -970,16 +970,16 @@ func (s *StoreSuite) TestOpenBlobPreV5WithMultiSeriesCharmInSingleSeriesId(c *gc
 
 	url := router.MustNewResolvedURL("cs:~charmers/precise/multi-series-23", 23)
 	err := store.AddCharmWithArchive(url, ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	blob, err := store.OpenBlobPreV5(url)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer blob.Close()
 
 	data, err := ioutil.ReadAll(blob)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	preV5Ch, err := charm.ReadCharmArchiveBytes(data)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	c.Assert(preV5Ch.Meta().Series, gc.HasLen, 0)
 }
@@ -997,15 +997,15 @@ func (s *StoreSuite) TestAddLog(c *gc.C) {
 	// Add logs to the store.
 	beforeAdding := time.Now().Add(-time.Second)
 	err := store.AddLog(&infoData, mongodoc.InfoLevel, mongodoc.IngestionType, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = store.AddLog(&errorData, mongodoc.ErrorLevel, mongodoc.IngestionType, urls)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	afterAdding := time.Now().Add(time.Second)
 
 	// Retrieve the logs from the store.
 	var docs []mongodoc.Log
 	err = store.DB.Logs().Find(nil).Sort("_id").All(&docs)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(docs, gc.HasLen, 2)
 
 	// The docs have been correctly added to the Mongo collection.
@@ -1048,12 +1048,12 @@ func (s *StoreSuite) TestAddLogBaseURLs(c *gc.C) {
 		charm.MustParseURL("trusty/mysql-42"),
 		charm.MustParseURL("~who/utopic/wordpress"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Retrieve the log from the store.
 	var doc mongodoc.Log
 	err = store.DB.Logs().Find(nil).One(&doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// The log includes the base URLs.
 	c.Assert(doc.URLs, jc.DeepEquals, []*charm.URL{
@@ -1076,12 +1076,12 @@ func (s *StoreSuite) TestAddLogDuplicateURLs(c *gc.C) {
 		charm.MustParseURL("trusty/mysql-42"),
 		charm.MustParseURL("mysql"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Retrieve the log from the store.
 	var doc mongodoc.Log
 	err = store.DB.Logs().Find(nil).One(&doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// The log excludes duplicate URLs.
 	c.Assert(doc.URLs, jc.DeepEquals, []*charm.URL{
@@ -1095,7 +1095,7 @@ func (s *StoreSuite) TestCollections(c *gc.C) {
 	defer store.Close()
 	colls := store.DB.Collections()
 	names, err := store.DB.CollectionNames()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// Some collections don't have indexes so they are created only when used.
 	createdOnUse := map[string]bool{
 		"migrations": true,
@@ -1148,10 +1148,10 @@ func (s *StoreSuite) TestOpenCachedBlobFileWithInvalidEntity(c *gc.C) {
 	wordpress := storetesting.Charms.CharmDir("wordpress")
 	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-23", 23)
 	err := store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	entity, err := store.FindEntity(url, FieldSelector("charmmeta"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r, err := store.OpenCachedBlobFile(entity, "", nil)
 	c.Assert(err, gc.ErrorMatches, "provided entity does not have required fields")
 	c.Assert(r, gc.Equals, nil)
@@ -1164,31 +1164,31 @@ func (s *StoreSuite) TestOpenCachedBlobFileWithFoundContent(c *gc.C) {
 	wordpress := storetesting.Charms.CharmDir("wordpress")
 	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-23", 23)
 	err := store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Get our expected content.
 	data, err := ioutil.ReadFile(filepath.Join(wordpress.Path, "metadata.yaml"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	expectContent := string(data)
 
 	entity, err := store.FindEntity(url, FieldSelector("blobname", "contents"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Check that, when we open the file for the first time,
 	// we see the expected content.
 	r, err := store.OpenCachedBlobFile(entity, mongodoc.FileIcon, func(f *zip.File) bool {
 		return path.Clean(f.Name) == "metadata.yaml"
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer r.Close()
 	data, err = ioutil.ReadAll(r)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(data), gc.Equals, expectContent)
 
 	// When retrieving the entity again, check that the Contents
 	// map has been set appropriately...
 	entity, err = store.FindEntity(url, FieldSelector("blobname", "contents"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(entity.Contents, gc.HasLen, 1)
 	c.Assert(entity.Contents[mongodoc.FileIcon].IsValid(), gc.Equals, true)
 
@@ -1198,10 +1198,10 @@ func (s *StoreSuite) TestOpenCachedBlobFileWithFoundContent(c *gc.C) {
 		c.Errorf("isFile called unexpectedly")
 		return false
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer r.Close()
 	data, err = ioutil.ReadAll(r)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(data), gc.Equals, expectContent)
 }
 
@@ -1212,10 +1212,10 @@ func (s *StoreSuite) TestOpenCachedBlobFileWithNotFoundContent(c *gc.C) {
 	wordpress := storetesting.Charms.CharmDir("wordpress")
 	url := router.MustNewResolvedURL("cs:~charmers/precise/wordpress-23", 23)
 	err := store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	entity, err := store.FindEntity(url, FieldSelector("blobname", "contents"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Check that, when we open the file for the first time,
 	// we get a NotFound error.
@@ -1229,7 +1229,7 @@ func (s *StoreSuite) TestOpenCachedBlobFileWithNotFoundContent(c *gc.C) {
 	// When retrieving the entity again, check that the Contents
 	// map has been set appropriately...
 	entity, err = store.FindEntity(url, FieldSelector("blobname", "contents"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(entity.Contents, gc.DeepEquals, map[mongodoc.FileId]mongodoc.ZipFile{
 		mongodoc.FileIcon: {},
 	})
@@ -1249,7 +1249,7 @@ func (s *StoreSuite) TestSESPutDoesNotErrorWithNoESConfigured(c *gc.C) {
 	store := s.newStore(c, false)
 	defer store.Close()
 	err := store.UpdateSearch(nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 var findBestEntityCharms = []struct {
@@ -2445,31 +2445,31 @@ func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
 	defer store.Close()
 	for _, ch := range findBestEntityCharms {
 		err := store.AddCharmWithArchive(ch.id, ch.charm)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = store.SetPromulgated(ch.id, ch.id.PromulgatedRevision != -1)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if ch.edge {
 			err := store.Publish(ch.id, nil, params.EdgeChannel)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		if ch.stable {
 			err := store.Publish(ch.id, nil, params.StableChannel)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 
 	for _, b := range findBestEntityBundles {
 		err := store.AddBundleWithArchive(b.id, b.bundle)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = store.SetPromulgated(b.id, b.id.PromulgatedRevision != -1)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if b.edge {
 			err := store.Publish(b.id, nil, params.EdgeChannel)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		if b.stable {
 			err := store.Publish(b.id, nil, params.StableChannel)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 
@@ -2485,7 +2485,7 @@ func (s *StoreSuite) TestFindBestEntity(c *gc.C) {
 				}
 				continue
 			}
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(EntityResolvedURL(entity), jc.DeepEquals, test.expectID)
 		}
 	}
@@ -2540,13 +2540,13 @@ func (s *StoreSuite) TestMatchingInterfacesQuery(c *gc.C) {
 	}}
 	for _, e := range entities {
 		err := store.DB.Entities().Insert(denormalizedEntity(e))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	for i, test := range matchingInterfacesQueryTests {
 		c.Logf("test %d: req %v; prov %v", i, test.required, test.provided)
 		var entities []*mongodoc.Entity
 		err := store.MatchingInterfacesQuery(test.required, test.provided).All(&entities)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		var got []string
 		for _, e := range entities {
 			got = append(got, e.URL.String())
@@ -2573,19 +2573,19 @@ func (s *StoreSuite) TestUpdateEntity(c *gc.C) {
 		c.Logf("test %d. %s", i, test.url)
 		url := router.MustNewResolvedURL(test.url, 10)
 		_, err := store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = store.DB.Entities().Insert(denormalizedEntity(&mongodoc.Entity{
 			URL:            charm.MustParseURL("~charmers/trusty/wordpress-10"),
 			PromulgatedURL: charm.MustParseURL("trusty/wordpress-4"),
 		}))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = store.UpdateEntity(url, bson.D{{"$set", bson.D{{"extrainfo.test", []byte("PASS")}}}})
 		if test.expectErr != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectErr)
 		} else {
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			entity, err := store.FindEntity(url, nil)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(string(entity.ExtraInfo["test"]), gc.Equals, "PASS")
 		}
 	}
@@ -2608,23 +2608,23 @@ func (s *StoreSuite) TestUpdateBaseEntity(c *gc.C) {
 		c.Logf("test %d. %s", i, test.url)
 		url := router.MustNewResolvedURL(test.url, 10)
 		_, err := store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = store.DB.BaseEntities().Insert(&mongodoc.BaseEntity{
 			URL:         charm.MustParseURL("~charmers/wordpress"),
 			User:        "charmers",
 			Name:        "wordpress",
 			Promulgated: true,
 		})
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = store.UpdateBaseEntity(url, bson.D{{"$set", bson.D{{"channelacls.unpublished", mongodoc.ACL{
 			Read: []string{"test"},
 		}}}}})
 		if test.expectErr != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectErr)
 		} else {
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			baseEntity, err := store.FindBaseEntity(&url.URL, nil)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(baseEntity.ChannelACLs[params.UnpublishedChannel].Read, jc.DeepEquals, []string{"test"})
 		}
 	}
@@ -2991,37 +2991,37 @@ func (s *StoreSuite) TestSetPromulgated(c *gc.C) {
 		c.Logf("\ntest %d. %s", i, test.about)
 		url := router.MustNewResolvedURL(test.url, -1)
 		_, err := store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		for _, entity := range test.entities {
 			err := store.DB.Entities().Insert(entity)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		for _, baseEntity := range test.baseEntities {
 			err := store.DB.BaseEntities().Insert(baseEntity)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		err = store.SetPromulgated(url, test.promulgate)
 		if test.expectErr != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectErr)
 			continue
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		n, err := store.DB.Entities().Count()
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(n, gc.Equals, len(test.expectEntities))
 		n, err = store.DB.BaseEntities().Count()
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(n, gc.Equals, len(test.expectBaseEntities))
 		for i, expectEntity := range test.expectEntities {
 			entity, err := store.FindEntity(EntityResolvedURL(expectEntity), nil)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(entity, jc.DeepEquals, expectEntity, gc.Commentf("entity %d", i))
 		}
 		for _, expectBaseEntity := range test.expectBaseEntities {
 			baseEntity, err := store.FindBaseEntity(expectBaseEntity.URL, nil)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(storetesting.NormalizeBaseEntity(baseEntity), jc.DeepEquals, storetesting.NormalizeBaseEntity(expectBaseEntity))
 		}
 	}
@@ -3070,57 +3070,57 @@ func (s *StoreSuite) TestSetPromulgatedUpdateSearch(c *gc.C) {
 
 	// Change the promulgated wordpress version to openstack-charmers.
 	err := store.SetPromulgated(url, true)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = store.ES.RefreshIndex(s.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// Check that the search records contain the correct information.
 	var zdoc SearchDoc
 	doc := zdoc
 	err = store.ES.GetDocument(s.TestIndex, typeName, store.ES.getID(charm.MustParseURL("~charmers/trusty/wordpress-0")), &doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(doc.PromulgatedURL, gc.IsNil)
 	c.Assert(doc.PromulgatedRevision, gc.Equals, -1)
 	doc = zdoc
 	err = store.ES.GetDocument(s.TestIndex, typeName, store.ES.getID(charm.MustParseURL("~charmers/precise/wordpress-0")), &doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(doc.PromulgatedURL, gc.IsNil)
 	c.Assert(doc.PromulgatedRevision, gc.Equals, -1)
 	doc = zdoc
 	err = store.ES.GetDocument(s.TestIndex, typeName, store.ES.getID(charm.MustParseURL("~openstack-charmers/trusty/wordpress-0")), &doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(doc.PromulgatedURL.String(), gc.Equals, "cs:trusty/wordpress-3")
 	c.Assert(doc.PromulgatedRevision, gc.Equals, 3)
 	doc = zdoc
 	err = store.ES.GetDocument(s.TestIndex, typeName, store.ES.getID(charm.MustParseURL("~openstack-charmers/precise/wordpress-0")), &doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(doc.PromulgatedURL.String(), gc.Equals, "cs:precise/wordpress-2")
 	c.Assert(doc.PromulgatedRevision, gc.Equals, 2)
 
 	// Remove the promulgated flag from openstack-charmers, meaning wordpress is
 	// no longer promulgated.
 	err = store.SetPromulgated(url, false)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = store.ES.RefreshIndex(s.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// Check that the search records contain the correct information.
 	doc = zdoc
 	err = store.ES.GetDocument(s.TestIndex, typeName, store.ES.getID(charm.MustParseURL("~charmers/trusty/wordpress-0")), &doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(doc.PromulgatedURL, gc.IsNil)
 	c.Assert(doc.PromulgatedRevision, gc.Equals, -1)
 	doc = zdoc
 	err = store.ES.GetDocument(s.TestIndex, typeName, store.ES.getID(charm.MustParseURL("~charmers/precise/wordpress-0")), &doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(doc.PromulgatedURL, gc.IsNil)
 	c.Assert(doc.PromulgatedRevision, gc.Equals, -1)
 	doc = zdoc
 	err = store.ES.GetDocument(s.TestIndex, typeName, store.ES.getID(charm.MustParseURL("~openstack-charmers/trusty/wordpress-0")), &doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(doc.PromulgatedURL, gc.IsNil)
 	c.Assert(doc.PromulgatedRevision, gc.Equals, -1)
 	doc = zdoc
 	err = store.ES.GetDocument(s.TestIndex, typeName, store.ES.getID(charm.MustParseURL("~openstack-charmers/precise/wordpress-0")), &doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(doc.PromulgatedURL, gc.IsNil)
 	c.Assert(doc.PromulgatedRevision, gc.Equals, -1)
 }
@@ -3164,7 +3164,7 @@ func (s *StoreSuite) TestCopyCopiesSessions(c *gc.C) {
 	wordpress := storetesting.Charms.CharmDir("wordpress")
 	url := MustParseResolvedURL("23 cs:~charmers/precise/wordpress-23")
 	err := store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	store1 := store.Copy()
 	defer store1.Close()
@@ -3173,16 +3173,16 @@ func (s *StoreSuite) TestCopyCopiesSessions(c *gc.C) {
 	store.Close()
 
 	entity, err := store1.FindEntity(url, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Also check the blob store, as it has its own session reference.
 	r, _, err := store1.BlobStore.Open(entity.BlobName, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Close()
 
 	// Also check the macaroon storage as that also has its own session reference.
 	m, err := store1.Bakery.NewMacaroon(nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(m, gc.NotNil)
 }
 
@@ -3195,7 +3195,7 @@ func (s *StoreSuite) TestAddAudit(c *gc.C) {
 	}
 
 	p, err := NewPool(s.Session.DB("juju_test"), nil, nil, config)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer p.Close()
 
 	store := p.Store()
@@ -3219,7 +3219,7 @@ func (s *StoreSuite) TestAddAudit(c *gc.C) {
 		store.addAuditAtTime(e, now)
 	}
 	data, err := ioutil.ReadFile(filename)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
 	c.Assert(lines, gc.HasLen, len(entries))
@@ -3231,7 +3231,7 @@ func (s *StoreSuite) TestAddAudit(c *gc.C) {
 
 func (s *StoreSuite) TestAddAuditWithNoLumberjack(c *gc.C) {
 	p, err := NewPool(s.Session.DB("juju_test"), nil, nil, ServerParams{})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer p.Close()
 
 	store := p.Store()
@@ -3308,21 +3308,21 @@ func (s *StoreSuite) TestBundleCharms(c *gc.C) {
 	defer store.Close()
 	rurl := router.MustNewResolvedURL("cs:~charmers/saucy/mysql-0", 0)
 	err := store.AddCharmWithArchive(rurl, mysql)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = store.Publish(rurl, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	riak := storetesting.Charms.CharmArchive(c.MkDir(), "riak")
 	rurl = router.MustNewResolvedURL("cs:~charmers/trusty/riak-42", 42)
 	err = store.AddCharmWithArchive(rurl, riak)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = store.Publish(rurl, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	wordpress := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	rurl = router.MustNewResolvedURL("cs:~charmers/utopic/wordpress-47", 47)
 	err = store.AddCharmWithArchive(rurl, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = store.Publish(rurl, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	tests := []struct {
 		about  string
@@ -3380,7 +3380,7 @@ func (s *StoreSuite) TestBundleCharms(c *gc.C) {
 	for i, test := range tests {
 		c.Logf("test %d: %s", i, test.about)
 		charms, err := store.bundleCharms(test.ids)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		// Ensure the charms returned are what we expect.
 		c.Assert(charms, gc.HasLen, len(test.charms))
 		for i, ch := range charms {
@@ -4105,15 +4105,15 @@ func (s *StoreSuite) TestPublish(c *gc.C) {
 
 		// Remove existing entities and base entities.
 		_, err := store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		// Insert the existing entity.
 		err = store.DB.Entities().Insert(denormalizedEntity(test.initialEntity))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		// Insert the existing base entity.
 		err = store.DB.BaseEntities().Insert(test.initialBaseEntity)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// Publish the entity.
 		err = store.Publish(test.url, nil, test.channels...)
@@ -4121,12 +4121,12 @@ func (s *StoreSuite) TestPublish(c *gc.C) {
 			c.Assert(err, gc.ErrorMatches, test.expectedErr)
 			continue
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		entity, err := store.FindEntity(test.url, nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(entity, jc.DeepEquals, denormalizedEntity(test.expectedEntity))
 		baseEntity, err := store.FindBaseEntity(&test.url.URL, nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(storetesting.NormalizeBaseEntity(baseEntity), jc.DeepEquals, storetesting.NormalizeBaseEntity(test.expectedBaseEntity))
 	}
 }
@@ -4142,7 +4142,7 @@ func (s *StoreSuite) TestIsUploadOwnedBy(c *gc.C) {
 	id := MustParseResolvedURL("cs:~charmers/precise/wordpress-3")
 	meta := storetesting.MetaWithResources(nil, "someResource")
 	err := store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	contents := []string{
 		"123456789 123456789 ",
@@ -4151,7 +4151,7 @@ func (s *StoreSuite) TestIsUploadOwnedBy(c *gc.C) {
 	uid := putMultipart(c, store.BlobStore, time.Time{}, contents...)
 
 	res, err := store.AddResourceWithUploadId(id, "someResource", uid)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	owner := resourceUploadOwner(res)
 	// isUploadOwnedBy should return true if called on the
@@ -4189,7 +4189,7 @@ func (s *StoreSuite) TestPublishWithFailedESInsert(c *gc.C) {
 
 	url := router.MustNewResolvedURL("~charmers/precise/wordpress-12", -1)
 	err := store.AddCharmWithArchive(url, storetesting.Charms.CharmDir("wordpress"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = store.Publish(url, nil, params.StableChannel)
 	c.Assert(err, gc.ErrorMatches, "cannot index cs:~charmers/precise/wordpress-12 to ElasticSearch: .*")
 }

--- a/internal/charmstore/zip_test.go
+++ b/internal/charmstore/zip_test.go
@@ -50,16 +50,16 @@ func (s *zipSuite) makeZipReader(c *gc.C, contents map[string]string) (io.ReadSe
 			header.Method = zip.Store
 		}
 		f, err := w.CreateHeader(header)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = f.Write([]byte(content))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	c.Assert(w.Close(), gc.IsNil)
 
 	// Retrieve the zip files in the archive.
 	zipReader := bytes.NewReader(buf.Bytes())
 	r, err := zip.NewReader(zipReader, int64(buf.Len()))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(r.File, gc.HasLen, len(contents))
 	return zipReader, r.File
 }
@@ -72,11 +72,11 @@ func (s *zipSuite) TestZipFileReader(c *gc.C) {
 	for i, f := range files {
 		c.Logf("test %d: %s", i, f.Name)
 		zf, err := charmstore.NewZipFile(f)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		zfr, err := charmstore.ZipFileReader(zipReader, zf)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		content, err := ioutil.ReadAll(zfr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(string(content), gc.Equals, s.contents[f.Name])
 	}
 }
@@ -104,9 +104,9 @@ func (s *zipSuite) TestNewZipFile(c *gc.C) {
 	for i, f := range files {
 		c.Logf("test %d: %s", i, f.Name)
 		zf, err := charmstore.NewZipFile(f)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		offset, err := f.DataOffset()
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		c.Assert(zf.Offset, gc.Equals, offset)
 		c.Assert(zf.Size, gc.Equals, int64(f.CompressedSize64))

--- a/internal/entitycache/cache_test.go
+++ b/internal/entitycache/cache_test.go
@@ -63,7 +63,7 @@ func (*suite) TestEntityIssuesBaseEntityQueryConcurrently(c *gc.C) {
 	go func() {
 		defer close(queryDone)
 		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"blobname": 1})
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields("blobname")))
 	}()
 
@@ -88,11 +88,11 @@ func (*suite) TestEntityIssuesBaseEntityQueryConcurrently(c *gc.C) {
 	// on the query channels and we won't receive it, so the test
 	// will deadlock.
 	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"baseurl": 1, "blobname": 1})
-	c.Check(err, gc.IsNil)
+	c.Check(err, gc.Equals, nil)
 	c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields("blobname")))
 
 	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), map[string]int{"name": 1})
-	c.Check(err, gc.IsNil)
+	c.Check(err, gc.Equals, nil)
 	c.Check(be, jc.DeepEquals, selectBaseEntityFields(baseEntity, baseEntityFields("name")))
 }
 
@@ -117,7 +117,7 @@ func (*suite) TestEntityIssuesBaseEntityQuerySequentiallyForPromulgatedURL(c *gc
 	go func() {
 		defer close(queryDone)
 		e, err := cache.Entity(charm.MustParseURL("wordpress-1"), map[string]int{"blobname": 1})
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields("blobname")))
 	}()
 
@@ -147,11 +147,11 @@ func (*suite) TestEntityIssuesBaseEntityQuerySequentiallyForPromulgatedURL(c *gc
 	// on the query channels and we won't receive it, so the test
 	// will deadlock.
 	e, err := cache.Entity(charm.MustParseURL("wordpress-1"), map[string]int{"baseurl": 1, "blobname": 1})
-	c.Check(err, gc.IsNil)
+	c.Check(err, gc.Equals, nil)
 	c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields("blobname")))
 
 	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), map[string]int{"name": 1})
-	c.Check(err, gc.IsNil)
+	c.Check(err, gc.Equals, nil)
 	c.Check(be, jc.DeepEquals, selectBaseEntityFields(baseEntity, baseEntityFields("name")))
 }
 
@@ -180,7 +180,7 @@ func (*suite) TestFetchWhenFieldsChangeBeforeQueryResult(c *gc.C) {
 	go func() {
 		defer close(queryDone)
 		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields()))
 	}()
 
@@ -200,7 +200,7 @@ func (*suite) TestFetchWhenFieldsChangeBeforeQueryResult(c *gc.C) {
 		defer close(query2Done)
 		// Note the extra "size" field.
 		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"size": 1})
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity2, entityFields("size")))
 	}()
 	// The second query should be sent immediately without waiting
@@ -224,7 +224,7 @@ func (*suite) TestFetchWhenFieldsChangeBeforeQueryResult(c *gc.C) {
 	close(store.entityqc)
 	close(store.baseEntityqc)
 	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
-	c.Check(err, gc.IsNil)
+	c.Check(err, gc.Equals, nil)
 	c.Check(e, jc.DeepEquals, selectEntityFields(entity2, entityFields("size")))
 }
 
@@ -254,7 +254,7 @@ func (*suite) TestSecondFetchesWaitForFirst(c *gc.C) {
 	go func() {
 		defer initialRequestGroup.Done()
 		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields()))
 	}()
 
@@ -269,7 +269,7 @@ func (*suite) TestSecondFetchesWaitForFirst(c *gc.C) {
 		go func() {
 			defer initialRequestGroup.Done()
 			e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
-			c.Check(err, gc.IsNil)
+			c.Check(err, gc.Equals, nil)
 			c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields()))
 		}()
 	}
@@ -291,7 +291,7 @@ func (*suite) TestSecondFetchesWaitForFirst(c *gc.C) {
 	go func() {
 		defer close(otherRequestDone)
 		e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-2"), nil)
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity2, entityFields()))
 	}()
 	query2 := <-store.entityqc
@@ -418,14 +418,14 @@ func (*suite) TestStartFetch(c *gc.C) {
 	go func() {
 		defer close(entityQueryDone)
 		e, err := cache.Entity(url, nil)
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields()))
 	}()
 	baseEntityQueryDone := make(chan struct{})
 	go func() {
 		defer close(baseEntityQueryDone)
 		e, err := cache.BaseEntity(baseURL, nil)
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, baseEntity)
 	}()
 
@@ -471,14 +471,14 @@ func (*suite) TestAddEntityFields(c *gc.C) {
 	go func() {
 		defer close(queryDone)
 		e, err := cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), map[string]int{"blobname": 1})
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields("blobname", "size")))
 
 		// Adding existing entity fields should have no effect.
 		cache.AddEntityFields(map[string]int{"blobname": 1, "size": 1})
 
 		e, err = cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), map[string]int{"size": 1})
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields("blobname", "size")))
 
 		// Adding a new field should will cause the cache to be invalidated
@@ -486,7 +486,7 @@ func (*suite) TestAddEntityFields(c *gc.C) {
 
 		cache.AddEntityFields(map[string]int{"blobhash": 1})
 		e, err = cache.Entity(charm.MustParseURL("cs:~bob/wordpress-1"), nil)
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields("blobname", "size", "blobhash")))
 	}()
 
@@ -534,7 +534,7 @@ func (*suite) TestLookupByDifferentKey(c *gc.C) {
 	cache := entitycache.New(store)
 	defer cache.Close()
 	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Check(e, jc.DeepEquals, selectEntityFields(entity, entityFields()))
 
 	oldEntity := e
@@ -548,7 +548,7 @@ func (*suite) TestLookupByDifferentKey(c *gc.C) {
 		BlobName: "w2",
 	}
 	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress"), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Logf("got %p; old entity %p; new entity %p", e, oldEntity, entity)
 	c.Assert(e, gc.Equals, oldEntity)
 	c.Assert(entityFetchCount, gc.Equals, 2)
@@ -607,7 +607,7 @@ func (s *suite) TestIterSingle(c *gc.C) {
 
 	// Check that the entity can now be fetched from the cache.
 	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e, gc.Equals, cachedEntity)
 
 	// A request for the base entity should now block
@@ -620,7 +620,7 @@ func (s *suite) TestIterSingle(c *gc.C) {
 	go func() {
 		defer close(queryDone)
 		e, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
-		c.Check(err, gc.IsNil)
+		c.Check(err, gc.Equals, nil)
 		c.Check(e, jc.DeepEquals, selectBaseEntityFields(baseEntity, baseEntityFields()))
 	}()
 
@@ -664,12 +664,12 @@ func (*suite) TestIterWithEntryAlreadyInCache(c *gc.C) {
 	cache := entitycache.New(store)
 	defer cache.Close()
 	e, err := cache.Entity(charm.MustParseURL("~bob/wordpress-1"), map[string]int{"size": 1, "blobsize": 1})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Check(e, jc.DeepEquals, selectEntityFields(store.entities[0], entityFields("size", "blobsize")))
 	cachedEntity := e
 
 	be, err := cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Check(be, jc.DeepEquals, selectBaseEntityFields(store.baseEntities[0], baseEntityFields()))
 	cachedBaseEntity := be
 
@@ -710,11 +710,11 @@ func (*suite) TestIterWithEntryAlreadyInCache(c *gc.C) {
 
 	// The original cached entities should still be there.
 	e, err = cache.Entity(charm.MustParseURL("~bob/wordpress-1"), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e, gc.Equals, cachedEntity)
 
 	be, err = cache.BaseEntity(charm.MustParseURL("~bob/wordpress"), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(be, gc.Equals, cachedBaseEntity)
 }
 
@@ -812,10 +812,10 @@ func (*suite) TestIterEntityBatchLimitExceeded(c *gc.C) {
 	// Check that all the entities and base entities are in fact cached.
 	for _, want := range entities {
 		got, err := cache.Entity(want.URL, nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(got, jc.DeepEquals, want)
 		gotBase, err := cache.BaseEntity(want.URL, nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(gotBase, jc.DeepEquals, &mongodoc.BaseEntity{
 			URL: want.BaseURL,
 		})
@@ -828,7 +828,7 @@ func (*suite) TestIterError(c *gc.C) {
 	iter := cache.CustomIter(fakeIter, nil)
 	// Err returns nil while the iteration is in progress.
 	err := iter.Err()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	replyc := <-fakeIter.req
 	replyc <- iterReply{

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -59,16 +59,16 @@ func (s *APISuite) TearDownTest(c *gc.C) {
 func newServer(c *gc.C, session *mgo.Session, config charmstore.ServerParams) (*charmstore.Server, *charmstore.Store) {
 	db := session.DB("charmstore")
 	pool, err := charmstore.NewPool(db, nil, nil, config)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	srv, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"": legacy.NewAPIHandler})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	return srv, pool.Store()
 }
 
 func (s *APISuite) TestCharmArchive(c *gc.C) {
 	_, wordpress := s.addPublicCharm(c, "wordpress", "cs:precise/wordpress-0")
 	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -109,7 +109,7 @@ func (s *APISuite) TestGetElidesSeriesFromMultiSeriesCharmMetadata(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 
 	gotCh, err := charm.ReadCharmArchiveBytes(rec.Body.Bytes())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	chMeta := ch.Meta()
 	chMeta.Series = nil
@@ -159,7 +159,7 @@ func (s *APISuite) TestServeCharmInfo(c *gc.C) {
 	wordpressURL, wordpress := s.addPublicCharm(c, "wordpress", "cs:precise/wordpress-1")
 	hashSum := fileSHA256(c, wordpress.Path)
 	digest, err := json.Marshal("who@canonical.com-bzr-digest")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	tests := []struct {
 		about     string
@@ -235,7 +235,7 @@ func (s *APISuite) TestServeCharmInfo(c *gc.C) {
 		err = s.store.UpdateEntity(wordpressURL, bson.D{{
 			"$set", bson.D{{"extrainfo", test.extrainfo}},
 		}})
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		expectInfo := charmrepo.InfoResponse{
 			CanonicalURL: test.canonical,
 			Sha256:       test.sha,
@@ -315,17 +315,17 @@ func (s *APISuite) TestAPIInfoWithGatedCharm(c *gc.C) {
 
 func fileSHA256(c *gc.C, path string) string {
 	f, err := os.Open(path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	hash := sha256.New()
 	_, err = io.Copy(hash, f)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	return fmt.Sprintf("%x", hash.Sum(nil))
 }
 
 func (s *APISuite) TestCharmPackageGet(c *gc.C) {
 	wordpressURL, wordpress := s.addPublicCharm(c, "wordpress", "cs:precise/wordpress-0")
 	archiveBytes, err := ioutil.ReadFile(wordpress.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	srv := httptest.NewServer(s.srv)
 	defer srv.Close()
@@ -334,11 +334,11 @@ func (s *APISuite) TestCharmPackageGet(c *gc.C) {
 	s.PatchValue(&charmrepo.LegacyStore.BaseURL, srv.URL)
 
 	ch, err := charmrepo.LegacyStore.Get(&wordpressURL.URL)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	chArchive := ch.(*charm.CharmArchive)
 
 	data, err := ioutil.ReadFile(chArchive.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(data, gc.DeepEquals, archiveBytes)
 }
 
@@ -354,7 +354,7 @@ func (s *APISuite) TestCharmPackageCharmInfo(c *gc.C) {
 	s.PatchValue(&charmrepo.LegacyStore.BaseURL, srv.URL)
 
 	resp, err := charmrepo.LegacyStore.Info(wordpressURL.PreferredURL(), mysqlURL.PreferredURL(), notFoundURL)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(resp, gc.HasLen, 3)
 	c.Assert(resp, jc.DeepEquals, []*charmrepo.InfoResponse{{
 		CanonicalURL: wordpressURL.String(),
@@ -401,16 +401,16 @@ func (s *APISuite) addPublicCharm(c *gc.C, charmName, curl string) (*router.Reso
 	}
 	archive := storetesting.Charms.CharmArchive(c.MkDir(), charmName)
 	err := s.store.AddCharmWithArchive(rurl, archive)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, rurl)
 	return rurl, archive
 }
 
 func (s *APISuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	err := s.store.SetPerms(&rurl.URL, "stable.read", params.Everyone)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.Publish(rurl, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 var serveCharmEventErrorsTests = []struct {
@@ -470,13 +470,13 @@ func (s *APISuite) TestServeCharmEvent(c *gc.C) {
 			params.BzrDigestKey: []byte(":"),
 		}}},
 	}})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Retrieve the entities.
 	mysql, err := s.store.FindEntity(mysqlUrl, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	riak, err := s.store.FindEntity(riakUrl, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	tests := []struct {
 		about  string
@@ -599,7 +599,7 @@ func (s *APISuite) TestServeCharmEventLastRevision(c *gc.C) {
 
 	// Retrieve the most recent revision of the entity.
 	entity, err := s.store.FindEntity(url2, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Ensure the last revision is correctly returned.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -619,18 +619,18 @@ func (s *APISuite) TestServeCharmEventLastRevision(c *gc.C) {
 
 func (s *APISuite) addExtraInfoDigest(c *gc.C, id *router.ResolvedURL, digest string) {
 	b, err := json.Marshal(digest)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.UpdateEntity(id, bson.D{{
 		"$set", bson.D{{"extrainfo", map[string][]byte{
 			params.BzrDigestKey: b,
 		}}},
 	}})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *APISuite) updateUploadTime(c *gc.C, id *router.ResolvedURL, uploadTime time.Time) {
 	err := s.store.UpdateEntity(id, bson.D{{
 		"$set", bson.D{{"uploadtime", uploadTime}},
 	}})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }

--- a/internal/mongodoc/doc_test.go
+++ b/internal/mongodoc/doc_test.go
@@ -20,10 +20,10 @@ var _ = gc.Suite(&DocSuite{})
 func (s *DocSuite) TestIntBoolGetBSON(c *gc.C) {
 	test := bson.D{{"true", mongodoc.IntBool(true)}, {"false", mongodoc.IntBool(false)}}
 	b, err := bson.Marshal(test)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	result := make(map[string]int, 2)
 	err = bson.Unmarshal(b, &result)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(result["true"], gc.Equals, 1)
 	c.Assert(result["false"], gc.Equals, -1)
 }
@@ -31,17 +31,17 @@ func (s *DocSuite) TestIntBoolGetBSON(c *gc.C) {
 func (s *DocSuite) TestIntBoolSetBSON(c *gc.C) {
 	test := bson.D{{"true", 1}, {"false", -1}}
 	b, err := bson.Marshal(test)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	var result map[string]mongodoc.IntBool
 	err = bson.Unmarshal(b, &result)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(result, jc.DeepEquals, map[string]mongodoc.IntBool{"true": true, "false": false})
 }
 
 func (s *DocSuite) TestIntBoolSetBSONIncorrectType(c *gc.C) {
 	test := bson.D{{"test", "true"}}
 	b, err := bson.Marshal(test)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	var result map[string]mongodoc.IntBool
 	err = bson.Unmarshal(b, &result)
 	c.Assert(err, gc.ErrorMatches, "cannot unmarshal value: BSON kind 0x02 isn't compatible with type int")
@@ -50,7 +50,7 @@ func (s *DocSuite) TestIntBoolSetBSONIncorrectType(c *gc.C) {
 func (s *DocSuite) TestIntBoolSetBSONInvalidValue(c *gc.C) {
 	test := bson.D{{"test", 2}}
 	b, err := bson.Marshal(test)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	var result map[string]mongodoc.IntBool
 	err = bson.Unmarshal(b, &result)
 	c.Assert(err, gc.ErrorMatches, `invalid value 2`)

--- a/internal/mongodoc/resource_test.go
+++ b/internal/mongodoc/resource_test.go
@@ -6,7 +6,6 @@ package mongodoc_test
 import (
 	"time"
 
-	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/mgo.v2/bson"
@@ -154,7 +153,7 @@ func (s *ResourceSuite) TestValidate(c *gc.C) {
 		c.Logf("%d. %s", i, test.about)
 		err := test.resource.Validate()
 		if test.expectError == "" {
-			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(err, gc.Equals, nil)
 			continue
 		}
 		c.Assert(err, gc.ErrorMatches, test.expectError)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1235,7 +1235,7 @@ func (s *RouterSuite) TestParseBool(c *gc.C) {
 			c.Assert(err, gc.ErrorMatches, "unexpected bool value .*")
 			continue
 		}
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -1265,7 +1265,7 @@ func (s *RouterSuite) TestCORSHeaders(c *gc.C) {
 
 func (s *RouterSuite) TestHTTPRequestPassedThroughToMeta(c *gc.C) {
 	testReq, err := http.NewRequest("GET", "/wordpress/meta/foo", nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	doneQuery := false
 	query := func(id *ResolvedURL, selector map[string]int, req *http.Request) (interface{}, error) {
 		if req != testReq {
@@ -1313,7 +1313,7 @@ func (s *RouterSuite) TestHTTPRequestPassedThroughToMeta(c *gc.C) {
 
 	testReq, err = http.NewRequest("PUT", "/wordpress/meta/foo", strings.NewReader(`"hello"`))
 	testReq.Header.Set("Content-Type", "application/json")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	resp = httptest.NewRecorder()
 	h.ServeHTTP(resp, testReq)
 	c.Assert(resp.Code, gc.Equals, http.StatusOK, gc.Commentf("response body: %s", resp.Body))
@@ -1876,7 +1876,7 @@ func (s *RouterSuite) TestRouterPut(c *gc.C) {
 			resolve = test.resolveURL
 		}
 		bodyVal, err := json.Marshal(test.body)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		ctxt := alwaysContext
 		ctxt.resolveURL = resolve
 		router := New(&test.handlers, ctxt)
@@ -2037,7 +2037,7 @@ func (s *RouterSuite) TestGetMetadata(c *gc.C) {
 			c.Assert(result, gc.IsNil)
 			continue
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(result, jc.DeepEquals, test.expectResult)
 	}
 }
@@ -2170,7 +2170,7 @@ func (s *RouterSuite) TestWriteJSON(c *gc.C) {
 		N int
 	}
 	err := httprequest.WriteJSON(rec, http.StatusTeapot, Number{1234})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(rec.Code, gc.Equals, http.StatusTeapot)
 	c.Assert(rec.Body.String(), gc.Equals, `{"N":1234}`)
 	c.Assert(rec.Header().Get("content-type"), gc.Equals, "application/json")
@@ -2181,7 +2181,7 @@ func (s *RouterSuite) TestWriteError(c *gc.C) {
 	WriteError(rec, errgo.Newf("an error"))
 	var errResp params.Error
 	err := json.Unmarshal(rec.Body.Bytes(), &errResp)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(errResp, gc.DeepEquals, params.Error{Message: "an error"})
 	c.Assert(rec.Code, gc.Equals, http.StatusInternalServerError)
 
@@ -2193,7 +2193,7 @@ func (s *RouterSuite) TestWriteError(c *gc.C) {
 	WriteError(rec, &errResp0)
 	var errResp1 params.Error
 	err = json.Unmarshal(rec.Body.Bytes(), &errResp1)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(errResp1, gc.DeepEquals, errResp0)
 	c.Assert(rec.Code, gc.Equals, http.StatusInternalServerError)
 }

--- a/internal/router/util_test.go
+++ b/internal/router/util_test.go
@@ -151,7 +151,7 @@ func (*utilSuite) TestRelativeURL(c *gc.C) {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 			c.Assert(result, gc.Equals, "")
 		} else {
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Check(result, gc.Equals, test.expect)
 		}
 	}
@@ -288,7 +288,7 @@ func (*utilSuite) TestUnmarshalJSONObject(c *gc.C) {
 			}
 			continue
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(string(v), jc.JSONEquals, test.expectValue)
 	}
 }

--- a/internal/storetesting/elasticsearch.go
+++ b/internal/storetesting/elasticsearch.go
@@ -58,7 +58,7 @@ func (s *ElasticSearchSuite) TearDownTest(c *gc.C) {
 // end of the test.
 func (s *ElasticSearchSuite) NewIndex(c *gc.C) string {
 	uuid, err := utils.NewUUID()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	id := time.Now().Format("20060102") + uuid.String()
 	s.indexes = append(s.indexes, id)
 	return id

--- a/internal/storetesting/entities.go
+++ b/internal/storetesting/entities.go
@@ -75,7 +75,7 @@ func (b EntityBuilder) Build() *mongodoc.Entity {
 func AssertEntity(c *gc.C, db *mgo.Collection, expect *mongodoc.Entity) {
 	var entity mongodoc.Entity
 	err := db.FindId(expect.URL).One(&entity)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(&entity, jc.DeepEquals, expect)
 }
 
@@ -130,7 +130,7 @@ func (b BaseEntityBuilder) Build() *mongodoc.BaseEntity {
 func AssertBaseEntity(c *gc.C, db *mgo.Collection, expect *mongodoc.BaseEntity) {
 	var baseEntity mongodoc.BaseEntity
 	err := db.FindId(expect.URL).One(&baseEntity)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(NormalizeBaseEntity(&baseEntity), jc.DeepEquals, NormalizeBaseEntity(expect))
 }
 

--- a/internal/storetesting/stats/stats.go
+++ b/internal/storetesting/stats/stats.go
@@ -23,7 +23,7 @@ func CheckCounterSum(c *gc.C, store *charmstore.Store, key []string, prefix bool
 			Prefix: prefix,
 		}
 		cs, err := store.Counters(&req)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if sum = cs[0].Count; sum == expected {
 			if expected == 0 && retry < 2 {
 				continue // Wait a bit to make sure.
@@ -42,7 +42,7 @@ func CheckSearchTotalDownloads(c *gc.C, store *charmstore.Store, id *charm.URL, 
 		var err error
 		time.Sleep(100 * time.Millisecond)
 		doc, err = store.ES.GetSearchDocument(id)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if doc.TotalDownloads == expected {
 			if expected == 0 && retry < 2 {
 				continue // Wait a bit to make sure.

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -538,7 +538,7 @@ func (s *APISuite) TestEndpointGet(c *gc.C) {
 	for i, ep := range metaEndpoints {
 		c.Logf("test %d: %s\n", i, ep.name)
 		data, err := ep.get(s.store, ep.checkURL)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		ep.assertCheckData(c, data)
 	}
 }
@@ -554,7 +554,7 @@ func (s *APISuite) TestAllMetaEndpointsTested(c *gc.C) {
 	c.Logf("meta response body: %s", rec.Body)
 	var list []string
 	err := json.Unmarshal(rec.Body.Bytes(), &list)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	listNames := make(map[string]bool)
 	for _, name := range list {
@@ -615,7 +615,7 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 			charmId := strings.TrimPrefix(url.String(), "cs:")
 			path := charmId + "/meta/" + ep.name
 			expectData, err := ep.get(s.store, url)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Logf("	expected data for %q: %#v", url, expectData)
 			if isNull(expectData) {
 				httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -646,7 +646,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		newResolvedURL("~charmers/trusty/wordpress-1", 1),
 	} {
 		err := s.store.AddCharmWithArchive(u, storetesting.NewCharm(nil))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	s.doAsUser("charmers", func() {
 		s.assertGet(c, "wordpress/meta/perm?channel=unpublished", params.PermResponse{
@@ -730,7 +730,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	// Publish one of the revisions to edge, then PUT to meta/perm
 	// and check that the edge ACLs have changed.
 	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), nil, params.EdgeChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	s.doAsUser("bob", func() {
 		// Check that we aren't allowed to put to the newly published entity as bob.
@@ -789,7 +789,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	// Publish wordpress-1 to stable and check that the stable ACLs
 	// have changed.
 	err = s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// The stable permissions only allow charmers currently, so act as
 	// charmers again.
@@ -1101,7 +1101,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 // given URL are as given.
 func (s *APISuite) assertChannelACLs(c *gc.C, url string, acls map[params.Channel]mongodoc.ACL) {
 	e, err := s.store.FindBaseEntity(charm.MustParseURL(url), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e.ChannelACLs, jc.DeepEquals, acls)
 }
 
@@ -1397,7 +1397,7 @@ func (s *APISuite) TestCommonInfo(c *gc.C) {
 			"key": "something",
 		})
 		e, err := s.store.FindBaseEntity(charm.MustParseURL(u), nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(e.CommonInfo, gc.DeepEquals, map[string][]byte{
 			"key": []byte("\"something\""),
 		})
@@ -1440,7 +1440,7 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 				continue
 			}
 			val, err := ep.get(s.store, url)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			if val != nil {
 				expectData.Meta[ep.name] = val
 			}
@@ -1544,7 +1544,7 @@ func (s *APISuite) TestBundleArchiveReplacesApplicationsWithServices(c *gc.C) {
 	})
 	c.Assert(rr.Code, gc.Equals, http.StatusOK)
 	r, err := zip.NewReader(bytes.NewReader(rr.Body.Bytes()), int64(rr.Body.Len()))
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	var bundleMetadataFound bool
 	for _, f := range r.File {
 		if f.Name != "bundle.yaml" {
@@ -1552,12 +1552,12 @@ func (s *APISuite) TestBundleArchiveReplacesApplicationsWithServices(c *gc.C) {
 		}
 		bundleMetadataFound = true
 		rc, err := f.Open()
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(err, gc.Equals, nil)
 		metadata, err := ioutil.ReadAll(rc)
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(err, gc.Equals, nil)
 		var m map[string]interface{}
 		err = yaml.Unmarshal(metadata, &m)
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, ok := m["services"]
 		c.Assert(ok, gc.Equals, true)
 		_, ok = m["applications"]
@@ -1858,7 +1858,7 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 			c.Assert(rurl, gc.IsNil)
 			continue
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(rurl, jc.DeepEquals, test.expect)
 	}
 }
@@ -1934,9 +1934,9 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-42", 42))
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
 	err := s.store.AddCharmWithArchive(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), storetesting.NewCharm(nil))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), nil, params.EdgeChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
 
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/haproxy-1", 1))
@@ -2409,13 +2409,13 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 				key := []string{params.StatsArchiveDownload, url.URL.Series, url.URL.Name, url.URL.User, strconv.Itoa(url.URL.Revision)}
 				for i := 0; i < downloads; i++ {
 					err := s.store.IncCounterAtTime(key, date)
-					c.Assert(err, gc.IsNil)
+					c.Assert(err, gc.Equals, nil)
 				}
 				if url.PromulgatedRevision > -1 {
 					key := []string{params.StatsArchiveDownloadPromulgated, url.URL.Series, url.URL.Name, "", strconv.Itoa(url.PromulgatedRevision)}
 					for i := 0; i < downloads; i++ {
 						err := s.store.IncCounterAtTime(key, date)
-						c.Assert(err, gc.IsNil)
+						c.Assert(err, gc.Equals, nil)
 					}
 				}
 			}
@@ -2425,9 +2425,9 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 
 		// Clean up the collections.
 		_, err := s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = s.store.DB.StatCounters().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -2608,12 +2608,12 @@ func (s *APISuite) publishCharmsAtKnownTimes(c *gc.C, charms []publishSpec) {
 		id, _ := s.addPublicCharmFromRepo(c, "wordpress", ch.id)
 		t := ch.published().PublishTime
 		err := s.store.UpdateEntity(id, bson.D{{"$set", bson.D{{"uploadtime", t}}}})
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if len(ch.acl) > 0 {
 			err := s.store.SetPerms(&id.URL, "unpublished.read", ch.acl...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			err = s.store.SetPerms(&id.URL, "stable.read", ch.acl...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 }
@@ -2666,7 +2666,7 @@ func (s *APISuite) TestHash256Laziness(c *gc.C) {
 
 	// Retrieve the SHA256 hash.
 	entity, err := s.store.FindEntity(id, charmstore.FieldSelector("blobhash256"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(entity.BlobHash256, gc.Not(gc.Equals), "")
 }
 
@@ -2741,10 +2741,10 @@ func (s *APISuite) TestURLChannelResolving(c *gc.C) {
 	s.idmServer.SetDefaultUser("charmers")
 	for _, add := range urlChannelResolvingEntities {
 		err := s.store.AddCharmWithArchive(add.id, storetesting.NewCharm(nil))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if add.channel != params.UnpublishedChannel {
 			err = s.store.Publish(add.id, nil, add.channel)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 	for i, test := range urlChannelResolvingTests {
@@ -2841,7 +2841,7 @@ func (s *APISuite) assertPut(c *gc.C, url string, val interface{}) {
 
 func (s *APISuite) assertPut0(c *gc.C, url string, val interface{}, asAdmin bool) {
 	body, err := json.Marshal(val)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	p := httptesting.DoRequestParams{
 		Handler: s.srv,
 		URL:     storeURL(url),
@@ -2892,15 +2892,15 @@ func (s *APISuite) TestMacaroon(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %s", rec.Body.String()))
 	var m macaroon.Macaroon
 	err := json.Unmarshal(rec.Body.Bytes(), &m)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(m.Location(), gc.Equals, "charmstore")
 
 	s.idmServer.SetDefaultUser("who")
 	client := httpbakery.NewClient()
 	ms, err := client.DischargeAll(&m)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	macaroonCookie, err := httpbakery.NewCookie(ms)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL("log"),
@@ -3219,16 +3219,16 @@ func (s *APISuite) TestPromulgate(c *gc.C) {
 	for i, test := range promulgateTests {
 		c.Logf("%d. %s\n", i, test.about)
 		_, err := s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		for _, e := range test.entities {
 			err := s.store.DB.Entities().Insert(e)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		for _, e := range test.baseEntities {
 			err := s.store.DB.BaseEntities().Insert(e)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		if test.method == "" {
 			test.method = "PUT"
@@ -3253,13 +3253,13 @@ func (s *APISuite) TestPromulgate(c *gc.C) {
 		}
 		httptesting.AssertJSONCall(c, p)
 		n, err := s.store.DB.Entities().Count()
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(n, gc.Equals, len(test.expectEntities))
 		for _, e := range test.expectEntities {
 			storetesting.AssertEntity(c, s.store.DB.Entities(), e)
 		}
 		n, err = s.store.DB.BaseEntities().Count()
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(n, gc.Equals, len(test.expectBaseEntities))
 		for _, e := range test.expectBaseEntities {
 			storetesting.AssertBaseEntity(c, s.store.DB.BaseEntities(), e)
@@ -3274,7 +3274,7 @@ func (s *APISuite) TestEndpointRequiringBaseEntityWithPromulgatedId(c *gc.C) {
 
 	// Unpromulgate the base entity
 	err := s.store.SetPromulgated(url, false)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Check that we can still enquire about the promulgation status
 	// of the entity when using its promulgated URL.
@@ -3296,7 +3296,7 @@ func (s *APISuite) TestTooManyConcurrentRequests(c *gc.C) {
 	}
 	db := s.Session.DB("charmstore")
 	srv, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer srv.Close()
 
 	// Get a store from the pool so that we'll be
@@ -3322,7 +3322,7 @@ func (s *APISuite) TestTooManyConcurrentRequests(c *gc.C) {
 var dischargeRequiredBody httptesting.BodyAsserter = func(c *gc.C, body json.RawMessage) {
 	var response httpbakery.Error
 	err := json.Unmarshal(body, &response)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(response.Code, gc.Equals, httpbakery.ErrDischargeRequired)
 	c.Assert(response.Message, gc.Equals, "verification failed: no macaroon cookies in request")
 	c.Assert(response.Info.Macaroon, gc.NotNil)
@@ -3336,7 +3336,7 @@ var dischargeRequiredBody httptesting.BodyAsserter = func(c *gc.C, body json.Raw
 
 func (s *APISuite) TestSetAuthCookie(c *gc.C) {
 	m, err := macaroon.New([]byte("key"), []byte("id"), "location")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	ms := macaroon.Slice{m}
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -3359,13 +3359,13 @@ func (s *APISuite) TestSetAuthCookie(c *gc.C) {
 	c.Assert(len(cookies), gc.Equals, 1)
 	expected, err := httpbakery.NewCookie(ms)
 	expected.Path = "/"
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(cookies[0].Value, gc.Equals, expected.Value)
 }
 
 func (s *APISuite) TestSetAuthCookieBodyError(c *gc.C) {
 	m, err := macaroon.New([]byte("key"), []byte("id"), "location")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL("set-auth-cookie"),
@@ -3380,7 +3380,7 @@ func (s *APISuite) TestSetAuthCookieBodyError(c *gc.C) {
 
 func (s *APISuite) TestSetAuthCookieMethodError(c *gc.C) {
 	m, err := macaroon.New([]byte("key"), []byte("id"), "location")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL("set-auth-cookie"),

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -116,7 +116,7 @@ func (s *ArchiveSuite) TestGetElidesSeriesFromMultiSeriesCharmMetadata(c *gc.C) 
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 
 	gotCh, err := charm.ReadCharmArchiveBytes(rec.Body.Bytes())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(gotCh.Meta().Series, gc.HasLen, 0)
 
 	// Check that the metadata is elided from the metadata file when retrieved
@@ -129,7 +129,7 @@ func (s *ArchiveSuite) TestGetElidesSeriesFromMultiSeriesCharmMetadata(c *gc.C) 
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 
 	gotMeta, err := charm.ReadMeta(bytes.NewReader(rec.Body.Bytes()))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(gotMeta.Series, gc.HasLen, 0)
 
 	chMeta := ch.Meta()
@@ -300,11 +300,11 @@ func (s *ArchiveSuite) TestPostErrors(c *gc.C) {
 func (s *ArchiveSuite) TestConcurrentUploads(c *gc.C) {
 	wordpress := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	f, err := os.Open(wordpress.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, f)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	hash, _ := hashOf(bytes.NewReader(buf.Bytes()))
 
@@ -326,11 +326,11 @@ func (s *ArchiveSuite) TestConcurrentUploads(c *gc.C) {
 		body := bytes.NewReader(buf.Bytes())
 		url := srv.URL + storeURL("~charmers/precise/wordpress/archive?hash="+hash)
 		req, err := http.NewRequest("POST", url, body)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		req.Header.Set("Content-Type", "application/zip")
 		req.SetBasicAuth(testUsername, testPassword)
 		resp, err := http.DefaultClient.Do(req)
-		if !c.Check(err, gc.IsNil) {
+		if !c.Check(err, gc.Equals, nil) {
 			return
 		}
 		defer resp.Body.Close()
@@ -530,9 +530,9 @@ func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 		newResolvedURL("cs:~charmers/utopic/logging-1", 1),
 	} {
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmArchive(c.MkDir(), rurl.URL.Name))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.Publish(rurl, nil, params.StableChannel)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	// A bundle that did not exist before should get revision 0.
@@ -681,7 +681,7 @@ func (s *ArchiveSuite) TestPostInvalidCharmMetadata(c *gc.C) {
 func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	path := storetesting.Charms.BundleArchivePath(c.MkDir(), "bad")
 	f, err := os.Open(path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer f.Close()
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
@@ -742,13 +742,13 @@ func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
 
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	f, err := os.Open(ch.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer f.Close()
 
 	// Calculate blob hashes.
 	hash := blobstore.NewHash()
 	_, err = io.Copy(hash, f)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	hashSum := fmt.Sprintf("%x", hash.Sum(nil))
 
 	// Simulate upload of current version
@@ -756,7 +756,7 @@ func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
 	defer h.Close()
 	b := bytes.NewBuffer([]byte("test body"))
 	r, err := http.NewRequest("POST", "/~charmers/precise/wordpress/archive?hash="+hashSum, b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Header.Set("Content-Type", "application/zip")
 	r.SetBasicAuth(testUsername, testPassword)
 	rec := httptest.NewRecorder()
@@ -775,7 +775,7 @@ func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
 func (s *ArchiveSuite) assertCannotUpload(c *gc.C, id string, content io.ReadSeeker, httpStatus int, errorCode params.ErrorCode, errorMessage string) {
 	hash, size := hashOf(content)
 	_, err := content.Seek(0, 0)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	path := fmt.Sprintf("%s/archive?hash=%s", id, hash)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -832,7 +832,7 @@ func (s *ArchiveSuite) assertUploadCharm(c *gc.C, method string, url *router.Res
 func (s *ArchiveSuite) assertUploadBundle(c *gc.C, method string, url *router.ResolvedURL, bundleName string) {
 	path := storetesting.Charms.BundleArchivePath(c.MkDir(), bundleName)
 	b, err := charm.ReadBundleArchive(path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	id, size := s.assertUpload(c, method, url, path)
 	s.assertEntityInfo(c, entityInfo{
 		Id: id,
@@ -846,18 +846,18 @@ func (s *ArchiveSuite) assertUploadBundle(c *gc.C, method string, url *router.Re
 
 func (s *ArchiveSuite) assertUpload(c *gc.C, method string, url *router.ResolvedURL, fileName string) (id *charm.URL, size int64) {
 	f, err := os.Open(fileName)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer f.Close()
 
 	// Calculate blob hashes.
 	hash := blobstore.NewHash()
 	hash256 := sha256.New()
 	size, err = io.Copy(io.MultiWriter(hash, hash256), f)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	hashSum := fmt.Sprintf("%x", hash.Sum(nil))
 	hash256Sum := fmt.Sprintf("%x", hash256.Sum(nil))
 	_, err = f.Seek(0, 0)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	uploadURL := url.URL
 	if method == "POST" {
@@ -888,7 +888,7 @@ func (s *ArchiveSuite) assertUpload(c *gc.C, method string, url *router.Resolved
 	})
 
 	entity, err := s.store.FindEntity(url, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(entity.BlobHash, gc.Equals, hashSum)
 	c.Assert(entity.BlobHash256, gc.Equals, hash256Sum)
 	c.Assert(entity.PreV5BlobHash256, gc.Not(gc.Equals), "")
@@ -992,7 +992,7 @@ func (s *ArchiveSuite) TestArchiveFileErrors(c *gc.C) {
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-0", 0))
 	id, _ := s.addPublicCharmFromRepo(c, "mysql", newResolvedURL("cs:~charmers/utopic/mysql-0", 0))
 	err := s.store.SetPerms(&id.URL, "stable.read", "no-one")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.idmServer.SetDefaultUser("bob")
 	for i, test := range archiveFileErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -1015,7 +1015,7 @@ func (s *ArchiveSuite) TestArchiveFileGet(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/utopic/all-hooks-0", 0)
 	s.addPublicCharm(c, ch, id)
 	zipFile, err := zip.OpenReader(ch.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer zipFile.Close()
 
 	// Check a file in the root directory.
@@ -1030,7 +1030,7 @@ func (s *ArchiveSuite) TestArchiveFileGetMultiSeries(c *gc.C) {
 	url := charm.MustParseURL("~charmers/juju-gui-0")
 	s.assertUploadCharm(c, "POST", newResolvedURL(url.String(), -1), "multi-series")
 	err := s.store.SetPerms(url, "unpublished.read", params.Everyone)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	c.Logf("dorequest %v", storeURL(url.String()+"/archive"))
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -1039,7 +1039,7 @@ func (s *ArchiveSuite) TestArchiveFileGetMultiSeries(c *gc.C) {
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %q", rec.Body.Bytes()))
 	ch, err := charm.ReadCharmArchiveBytes(rec.Body.Bytes())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(ch.Meta().Series, gc.HasLen, 0)
 }
 
@@ -1054,10 +1054,10 @@ func (s *ArchiveSuite) assertArchiveFileContents(c *gc.C, zipFile *zip.ReadClose
 	for _, file := range zipFile.File {
 		if file.Name == filePath {
 			r, err := file.Open()
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			defer r.Close()
 			expectBytes, err = ioutil.ReadAll(r)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			break
 		}
 	}
@@ -1085,12 +1085,12 @@ func (s *ArchiveSuite) TestDelete(c *gc.C) {
 	id := "~charmers/utopic/mysql-42"
 	url := newResolvedURL(id, -1)
 	err := s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Retrieve the corresponding entity.
 	var entity mongodoc.Entity
 	err = s.store.DB.Entities().FindId(&url.URL).Select(bson.D{{"blobname", 1}}).One(&entity)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Delete the charm using the API.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -1109,7 +1109,7 @@ func (s *ArchiveSuite) TestDelete(c *gc.C) {
 	// TODO(mhilton) reinstate this check when DELETE is re-enabled.
 	//	// The entity has been deleted.
 	//	count, err := s.store.DB.Entities().FindId(url).Count()
-	//	c.Assert(err, gc.IsNil)
+	//	c.Assert(err, gc.Equals, nil)
 	//	c.Assert(count, gc.Equals, 0)
 	//
 	//	// The blob has been deleted.
@@ -1123,7 +1123,7 @@ func (s *ArchiveSuite) TestDeleteSpecificCharm(c *gc.C) {
 		err := s.store.AddCharmWithArchive(
 			newResolvedURL(id, -1),
 			storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	// Delete the second charm using the API.
@@ -1148,7 +1148,7 @@ func (s *ArchiveSuite) TestDeleteSpecificCharm(c *gc.C) {
 	count, err := s.store.DB.Entities().Find(bson.D{{
 		"_id", bson.D{{"$in", urls}},
 	}}).Count()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(count, gc.Equals, 2)
 }
 
@@ -1174,14 +1174,14 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 //	id := "~charmers/utopic/mysql-42"
 //	url := newResolvedURL(id, -1)
 //	err := s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-//	c.Assert(err, gc.IsNil)
+//	c.Assert(err, gc.Equals, nil)
 //
 //	err = s.store.DB.Entities().UpdateId(&url.URL, bson.M{
 //		"$set": bson.M{
 //			"blobname": "no-such-name",
 //		},
 //	})
-//	c.Assert(err, gc.IsNil)
+//	c.Assert(err, gc.Equals, nil)
 //	// TODO update entity to change BlobName to "no-such-name"
 //
 //	// Try to delete the charm using the API.
@@ -1209,7 +1209,7 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 //	err := s.store.AddCharmWithArchive(
 //		newResolvedURL(id, -1),
 //		storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-//	c.Assert(err, gc.IsNil)
+//	c.Assert(err, gc.Equals, nil)
 //
 //	// Delete the charm using the API.
 //	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -1242,7 +1242,7 @@ func (s *basicAuthArchiveSuite) TestPostAuthErrors(c *gc.C) {
 //		newResolvedURL("~charmers/utopic/django-42", 42),
 //		storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"),
 //	)
-//	c.Assert(err, gc.IsNil)
+//	c.Assert(err, gc.Equals, nil)
 //	s.checkAuthErrors(c, "DELETE", "utopic/django-42/archive")
 //}
 
@@ -1252,7 +1252,7 @@ func (s *basicAuthArchiveSuite) TestPostErrorReadsFully(c *gc.C) {
 
 	b := strings.NewReader("test body")
 	r, err := http.NewRequest("POST", "/~charmers/trusty/wordpress/archive", b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Header.Set("Content-Type", "application/zip")
 	r.SetBasicAuth(testUsername, testPassword)
 	rec := httptest.NewRecorder()
@@ -1266,7 +1266,7 @@ func (s *basicAuthArchiveSuite) TestPostAuthErrorReadsFully(c *gc.C) {
 	defer h.Close()
 	b := strings.NewReader("test body")
 	r, err := http.NewRequest("POST", "/~charmers/trusty/wordpress/archive", b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Header.Set("Content-Type", "application/zip")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, r)

--- a/internal/v4/auth_test.go
+++ b/internal/v4/auth_test.go
@@ -161,16 +161,16 @@ func dischargedAuthCookie(c *gc.C, srv http.Handler, caveats ...string) *http.Co
 	})
 	var m macaroon.Macaroon
 	err := json.Unmarshal(rec.Body.Bytes(), &m)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	for _, cav := range caveats {
 		err := m.AddFirstPartyCaveat(cav)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	client := httpbakery.NewClient()
 	ms, err := client.DischargeAll(&m)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	macaroonCookie, err := httpbakery.NewCookie(ms)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	return macaroonCookie
 }
 
@@ -389,21 +389,21 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		// Add a charm to the store, used for testing.
 		rurl := newResolvedURL("~charmers/utopic/wordpress-42", -1)
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("wordpress"))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// publish the charm on any required channels.
 		if len(test.channels) > 0 {
 			err := s.store.Publish(rurl, nil, test.channels...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 
 		// Change the ACLs for the testing charm.
 		err = s.store.SetPerms(&rurl.URL, "unpublished.read", test.unpublishedReadPerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.SetPerms(&rurl.URL, "edge.read", test.edgeReadPerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.SetPerms(&rurl.URL, "stable.read", test.stableReadPerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// Define an helper function used to send requests and check responses.
 		doRequest := func(path string, expectStatus int, expectBody interface{}) {
@@ -429,7 +429,7 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -607,21 +607,21 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 		// Add a charm to the store, used for testing.
 		rurl := newResolvedURL("~charmers/utopic/wordpress-42", -1)
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("wordpress"))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// publish the charm on any required channels.
 		if len(test.channels) > 0 {
 			err := s.store.Publish(rurl, nil, test.channels...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 
 		// Change the ACLs for the testing charm.
 		err = s.store.SetPerms(&rurl.URL, "unpublished.write", test.unpublishedWritePerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.SetPerms(&rurl.URL, "edge.write", test.edgeWritePerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.SetPerms(&rurl.URL, "stable.write", test.stableWritePerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		makeRequest := func(path string, expectStatus int, expectBody interface{}) {
 			rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -648,7 +648,7 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 	}
 }
@@ -798,9 +798,9 @@ func (s *authSuite) TestUploadEntityAuthorization(c *gc.C) {
 
 		// Remove all entities from the store.
 		_, err := s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -814,10 +814,10 @@ type readSeekCloser interface {
 func archiveInfo(c *gc.C, name string) (r readSeekCloser, hashSum string, size int64) {
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), name)
 	f, err := os.Open(ch.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	hash, size := hashOf(f)
 	_, err = f.Seek(0, 0)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	return f, hash, size
 }
 
@@ -860,7 +860,7 @@ func (s *authSuite) TestIsEntityCaveat(c *gc.C) {
 	// Change the ACLs for charms we've just uploaded, otherwise
 	// no authorization checking will take place.
 	err := s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	client := s.login("bob", "is-entity cs:~charmers/utopic/wordpress-42")
 	s.idmServer.SetDefaultUser("")
@@ -880,7 +880,7 @@ func (s *authSuite) TestIsEntityCaveat(c *gc.C) {
 			c.Assert(rec.Code, gc.Equals, http.StatusUnauthorized)
 			var respErr httpbakery.Error
 			err := json.Unmarshal(rec.Body.Bytes(), &respErr)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(respErr.Message, gc.Matches, test.expectError)
 			continue
 		}
@@ -928,17 +928,17 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 	c.Assert(gotBody, gc.NotNil)
 	var m macaroon.Macaroon
 	err := json.Unmarshal(gotBody, &m)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	caveats := m.Caveats()
 	foundExpiry := false
 	for _, cav := range caveats {
 		cond, arg, err := checkers.ParseCaveat(string(cav.Id))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		switch cond {
 		case checkers.CondTimeBefore:
 			t, err := time.Parse(time.RFC3339Nano, arg)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(t, jc.TimeBetween(now.Add(v5.DelegatableMacaroonExpiry), now.Add(v5.DelegatableMacaroonExpiry+time.Second)))
 			foundExpiry = true
 		}
@@ -952,12 +952,12 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 	err = s.store.AddCharmWithArchive(
 		rurl,
 		storetesting.Charms.CharmDir("wordpress"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.Publish(rurl, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// Change the ACLs for the testing charm.
 	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// First check that we require authorization to access the charm.
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -972,9 +972,9 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 
 	client := httpbakery.NewClient()
 	u, err := url.Parse("http://127.0.0.1")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = httpbakery.SetCookie(client.Jar, u, macaroon.Slice{&m})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,

--- a/internal/v4/common_test.go
+++ b/internal/v4/common_test.go
@@ -164,7 +164,7 @@ func (s *commonSuite) startServer(c *gc.C) {
 	db := s.Session.DB("charmstore")
 	var err error
 	s.srv, err = charmstore.NewServer(db, si, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.srvParams = config
 
 	if s.enableIdentity {
@@ -172,7 +172,7 @@ func (s *commonSuite) startServer(c *gc.C) {
 		config.PublicKeyLocator = nil
 		config.IdentityAPIURL = ""
 		s.noMacaroonSrv, err = charmstore.NewServer(db, si, config, map[string]charmstore.NewAPIHandlerFunc{"v4": v4.NewAPIHandler})
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	} else {
 		s.noMacaroonSrv = s.srv
 	}
@@ -186,16 +186,16 @@ func (s *commonSuite) addPublicCharmFromRepo(c *gc.C, charmName string, rurl *ro
 
 func (s *commonSuite) addPublicCharm(c *gc.C, ch charm.Charm, rurl *router.ResolvedURL) (*router.ResolvedURL, charm.Charm) {
 	err := s.store.AddCharmWithArchive(rurl, ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, rurl)
 	return rurl, ch
 }
 
 func (s *commonSuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
 	err := s.store.SetPerms(&rurl.URL, "stable.read", params.Everyone)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.Publish(rurl, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *commonSuite) addPublicBundleFromRepo(c *gc.C, bundleName string, rurl *router.ResolvedURL, addRequiredCharms bool) (*router.ResolvedURL, charm.Bundle) {
@@ -207,7 +207,7 @@ func (s *commonSuite) addPublicBundle(c *gc.C, bundle charm.Bundle, rurl *router
 		s.addRequiredCharms(c, bundle)
 	}
 	err := s.store.AddBundleWithArchive(rurl, bundle)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, rurl)
 	return rurl, bundle
 }
@@ -226,7 +226,7 @@ func (s *commonSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
 func (s *commonSuite) setPerms(c *gc.C, readACLs map[string][]string) {
 	for url, acl := range readACLs {
 		err := s.store.SetPerms(charm.MustParseURL(url), "stable.read", acl...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -235,10 +235,10 @@ func (s *commonSuite) setPerms(c *gc.C, readACLs map[string][]string) {
 // is responsible for calling Put on the returned handler.
 func (s *commonSuite) handler(c *gc.C) v4.ReqHandler {
 	h, err := v4.New(s.store.Pool(), s.srvParams, "")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	rh, err := h.NewReqHandler(new(http.Request))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// It would be nice if we could call s.AddCleanup here
 	// to call rh.Put when the test has completed, but
 	// unfortunately CleanupSuite.TearDownTest runs
@@ -325,7 +325,7 @@ func (s *commonSuite) assertPutAsAdmin(c *gc.C, url string, val interface{}) {
 
 func (s *commonSuite) assertPut0(c *gc.C, url string, val interface{}, asAdmin bool) {
 	body, err := json.Marshal(val)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	p := httptesting.JSONCallParams{
 		Handler: s.srv,
 		URL:     storeURL(url),
@@ -373,7 +373,7 @@ func (s *commonSuite) assertGetIsUnauthorized(c *gc.C, url, expectMessage string
 // error message.
 func (s *commonSuite) assertPutIsUnauthorized(c *gc.C, url string, val interface{}, expectMessage string) {
 	body, err := json.Marshal(val)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,
 		URL:     storeURL(url),

--- a/internal/v4/content_test.go
+++ b/internal/v4/content_test.go
@@ -87,7 +87,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	url := newResolvedURL("cs:~charmers/bundle/wordpressbundle-42", 42)
 	s.addRequiredCharms(c, bundle)
 	err := s.store.AddBundleWithArchive(url, bundle)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -149,7 +149,7 @@ func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 	url := newResolvedURL("cs:~charmers/bundle/wordpressbundle-42", 42)
 	s.addRequiredCharms(c, bundle)
 	err := s.store.AddBundleWithArchive(url, bundle)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -201,7 +201,7 @@ func (s *APISuite) TestServeReadMe(c *gc.C) {
 		content := fmt.Sprintf("some content %d", i)
 		if test.name != "" {
 			err := ioutil.WriteFile(filepath.Join(wordpress.Path, test.name), []byte(content), 0666)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 
 		url.URL.Revision = i
@@ -228,7 +228,7 @@ func (s *APISuite) TestServeReadMe(c *gc.C) {
 func charmWithExtraFile(c *gc.C, name, file, content string) *charm.CharmDir {
 	ch := storetesting.Charms.ClonedDir(c.MkDir(), name)
 	err := ioutil.WriteFile(filepath.Join(ch.Path, file), []byte(content), 0666)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	return ch
 }
 
@@ -239,7 +239,7 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 
 	url := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
 	err := s.store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -266,11 +266,11 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 	// Reload the charm with an icon that already has viewBox.
 	wordpress = storetesting.Charms.ClonedDir(c.MkDir(), "wordpress")
 	err = ioutil.WriteFile(filepath.Join(wordpress.Path, "icon.svg"), []byte(expected), 0666)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	url.URL.Revision++
 	err = s.store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, url)
 
 	// Check that we still get expected svg.
@@ -408,7 +408,7 @@ func assertXMLContains(c *gc.C, body []byte, need map[string]func(xml.Token) boo
 		if err == io.EOF {
 			break
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		for what, f := range need {
 			if f(tok) {
 				delete(need, what)

--- a/internal/v4/list_test.go
+++ b/internal/v4/list_test.go
@@ -53,11 +53,11 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 	s.addCharmsToStore(c)
 	// hide the riak charm
 	err := s.store.SetPerms(charm.MustParseURL("cs:~charmers/riak"), "stable.read", "charmers", "test-user")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.UpdateSearch(newResolvedURL("~charmers/trusty/riak-0", 0))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.esSuite.ES.RefreshIndex(s.esSuite.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *ListSuite) addCharmsToStore(c *gc.C) {
@@ -151,7 +151,7 @@ func (s *ListSuite) TestSuccessfulList(c *gc.C) {
 		})
 		var sr params.ListResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, len(test.results))
 		c.Logf("results: %s", rec.Body.Bytes())
 		for i := range test.results {
@@ -254,7 +254,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 			}
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, 1)
 		c.Assert(string(sr.Results[0].Meta), jc.JSONEquals, test.meta)
 	}
@@ -278,9 +278,9 @@ func (s *ListSuite) TestListIncludeError(c *gc.C) {
 	// Now remove one of the blobs. The list should still
 	// work, but only return a single result.
 	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.BlobStore.Remove(entity.BlobName, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Now list again - we should get one result less
 	// (and the error will be logged).
@@ -290,7 +290,7 @@ func (s *ListSuite) TestListIncludeError(c *gc.C) {
 	// uses LoggingSuite.
 	var tw loggo.TestWriter
 	err = loggo.RegisterWriter("test-log", &tw)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -374,7 +374,7 @@ func (s *ListSuite) TestSortingList(c *gc.C) {
 		})
 		var sr params.ListResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, len(test.results), gc.Commentf("expected %#v", test.results))
 		c.Logf("results: %s", rec.Body.Bytes())
 		for i := range test.results {
@@ -390,7 +390,7 @@ func (s *ListSuite) TestSortUnsupportedListField(c *gc.C) {
 	})
 	var e params.Error
 	err := json.Unmarshal(rec.Body.Bytes(), &e)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e.Code, gc.Equals, params.ErrBadRequest)
 	c.Assert(e.Message, gc.Equals, "invalid sort field: unrecognized sort parameter \"text\"")
 }
@@ -412,7 +412,7 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 	})
 	var sr params.ListResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(sr.Results, gc.HasLen, 4, gc.Commentf("expected %#v", testresults))
 	c.Logf("results: %s", rec.Body.Bytes())
 	for i := range testresults {
@@ -430,7 +430,7 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 		URL:     storeURL("list?sort=name"),
 	})
 	err = json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(sr.Results, gc.HasLen, 4, gc.Commentf("expected %#v", testresults))
 	c.Logf("results: %s", rec.Body.Bytes())
 	for i := range testresults {
@@ -440,7 +440,7 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 
 func (s *ListSuite) assertPut(c *gc.C, url string, val interface{}) {
 	body, err := json.Marshal(val)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
 		URL:     storeURL(url),
@@ -473,7 +473,7 @@ func (s *ListSuite) TestListWithAdminCredentials(c *gc.C) {
 	}
 	var sr params.ListResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertListResultSet(c, sr, expected)
 }
 
@@ -493,7 +493,7 @@ func (s *ListSuite) TestListWithUserMacaroon(c *gc.C) {
 	}
 	var sr params.ListResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertListResultSet(c, sr, expected)
 }
 
@@ -501,9 +501,9 @@ func (s *ListSuite) TestSearchWithBadAdminCredentialsAndACookie(c *gc.C) {
 	m, err := s.store.Bakery.NewMacaroon([]checkers.Caveat{
 		idmclient.UserDeclaration("test-user"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	macaroonCookie, err := httpbakery.NewCookie(macaroon.Slice{m})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler:  s.srv,
 		URL:      storeURL("list"),
@@ -520,7 +520,7 @@ func (s *ListSuite) TestSearchWithBadAdminCredentialsAndACookie(c *gc.C) {
 	}
 	var sr params.ListResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertListResultSet(c, sr, expected)
 }
 

--- a/internal/v4/log_test.go
+++ b/internal/v4/log_test.go
@@ -222,7 +222,7 @@ func (s *logSuite) TestGetLogs(c *gc.C) {
 	for _, key := range []string{"info1", "error1", "info2", "warning1", "error2", "info3", "error3", "stats"} {
 		resp := logResponses[key]
 		err := s.store.AddLog(&resp.Data, paramsLogLevels[resp.Level], paramsLogTypes[resp.Type], resp.URLs)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	afterAdding := time.Now().Add(time.Second)
 
@@ -244,7 +244,7 @@ func (s *logSuite) TestGetLogs(c *gc.C) {
 		var logs []*params.LogResponse
 		decoder := json.NewDecoder(rec.Body)
 		err := decoder.Decode(&logs)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// Check and then reset the response time so that the whole body
 		// can be more easily compared later.
@@ -347,7 +347,7 @@ func (s *logSuite) TestGetLogsErrorInvalidLog(c *gc.C) {
 		Type:  mongodoc.IngestionType,
 		Time:  time.Now(),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// The log is just ignored.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
@@ -383,7 +383,7 @@ func (s *logSuite) TestPostLogs(c *gc.C) {
 	// Ensure the log message has been added to the database.
 	var doc mongodoc.Log
 	err := s.store.DB.Logs().Find(nil).One(&doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(doc.Data), gc.Equals, `"info data"`)
 	c.Assert(doc.Level, gc.Equals, mongodoc.InfoLevel)
 	c.Assert(doc.Type, gc.Equals, mongodoc.IngestionType)
@@ -409,7 +409,7 @@ func (s *logSuite) TestPostLogsMultipleEntries(c *gc.C) {
 		Type:  params.IngestionType,
 	}}
 	body, err := json.Marshal(logs)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Send the request.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -429,7 +429,7 @@ func (s *logSuite) TestPostLogsMultipleEntries(c *gc.C) {
 	// TODO avoid reordering logs by adding a sequence number.
 	var docs []mongodoc.Log
 	err = s.store.DB.Logs().Find(nil).Sort("level").All(&docs)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(docs, gc.HasLen, 2)
 	c.Check(string(docs[0].Data), gc.Equals, string(infoData))
 	c.Check(docs[0].Level, gc.Equals, mongodoc.InfoLevel)

--- a/internal/v4/relations_test.go
+++ b/internal/v4/relations_test.go
@@ -268,7 +268,7 @@ func (s *RelationsSuite) TestMetaCharmRelated(c *gc.C) {
 		})
 		// Clean up the entities in the store.
 		_, err := s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -571,7 +571,7 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 		})
 		if test.addCharm != nil {
 			err := s.store.DB.Entities().Remove(bson.D{{"_id", &test.addCharm.URL}})
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 }
@@ -584,7 +584,7 @@ func (s *RelationsSuite) TestMetaBundlesContainingBundleACL(c *gc.C) {
 		if url.URL.Name == "useless" {
 			// The useless bundle is not available for "everyone".
 			err := s.store.SetPerms(&url.URL, "stable.read", url.URL.User)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 
@@ -612,11 +612,11 @@ func sameMetaAnyResponses(expect interface{}) httptesting.BodyAsserter {
 		}
 		var got []*params.MetaAnyResponse
 		err := json.Unmarshal(m, &got)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		sort.Sort(metaAnyResponseById(got))
 		sort.Sort(metaAnyResponseById(expectMeta))
 		data, err := json.Marshal(got)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(string(data), jc.JSONEquals, expect)
 	}
 }

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -49,11 +49,11 @@ func (s *SearchSuite) SetUpTest(c *gc.C) {
 	s.commonSuite.SetUpTest(c)
 	s.addCharmsToStore(c)
 	err := s.store.SetPerms(charm.MustParseURL("cs:~charmers/riak"), "stable.read", "charmers", "test-user")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.UpdateSearch(newResolvedURL("~charmers/trusty/riak-0", 0))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.esSuite.ES.RefreshIndex(s.esSuite.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *SearchSuite) addCharmsToStore(c *gc.C) {
@@ -283,7 +283,7 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		})
 		var sr params.SearchResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, len(test.results))
 		c.Logf("results: %s", rec.Body.Bytes())
 		assertResultSet(c, sr, test.results)
@@ -297,7 +297,7 @@ func (s *SearchSuite) TestPaginatedSearch(c *gc.C) {
 	})
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(sr.Results, gc.HasLen, 1)
 	c.Assert(sr.Total, gc.Equals, 2)
 }
@@ -396,7 +396,7 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 			}
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, 1)
 		c.Assert(string(sr.Results[0].Meta), jc.JSONEquals, test.meta)
 	}
@@ -412,7 +412,7 @@ func (s *SearchSuite) TestSearchError(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusInternalServerError)
 	var resp params.Error
 	err = json.Unmarshal(rec.Body.Bytes(), &resp)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(resp.Code, gc.Equals, params.ErrorCode(""))
 	c.Assert(resp.Message, gc.Matches, "error performing search: search failed: .*")
 }
@@ -437,9 +437,9 @@ func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
 	// work, but only return a single result.
 	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
 
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.BlobStore.Remove(entity.BlobName, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Now search again - we should get one result less
 	// (and the error will be logged).
@@ -449,7 +449,7 @@ func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
 	// uses LoggingSuite.
 	var tw loggo.TestWriter
 	err = loggo.RegisterWriter("test-log", &tw)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -565,7 +565,7 @@ func (s *SearchSuite) TestSorting(c *gc.C) {
 		})
 		var sr params.SearchResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		// Not using assertResultSet(c, sr, test.results) as it does sort internally
 		c.Assert(sr.Results, gc.HasLen, len(test.results), gc.Commentf("expected %#v", test.results))
 		c.Logf("results: %s", rec.Body.Bytes())
@@ -582,7 +582,7 @@ func (s *SearchSuite) TestSortUnsupportedField(c *gc.C) {
 	})
 	var e params.Error
 	err := json.Unmarshal(rec.Body.Bytes(), &e)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e.Code, gc.Equals, params.ErrBadRequest)
 	c.Assert(e.Message, gc.Equals, "invalid sort field: unrecognized sort parameter \"foo\"")
 }
@@ -599,18 +599,18 @@ func (s *SearchSuite) TestDownloadsBoost(c *gc.C) {
 		s.addPublicCharm(c, getSearchCharm(n), url)
 		for i := 0; i < cnt; i++ {
 			err := s.store.IncrementDownloadCounts(url)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 	err := s.esSuite.ES.RefreshIndex(s.esSuite.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
 		URL:     storeURL("search?owner=downloads-test"),
 	})
 	var sr params.SearchResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(sr.Results, gc.HasLen, 3)
 	c.Assert(sr.Results[0].Id.Name, gc.Equals, "varnish")
 	c.Assert(sr.Results[1].Id.Name, gc.Equals, "wordpress")
@@ -639,7 +639,7 @@ func (s *SearchSuite) TestSearchWithAdminCredentials(c *gc.C) {
 	}
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertResultSet(c, sr, expected)
 }
 
@@ -664,7 +664,7 @@ func (s *SearchSuite) TestSearchWithUserMacaroon(c *gc.C) {
 	}
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertResultSet(c, sr, expected)
 }
 
@@ -690,7 +690,7 @@ func (s *SearchSuite) TestSearchWithUserInGroups(c *gc.C) {
 	}
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertResultSet(c, sr, expected)
 }
 
@@ -716,7 +716,7 @@ func (s *SearchSuite) TestSearchWithBadAdminCredentialsAndACookie(c *gc.C) {
 	}
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertResultSet(c, sr, expected)
 }
 

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -132,7 +132,7 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 
 		var err error
 		_, countsBefore, err = s.store.ArchiveDownloadCounts(ref, true)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 			Handler:  s.srv,
@@ -146,7 +146,7 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 		c.Assert(rec.Code, gc.Equals, test.status)
 
 		_, countsAfter, err = s.store.ArchiveDownloadCounts(ref, true)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(countsAfter.Total-countsBefore.Total, gc.Equals, int64(1))
 		if test.previousMonth {
 			c.Assert(countsAfter.LastDay-countsBefore.LastDay, gc.Equals, int64(0))
@@ -239,7 +239,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 		if test.partialUpdate {
 			var err error
 			_, countsBefore, err = s.store.ArchiveDownloadCounts(ref, true)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler:      s.srv,
@@ -256,7 +256,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 		})
 		if test.partialUpdate {
 			_, countsAfter, err := s.store.ArchiveDownloadCounts(ref, true)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(countsAfter.Total-countsBefore.Total, gc.Equals, int64(1))
 			c.Assert(countsAfter.LastDay-countsBefore.LastDay, gc.Equals, int64(1))
 		}
@@ -307,14 +307,14 @@ func (s *StatsSuite) TestStatsCounter(c *gc.C) {
 
 	for _, key := range [][]string{{"a", "b"}, {"a", "b"}, {"a", "c"}, {"a"}} {
 		err := s.store.IncCounter(key)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	var all []interface{}
 	err := s.store.DB.StatCounters().Find(nil).All(&all)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	data, err := json.Marshal(all)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Logf("%s", data)
 
 	expected := map[string]int64{
@@ -357,7 +357,7 @@ func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
 	}
 	for _, key := range incs {
 		err := s.store.IncCounter(key)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	tests := []struct {
@@ -458,7 +458,7 @@ func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {
 		t = t.Add(time.Duration(i) * charmstore.StatsGranularity)
 
 		err := s.store.IncCounterAtTime(inc.key, t)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	tests := []struct {

--- a/internal/v4/status_test.go
+++ b/internal/v4/status_test.go
@@ -221,7 +221,7 @@ func (s *APISuite) TestStatusBaseEntitiesError(c *gc.C) {
 		Name: "django",
 	}
 	err := s.store.DB.BaseEntities().Insert(entity)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	s.AssertDebugStatus(c, false, map[string]params.DebugStatus{
 		"base_entities": {
@@ -245,7 +245,7 @@ func (s *APISuite) AssertDebugStatus(c *gc.C, complete bool, status map[string]p
 	c.Assert(rec.Header().Get("Content-Type"), gc.Equals, "application/json")
 	var gotStatus map[string]params.DebugStatus
 	err := json.Unmarshal(rec.Body.Bytes(), &gotStatus)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	for key, r := range gotStatus {
 		if _, found := status[key]; !complete && !found {
 			delete(gotStatus, key)
@@ -275,7 +275,7 @@ func (s *statusWithElasticSearchSuite) TestStatusWithElasticSearch(c *gc.C) {
 	})
 	var results map[string]params.DebugStatus
 	err := json.Unmarshal(rec.Body.Bytes(), &results)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(results["elasticsearch"].Name, gc.Equals, "Elastic search is running")
 	c.Assert(results["elasticsearch"].Value, jc.Contains, "cluster_name:")
 }

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -676,7 +676,7 @@ func (s *APISuite) TestEndpointGet(c *gc.C) {
 			// endpoint not relevant.
 			continue
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		ep.assertCheckData(c, data)
 	}
 }
@@ -694,7 +694,7 @@ func (s *APISuite) TestAllMetaEndpointsTested(c *gc.C) {
 		})
 		c.Logf("meta response body: %s", rec.Body)
 		err := json.Unmarshal(rec.Body.Bytes(), &list)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	})
 
 	listNames := make(map[string]bool)
@@ -764,7 +764,7 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 				// endpoint not relevant.
 				continue
 			}
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Logf("	expected data for %q: %#v", url, expectData)
 			if isNull(expectData) {
 				httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -915,13 +915,13 @@ func (s *APISuite) TestMetaPublished(c *gc.C) {
 	for _, test := range metaPublishedTests {
 		id := mustParseResolvedURL(test.id)
 		err := s.store.AddEntityWithArchive(id, test.entity)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if len(test.channels) > 0 {
 			err = s.store.Publish(id, nil, test.channels...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		err = s.store.SetPerms(&id.URL, "unpublished.read", params.Everyone)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	// Then run the checks.
 	for i, test := range metaPublishedTests {
@@ -1016,7 +1016,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 		newResolvedURL("~charmers/trusty/wordpress-1", 1),
 	} {
 		err := s.store.AddCharmWithArchive(u, storetesting.NewCharm(nil))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	s.doAsUser("charmers", func() {
 		s.assertGet(c, "wordpress/meta/perm?channel=unpublished", params.PermResponse{
@@ -1100,7 +1100,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	// Publish one of the revisions to edge, then PUT to meta/perm
 	// and check that the edge ACLs have changed.
 	err := s.store.Publish(newResolvedURL("~charmers/precise/wordpress-23", 23), nil, params.EdgeChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	s.doAsUser("bob", func() {
 		// Check that we aren't allowed to put to the newly published entity as bob.
@@ -1160,7 +1160,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	// Publish wordpress-1 to stable and check that the stable ACLs
 	// have changed.
 	err = s.store.Publish(newResolvedURL("~charmers/trusty/wordpress-1", 1), nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// The stable permissions only allow charmers currently, so act as
 	// charmers again.
@@ -1558,7 +1558,7 @@ func (s *APISuite) TestMetaCanWriteWithAnotherMeta(c *gc.C) {
 func (s *APISuite) TestMetaCanWriteDifferentStableAPIPerms(c *gc.C) {
 	id, _ := s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~bob/precise/wordpress-23", 23))
 	err := s.store.SetPerms(&id.URL, "stable.write", "charmers")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// Bob can't write to the stable channel.
 	s.doAsUser("bob", func() {
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -1916,7 +1916,7 @@ func (s *APISuite) TestCommonInfo(c *gc.C) {
 			"key": "something",
 		})
 		e, err := s.store.FindBaseEntity(charm.MustParseURL(u), nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(e.CommonInfo, gc.DeepEquals, map[string][]byte{
 			"key": []byte("\"something\""),
 		})
@@ -1963,7 +1963,7 @@ func (s *APISuite) TestMetaEndpointsAny(c *gc.C) {
 				// endpoint not relevant.
 				continue
 			}
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			if val != nil {
 				expectData.Meta[ep.name] = val
 			}
@@ -2299,7 +2299,7 @@ func (s *APISuite) TestResolveURL(c *gc.C) {
 			c.Assert(rurl, gc.IsNil)
 			continue
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(rurl, jc.DeepEquals, test.expect)
 	}
 }
@@ -2367,9 +2367,9 @@ func (s *APISuite) TestServeExpandId(c *gc.C) {
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-42", 42))
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/trusty/wordpress-47", 47))
 	err := s.store.AddCharmWithArchive(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), storetesting.NewCharm(nil))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.Publish(newResolvedURL("cs:~charmers/trusty/wordpress-48", 48), nil, params.EdgeChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.addPublicCharmFromRepo(c, "multi-series", newResolvedURL("cs:~charmers/wordpress-5", 49))
 
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/precise/haproxy-1", 1))
@@ -2837,13 +2837,13 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 				key := []string{params.StatsArchiveDownload, url.URL.Series, url.URL.Name, url.URL.User, strconv.Itoa(url.URL.Revision)}
 				for i := 0; i < downloads; i++ {
 					err := s.store.IncCounterAtTime(key, date)
-					c.Assert(err, gc.IsNil)
+					c.Assert(err, gc.Equals, nil)
 				}
 				if url.PromulgatedRevision > -1 {
 					key := []string{params.StatsArchiveDownloadPromulgated, url.URL.Series, url.URL.Name, "", strconv.Itoa(url.PromulgatedRevision)}
 					for i := 0; i < downloads; i++ {
 						err := s.store.IncCounterAtTime(key, date)
-						c.Assert(err, gc.IsNil)
+						c.Assert(err, gc.Equals, nil)
 					}
 				}
 			}
@@ -2853,9 +2853,9 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 
 		// Clean up the collections.
 		_, err := s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = s.store.DB.StatCounters().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -2881,13 +2881,13 @@ func (s *APISuite) TestMetaStatsWhenChangedtoMultiSeries(c *gc.C) {
 		key := []string{params.StatsArchiveDownload, url.URL.Series, url.URL.Name, url.URL.User, strconv.Itoa(url.URL.Revision)}
 		for i := 0; i < downloads; i++ {
 			err := s.store.IncCounterAtTime(key, date)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		if url.PromulgatedRevision > -1 {
 			key := []string{params.StatsArchiveDownloadPromulgated, url.URL.Series, url.URL.Name, "", strconv.Itoa(url.PromulgatedRevision)}
 			for i := 0; i < downloads; i++ {
 				err := s.store.IncCounterAtTime(key, date)
-				c.Assert(err, gc.IsNil)
+				c.Assert(err, gc.Equals, nil)
 			}
 		}
 	}
@@ -2927,9 +2927,9 @@ func (s *APISuite) TestMetaStatsWhenChangedtoMultiSeries(c *gc.C) {
 
 	// Clean up the collections.
 	_, err := s.store.DB.Entities().RemoveAll(nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	_, err = s.store.DB.StatCounters().RemoveAll(nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 }
 
@@ -3333,12 +3333,12 @@ func (s *APISuite) TestPublishAuthorization(c *gc.C) {
 		c.Logf("test %d: %v", i, test.about)
 		id := newResolvedURL(fmt.Sprintf("cs:~who/precise/wordpress%d-0", i), -1)
 		err := s.store.AddCharmWithArchive(id, storetesting.NewCharm(nil))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		for ch, acl := range test.acls {
 			err := s.store.SetPerms(&id.URL, string(ch)+".read", acl.Read...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			err = s.store.SetPerms(&id.URL, string(ch)+".write", acl.Write...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		if test.expectError {
 			httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -3388,15 +3388,15 @@ func (s *APISuite) TestPublishSuccess(c *gc.C) {
 	id0 := newResolvedURL("cs:~bob/precise/wordpress-0", -1)
 	meta := storetesting.MetaWithResources(nil, "someResource")
 	err := s.store.AddCharmWithArchive(id0, storetesting.NewCharm(meta))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.uploadResource(c, id0, "someResource", "stuff 0")
 	s.uploadResource(c, id0, "someResource", "stuff 1")
 	err = s.store.Publish(id0, map[string]int{"someResource": 0}, params.EdgeChannel, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Add an unpublished entity.
 	err = s.store.AddCharmWithArchive(newResolvedURL("cs:~bob/precise/wordpress-1", -1), storetesting.NewCharm(meta))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Publish it to the edge channel.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -3455,12 +3455,12 @@ func (s *APISuite) publishCharmsAtKnownTimes(c *gc.C, charms []publishSpec) {
 		id, _ := s.addPublicCharmFromRepo(c, "wordpress", ch.id)
 		t := ch.published().PublishTime
 		err := s.store.UpdateEntity(id, bson.D{{"$set", bson.D{{"uploadtime", t}}}})
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if len(ch.acl) > 0 {
 			err := s.store.SetPerms(&id.URL, "unpublished.read", ch.acl...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			err = s.store.SetPerms(&id.URL, "stable.read", ch.acl...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 }
@@ -3513,7 +3513,7 @@ func (s *APISuite) TestHash256Laziness(c *gc.C) {
 
 	// Retrieve the SHA256 hash.
 	entity, err := s.store.FindEntity(id, charmstore.FieldSelector("blobhash256"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(entity.BlobHash256, gc.Not(gc.Equals), "")
 }
 
@@ -3588,10 +3588,10 @@ func (s *APISuite) TestURLChannelResolving(c *gc.C) {
 	s.idmServer.SetDefaultUser("charmers")
 	for _, add := range urlChannelResolvingEntities {
 		err := s.store.AddCharmWithArchive(add.id, storetesting.NewCharm(nil))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		if add.channel != params.UnpublishedChannel {
 			err = s.store.Publish(add.id, nil, add.channel)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 	for i, test := range urlChannelResolvingTests {
@@ -3700,15 +3700,15 @@ func (s *APISuite) TestMacaroon(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusOK, gc.Commentf("body: %s", rec.Body.String()))
 	var m macaroon.Macaroon
 	err := json.Unmarshal(rec.Body.Bytes(), &m)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(m.Location(), gc.Equals, "charmstore")
 
 	s.idmServer.SetDefaultUser("who")
 	client := httpbakery.NewClient()
 	ms, err := client.DischargeAll(&m)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	macaroonCookie, err := httpbakery.NewCookie(ms)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL("log"),
@@ -4027,16 +4027,16 @@ func (s *APISuite) TestPromulgate(c *gc.C) {
 	for i, test := range promulgateTests {
 		c.Logf("%d. %s\n", i, test.about)
 		_, err := s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		for _, e := range test.entities {
 			err := s.store.DB.Entities().Insert(e)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		for _, e := range test.baseEntities {
 			err := s.store.DB.BaseEntities().Insert(e)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		if test.method == "" {
 			test.method = "PUT"
@@ -4066,13 +4066,13 @@ func (s *APISuite) TestPromulgate(c *gc.C) {
 		}
 		httptesting.AssertJSONCall(c, p)
 		n, err := s.store.DB.Entities().Count()
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(n, gc.Equals, len(test.expectEntities))
 		for _, e := range test.expectEntities {
 			storetesting.AssertEntity(c, s.store.DB.Entities(), e)
 		}
 		n, err = s.store.DB.BaseEntities().Count()
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(n, gc.Equals, len(test.expectBaseEntities))
 		for _, e := range test.expectBaseEntities {
 			storetesting.AssertBaseEntity(c, s.store.DB.BaseEntities(), e)
@@ -4106,7 +4106,7 @@ func (s *APISuite) TestEndpointRequiringBaseEntityWithPromulgatedId(c *gc.C) {
 
 	// Unpromulgate the base entity
 	err := s.store.SetPromulgated(url, false)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Check that we can still enquire about the promulgation status
 	// of the entity when using its promulgated URL.
@@ -4128,7 +4128,7 @@ func (s *APISuite) TestTooManyConcurrentRequests(c *gc.C) {
 	}
 	db := s.Session.DB("charmstore")
 	srv, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"v5": v5.NewAPIHandler})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer srv.Close()
 
 	// Get a store from the pool so that we'll be
@@ -4154,7 +4154,7 @@ func (s *APISuite) TestTooManyConcurrentRequests(c *gc.C) {
 var dischargeRequiredBody httptesting.BodyAsserter = func(c *gc.C, body json.RawMessage) {
 	var response httpbakery.Error
 	err := json.Unmarshal(body, &response)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(response.Code, gc.Equals, httpbakery.ErrDischargeRequired)
 	c.Assert(response.Message, gc.Equals, "verification failed: no macaroon cookies in request")
 	c.Assert(response.Info.Macaroon, gc.NotNil)
@@ -4168,7 +4168,7 @@ var dischargeRequiredBody httptesting.BodyAsserter = func(c *gc.C, body json.Raw
 
 func (s *APISuite) TestSetAuthCookie(c *gc.C) {
 	m, err := macaroon.New([]byte("key"), []byte("id"), "location")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	ms := macaroon.Slice{m}
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -4191,13 +4191,13 @@ func (s *APISuite) TestSetAuthCookie(c *gc.C) {
 	c.Assert(len(cookies), gc.Equals, 1)
 	expected, err := httpbakery.NewCookie(ms)
 	expected.Path = "/"
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(cookies[0].Value, gc.Equals, expected.Value)
 }
 
 func (s *APISuite) TestSetAuthCookieBodyError(c *gc.C) {
 	m, err := macaroon.New([]byte("key"), []byte("id"), "location")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL("set-auth-cookie"),
@@ -4212,7 +4212,7 @@ func (s *APISuite) TestSetAuthCookieBodyError(c *gc.C) {
 
 func (s *APISuite) TestSetAuthCookieMethodError(c *gc.C) {
 	m, err := macaroon.New([]byte("key"), []byte("id"), "location")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
 		URL:          storeURL("set-auth-cookie"),
@@ -4228,7 +4228,7 @@ func (s *APISuite) TestSetAuthCookieMethodError(c *gc.C) {
 
 func (s *APISuite) TestLogout(c *gc.C) {
 	m, err := macaroon.New([]byte("key"), []byte("id"), "location")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	ms := macaroon.Slice{m}
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -4263,7 +4263,7 @@ func (s *APISuite) TestLogout(c *gc.C) {
 // given URL are as given.
 func (s *APISuite) assertChannelACLs(c *gc.C, url string, acls map[params.Channel]mongodoc.ACL) {
 	e, err := s.store.FindBaseEntity(charm.MustParseURL(url), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e.ChannelACLs, jc.DeepEquals, acls)
 }
 

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
@@ -298,11 +297,11 @@ func (s *ArchiveSuite) TestPostErrors(c *gc.C) {
 func (s *ArchiveSuite) TestConcurrentUploads(c *gc.C) {
 	wordpress := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	f, err := os.Open(wordpress.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, f)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	hash, _ := hashOf(bytes.NewReader(buf.Bytes()))
 
@@ -324,11 +323,11 @@ func (s *ArchiveSuite) TestConcurrentUploads(c *gc.C) {
 		body := bytes.NewReader(buf.Bytes())
 		url := srv.URL + storeURL("~charmers/precise/wordpress/archive?hash="+hash)
 		req, err := http.NewRequest("POST", url, body)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		req.Header.Set("Content-Type", "application/zip")
 		req.SetBasicAuth(testUsername, testPassword)
 		resp, err := http.DefaultClient.Do(req)
-		if !c.Check(err, gc.IsNil) {
+		if !c.Check(err, gc.Equals, nil) {
 			return
 		}
 		defer resp.Body.Close()
@@ -573,9 +572,9 @@ func (s *ArchiveSuite) TestPostBundle(c *gc.C) {
 		newResolvedURL("cs:~charmers/utopic/logging-1", 1),
 	} {
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmArchive(c.MkDir(), rurl.URL.Name))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.Publish(rurl, nil, params.StableChannel)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	// A bundle that did not exist before should get revision 0.
@@ -784,7 +783,7 @@ func (s *ArchiveSuite) TestPostInvalidCharmMetadata(c *gc.C) {
 func (s *ArchiveSuite) TestPostInvalidBundleData(c *gc.C) {
 	path := storetesting.Charms.BundleArchivePath(c.MkDir(), "bad")
 	f, err := os.Open(path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer f.Close()
 	// Here we exercise both bundle internal verification (bad relation) and
 	// validation with respect to charms (wordpress and mysql are missing).
@@ -845,13 +844,13 @@ func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
 
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), "wordpress")
 	f, err := os.Open(ch.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer f.Close()
 
 	// Calculate blob hashes.
 	hash := blobstore.NewHash()
 	_, err = io.Copy(hash, f)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	hashSum := fmt.Sprintf("%x", hash.Sum(nil))
 
 	// Simulate upload of current version
@@ -859,7 +858,7 @@ func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
 	defer h.Close()
 	b := bytes.NewBuffer([]byte("test body"))
 	r, err := http.NewRequest("POST", "/~charmers/precise/wordpress/archive?hash="+hashSum, b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Header.Set("Content-Type", "application/zip")
 	r.SetBasicAuth(testUsername, testPassword)
 	rec := httptest.NewRecorder()
@@ -878,7 +877,7 @@ func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
 func (s *ArchiveSuite) assertCannotUpload(c *gc.C, id string, content io.ReadSeeker, httpStatus int, errorCode params.ErrorCode, errorMessage string) {
 	hash, size := hashOf(content)
 	_, err := content.Seek(0, 0)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	path := fmt.Sprintf("%s/archive?hash=%s", id, hash)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -932,7 +931,7 @@ func (s *commonArchiveSuite) assertUploadCharm(c *gc.C, method string, url *rout
 func (s *commonArchiveSuite) assertUploadBundle(c *gc.C, method string, url *router.ResolvedURL, bundleName string) {
 	path := storetesting.Charms.BundleArchivePath(c.MkDir(), bundleName)
 	b, err := charm.ReadBundleArchive(path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	id, size := s.assertUpload(c, uploadParams{
 		method:   method,
 		id:       url,
@@ -958,18 +957,18 @@ type uploadParams struct {
 
 func (s *commonArchiveSuite) assertUpload(c *gc.C, p uploadParams) (id *charm.URL, size int64) {
 	f, err := os.Open(p.fileName)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer f.Close()
 
 	// Calculate blob hashes.
 	hash := blobstore.NewHash()
 	hash256 := sha256.New()
 	size, err = io.Copy(io.MultiWriter(hash, hash256), f)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	hashSum := fmt.Sprintf("%x", hash.Sum(nil))
 	hash256Sum := fmt.Sprintf("%x", hash256.Sum(nil))
 	_, err = f.Seek(0, 0)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	uploadURL := p.id.URL
 	if p.method == "POST" {
@@ -1017,7 +1016,7 @@ func (s *commonArchiveSuite) assertUpload(c *gc.C, p uploadParams) (id *charm.UR
 	for _, ch := range params.OrderedChannels {
 		_, err := s.store.FindBestEntity(&p.id.URL, ch, nil)
 		if expectChans[ch] {
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		} else {
 			c.Assert(err, gc.NotNil)
 			c.Assert(errgo.Cause(err), gc.Equals, params.ErrNotFound)
@@ -1025,7 +1024,7 @@ func (s *commonArchiveSuite) assertUpload(c *gc.C, p uploadParams) (id *charm.UR
 	}
 
 	entity, err := s.store.FindEntity(p.id, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(entity.BlobHash, gc.Equals, hashSum)
 	if p.id.URL.Series != "" {
 		c.Assert(entity.BlobHash256, gc.Equals, hash256Sum)
@@ -1042,7 +1041,7 @@ func (s *commonArchiveSuite) assertUpload(c *gc.C, p uploadParams) (id *charm.UR
 	// Test that the expected entry has been created
 	// in the blob store.
 	r, _, err := s.store.BlobStore.Open(entity.BlobName, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Close()
 
 	return expectId, size
@@ -1142,7 +1141,7 @@ func (s *ArchiveSuite) TestArchiveFileErrors(c *gc.C) {
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("cs:~charmers/utopic/wordpress-0", 0))
 	id, _ := s.addPublicCharmFromRepo(c, "mysql", newResolvedURL("cs:~charmers/utopic/mysql-0", 0))
 	err := s.store.SetPerms(&id.URL, "stable.read", "no-one")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.idmServer.SetDefaultUser("bob")
 	for i, test := range archiveFileErrorsTests {
 		c.Logf("test %d: %s", i, test.about)
@@ -1164,7 +1163,7 @@ func (s *ArchiveSuite) TestArchiveFileGet(c *gc.C) {
 	id := newResolvedURL("cs:~charmers/utopic/all-hooks-0", 0)
 	s.addPublicCharm(c, ch, id)
 	zipFile, err := zip.OpenReader(ch.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer zipFile.Close()
 
 	// Check a file in the root directory.
@@ -1184,10 +1183,10 @@ func (s *ArchiveSuite) assertArchiveFileContents(c *gc.C, zipFile *zip.ReadClose
 	for _, file := range zipFile.File {
 		if file.Name == filePath {
 			r, err := file.Open()
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			defer r.Close()
 			expectBytes, err = ioutil.ReadAll(r)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			break
 		}
 	}
@@ -1215,12 +1214,12 @@ func (s *ArchiveSuite) TestDelete(c *gc.C) {
 	id := "~charmers/utopic/mysql-42"
 	url := newResolvedURL(id, -1)
 	err := s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Retrieve the corresponding entity.
 	var entity mongodoc.Entity
 	err = s.store.DB.Entities().FindId(&url.URL).Select(bson.D{{"blobname", 1}}).One(&entity)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Delete the charm using the API.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -1239,7 +1238,7 @@ func (s *ArchiveSuite) TestDelete(c *gc.C) {
 	// TODO(mhilton) reinstate this check when DELETE is re-enabled.
 	//	// The entity has been deleted.
 	//	count, err := s.store.DB.Entities().FindId(url).Count()
-	//	c.Assert(err, gc.IsNil)
+	//	c.Assert(err, gc.Equals, nil)
 	//	c.Assert(count, gc.Equals, 0)
 	//
 	//	// The blob has been deleted.
@@ -1253,7 +1252,7 @@ func (s *ArchiveSuite) TestDeleteSpecificCharm(c *gc.C) {
 		err := s.store.AddCharmWithArchive(
 			newResolvedURL(id, -1),
 			storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	// Delete the second charm using the API.
@@ -1278,7 +1277,7 @@ func (s *ArchiveSuite) TestDeleteSpecificCharm(c *gc.C) {
 	count, err := s.store.DB.Entities().Find(bson.D{{
 		"_id", bson.D{{"$in", urls}},
 	}}).Count()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(count, gc.Equals, 2)
 }
 
@@ -1304,14 +1303,14 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 //	id := "~charmers/utopic/mysql-42"
 //	url := newResolvedURL(id, -1)
 //	err := s.store.AddCharmWithArchive(url, storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-//	c.Assert(err, gc.IsNil)
+//	c.Assert(err, gc.Equals, nil)
 //
 //	err = s.store.DB.Entities().UpdateId(&url.URL, bson.M{
 //		"$set": bson.M{
 //			"blobname": "no-such-name",
 //		},
 //	})
-//	c.Assert(err, gc.IsNil)
+//	c.Assert(err, gc.Equals, nil)
 //	// TODO update entity to change BlobName to "no-such-name"
 //
 //	// Try to delete the charm using the API.
@@ -1339,7 +1338,7 @@ func (s *ArchiveSuite) TestDeleteNotFound(c *gc.C) {
 //	err := s.store.AddCharmWithArchive(
 //		newResolvedURL(id, -1),
 //		storetesting.Charms.CharmArchive(c.MkDir(), "mysql"))
-//	c.Assert(err, gc.IsNil)
+//	c.Assert(err, gc.Equals, nil)
 //
 //	// Delete the charm using the API.
 //	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -1372,7 +1371,7 @@ func (s *basicAuthArchiveSuite) TestPostAuthErrors(c *gc.C) {
 //		newResolvedURL("~charmers/utopic/django-42", 42),
 //		storetesting.Charms.CharmArchive(c.MkDir(), "wordpress"),
 //	)
-//	c.Assert(err, gc.IsNil)
+//	c.Assert(err, gc.Equals, nil)
 //	s.checkAuthErrors(c, "DELETE", "utopic/django-42/archive")
 //}
 
@@ -1382,7 +1381,7 @@ func (s *basicAuthArchiveSuite) TestPostErrorReadsFully(c *gc.C) {
 
 	b := strings.NewReader("test body")
 	r, err := http.NewRequest("POST", "/~charmers/trusty/wordpress/archive", b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Header.Set("Content-Type", "application/zip")
 	r.SetBasicAuth(testUsername, testPassword)
 	rec := httptest.NewRecorder()
@@ -1396,7 +1395,7 @@ func (s *basicAuthArchiveSuite) TestPostAuthErrorReadsFully(c *gc.C) {
 	defer h.Close()
 	b := strings.NewReader("test body")
 	r, err := http.NewRequest("POST", "/~charmers/trusty/wordpress/archive", b)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	r.Header.Set("Content-Type", "application/zip")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, r)
@@ -1551,14 +1550,14 @@ func (s *ArchiveSuite) TestGetNewPromulgatedRevision(c *gc.C) {
 	for _, url := range charms {
 		ch := storetesting.NewCharm(new(charm.Meta))
 		err := s.store.AddCharmWithArchive(mustParseResolvedURL(url), ch)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	handler := s.handler(c)
 	defer handler.Close()
 	for i, test := range getNewPromulgatedRevisionTests {
 		c.Logf("%d. %s", i, test.about)
 		rev, err := v5.GetNewPromulgatedRevision(handler, test.id)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(rev, gc.Equals, test.expectRev)
 	}
 }
@@ -1738,16 +1737,16 @@ func (s *ArchiveSuiteWithTerms) TestGetArchiveWithBlankMacaroon(c *gc.C) {
 	c.Assert(gotBody, gc.NotNil)
 	var m macaroon.Macaroon
 	err := json.Unmarshal(gotBody, &m)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	bClient := httpbakery.NewClient()
 	ms, err := bClient.DischargeAll(&m)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	u, err := url.Parse("http://127.0.0.1")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = httpbakery.SetCookie(client.Jar, u, ms)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler:     s.srv,

--- a/internal/v5/auth_test.go
+++ b/internal/v5/auth_test.go
@@ -360,21 +360,21 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 		// Add a charm to the store, used for testing.
 		rurl := newResolvedURL("~charmers/utopic/wordpress-42", -1)
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("wordpress"))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// publish the charm on any required channels.
 		if len(test.channels) > 0 {
 			err := s.store.Publish(rurl, nil, test.channels...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 
 		// Change the ACLs for the testing charm.
 		err = s.store.SetPerms(&rurl.URL, "unpublished.read", test.unpublishedReadPerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.SetPerms(&rurl.URL, "edge.read", test.edgeReadPerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.SetPerms(&rurl.URL, "stable.read", test.stableReadPerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// Define an helper function used to send requests and check responses.
 		doRequest := func(path string, expectStatus int, expectBody interface{}) {
@@ -400,7 +400,7 @@ func (s *authSuite) TestReadAuthorization(c *gc.C) {
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -578,21 +578,21 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 		// Add a charm to the store, used for testing.
 		rurl := newResolvedURL("~charmers/utopic/wordpress-42", -1)
 		err := s.store.AddCharmWithArchive(rurl, storetesting.Charms.CharmDir("wordpress"))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// publish the charm on any required channels.
 		if len(test.channels) > 0 {
 			err := s.store.Publish(rurl, nil, test.channels...)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 
 		// Change the ACLs for the testing charm.
 		err = s.store.SetPerms(&rurl.URL, "unpublished.write", test.unpublishedWritePerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.SetPerms(&rurl.URL, "edge.write", test.edgeWritePerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		err = s.store.SetPerms(&rurl.URL, "stable.write", test.stableWritePerm...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		makeRequest := func(path string, expectStatus int, expectBody interface{}) {
 			rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -619,7 +619,7 @@ func (s *authSuite) TestWriteAuthorization(c *gc.C) {
 
 		// Remove all entities from the store.
 		_, err = s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 	}
 }
@@ -769,9 +769,9 @@ func (s *authSuite) TestUploadEntityAuthorization(c *gc.C) {
 
 		// Remove all entities from the store.
 		_, err := s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -785,10 +785,10 @@ type readSeekCloser interface {
 func archiveInfo(c *gc.C, name string) (r readSeekCloser, hashSum string, size int64) {
 	ch := storetesting.Charms.CharmArchive(c.MkDir(), name)
 	f, err := os.Open(ch.Path)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	hash, size := hashOf(f)
 	_, err = f.Seek(0, 0)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	return f, hash, size
 }
 
@@ -831,7 +831,7 @@ func (s *authSuite) TestIsEntityCaveat(c *gc.C) {
 	// Change the ACLs for charms we've just uploaded, otherwise
 	// no authorization checking will take place.
 	err := s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	client := s.login("bob", "is-entity cs:~charmers/utopic/wordpress-42")
 	s.idmServer.SetDefaultUser("")
@@ -851,7 +851,7 @@ func (s *authSuite) TestIsEntityCaveat(c *gc.C) {
 			c.Assert(rec.Code, gc.Equals, http.StatusUnauthorized)
 			var respErr httpbakery.Error
 			err := json.Unmarshal(rec.Body.Bytes(), &respErr)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(respErr.Message, gc.Matches, test.expectError)
 			continue
 		}
@@ -899,17 +899,17 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 	c.Assert(gotBody, gc.NotNil)
 	var m macaroon.Macaroon
 	err := json.Unmarshal(gotBody, &m)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	caveats := m.Caveats()
 	foundExpiry := false
 	for _, cav := range caveats {
 		cond, arg, err := checkers.ParseCaveat(string(cav.Id))
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		switch cond {
 		case checkers.CondTimeBefore:
 			t, err := time.Parse(time.RFC3339Nano, arg)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(t, jc.TimeBetween(now.Add(v5.DelegatableMacaroonExpiry), now.Add(v5.DelegatableMacaroonExpiry+time.Second)))
 			foundExpiry = true
 		}
@@ -923,12 +923,12 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 	err = s.store.AddCharmWithArchive(
 		rurl,
 		storetesting.Charms.CharmDir("wordpress"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.Publish(rurl, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// Change the ACLs for the testing charm.
 	err = s.store.SetPerms(charm.MustParseURL("cs:~charmers/wordpress"), "stable.read", "bob")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// First check that we require authorization to access the charm.
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -943,9 +943,9 @@ func (s *authSuite) TestDelegatableMacaroon(c *gc.C) {
 
 	client := httpbakery.NewClient()
 	u, err := url.Parse("http://127.0.0.1")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = httpbakery.SetCookie(client.Jar, u, macaroon.Slice{&m})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,
@@ -977,11 +977,11 @@ func (s *authSuite) TestDelegatableMacaroonWithBasicAuth(c *gc.C) {
 
 func (s *authSuite) TestDelegatableMacaroonWithIds(c *gc.C) {
 	err := s.store.AddCharmWithArchive(newResolvedURL("~charmers/utopic/wordpress-1", 1), storetesting.NewCharm(nil))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.AddCharmWithArchive(newResolvedURL("~charmers/utopic/wordpress-2", 2), storetesting.NewCharm(nil))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.AddCharmWithArchive(newResolvedURL("~charmers/precise/mysql-1", 1), storetesting.NewCharm(nil))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Check that we can't acquire a delegatable macaroon if we
 	// don't already have permission.
@@ -1046,7 +1046,7 @@ func (s *authSuite) TestDelegatableMacaroonWithIds(c *gc.C) {
 
 func (s *authSuite) TestRenewDelegatableMacaroonWithIds(c *gc.C) {
 	err := s.store.AddCharmWithArchive(newResolvedURL("~charmers/utopic/wordpress-1", 1), storetesting.NewCharm(nil))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Fake the current time so that we can easily test expiration times.
 	t0 := time.Now()
@@ -1152,11 +1152,11 @@ func (s *authSuite) TestDelegatableMacaroonCannotBeUsedForWriting(c *gc.C) {
 
 	id := newResolvedURL("~charmers/utopic/wordpress-1", 1)
 	err := s.store.AddCharmWithArchive(id, storetesting.NewCharm(nil))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.SetPerms(&id.URL, "stable.read", "bob")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.Publish(id, nil, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	var m *macaroon.Macaroon
 	s.doAsUser("bob", func() {
@@ -1180,7 +1180,7 @@ func (s *authSuite) TestDelegatableMacaroonCannotBeUsedForWriting(c *gc.C) {
 
 func (s *authSuite) TestRenewMacaroon(c *gc.C) {
 	m, err := macaroon.New([]byte("key"), []byte("id"), "somewhere")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	m.AddFirstPartyCaveat("active-time-before xxx")
 	m.AddFirstPartyCaveat("hello")
 	m.AddThirdPartyCaveat([]byte("otherkey"), []byte("x"), "location")
@@ -1188,15 +1188,15 @@ func (s *authSuite) TestRenewMacaroon(c *gc.C) {
 	m.AddFirstPartyCaveat("active-time-before yyy")
 
 	newm, err := macaroon.New([]byte("otherkey"), []byte("id2"), "somewhere")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	expectTime := "2016-04-22T16:30:00Z"
 
 	expiry, err := time.Parse(time.RFC3339, expectTime)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	err = v5.RenewMacaroon(newm, macaroon.Slice{m}, expiry)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// The new macaroon should have all the first party caveats
 	// from the original, omitting the third party caveats
@@ -1218,7 +1218,7 @@ func (s *authSuite) TestNewServerWithoutIdentityAgent(c *gc.C) {
 
 	db := s.Session.DB("charmstore")
 	srv, err := charmstore.NewServer(db, nil, config, map[string]charmstore.NewAPIHandlerFunc{"v5": v5.NewAPIHandler})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer srv.Close()
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -1249,7 +1249,7 @@ func (s *authSuite) getDelegatableMacaroon(c *gc.C, ch params.Channel, urlStrs .
 	c.Assert(gotBody, gc.NotNil)
 	var m macaroon.Macaroon
 	err := json.Unmarshal(gotBody, &m)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	return &m
 }
 

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -176,7 +176,7 @@ func (s *commonSuite) startServer(c *gc.C) {
 	db := s.Session.DB("charmstore")
 	var err error
 	s.srv, err = charmstore.NewServer(db, si, config, map[string]charmstore.NewAPIHandlerFunc{"v5": v5.NewAPIHandler})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.srvParams = config
 
 	if s.enableIdentity {
@@ -184,7 +184,7 @@ func (s *commonSuite) startServer(c *gc.C) {
 		config.PublicKeyLocator = nil
 		config.IdentityAPIURL = ""
 		s.noMacaroonSrv, err = charmstore.NewServer(db, si, config, map[string]charmstore.NewAPIHandlerFunc{"v5": v5.NewAPIHandler})
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	} else {
 		s.noMacaroonSrv = s.srv
 	}
@@ -202,7 +202,7 @@ func (s *commonSuite) addPublicCharmFromRepo(c *gc.C, charmName string, rurl *ro
 // with the content "<resourcename> content".
 func (s *commonSuite) addPublicCharm(c *gc.C, ch charm.Charm, id *router.ResolvedURL) (*router.ResolvedURL, charm.Charm) {
 	err := s.store.AddCharmWithArchive(id, ch)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	var resources map[string]int
 	if len(ch.Meta().Resources) > 0 {
@@ -210,7 +210,7 @@ func (s *commonSuite) addPublicCharm(c *gc.C, ch charm.Charm, id *router.Resolve
 		// The charm has resources. Ensure that all the required resources are uploaded,
 		// then publish with them.
 		resDocs, err := s.store.ListResources(id, params.UnpublishedChannel)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		for _, doc := range resDocs {
 			if doc.Revision == -1 {
 				// The resource doesn't exist so upload one.
@@ -226,9 +226,9 @@ func (s *commonSuite) addPublicCharm(c *gc.C, ch charm.Charm, id *router.Resolve
 
 func (s *commonSuite) setPublicWithResources(c *gc.C, rurl *router.ResolvedURL, resources map[string]int) {
 	err := s.store.SetPerms(&rurl.URL, "stable.read", params.Everyone)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.Publish(rurl, resources, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *commonSuite) setPublic(c *gc.C, rurl *router.ResolvedURL) {
@@ -244,7 +244,7 @@ func (s *commonSuite) addPublicBundle(c *gc.C, bundle charm.Bundle, rurl *router
 		s.addRequiredCharms(c, bundle)
 	}
 	err := s.store.AddBundleWithArchive(rurl, bundle)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, rurl)
 	return rurl, bundle
 }
@@ -263,7 +263,7 @@ func (s *commonSuite) addCharms(c *gc.C, charms map[string]charm.Charm) {
 func (s *commonSuite) setPerms(c *gc.C, readACLs map[string][]string) {
 	for url, acl := range readACLs {
 		err := s.store.SetPerms(charm.MustParseURL(url), "stable.read", acl...)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -272,10 +272,10 @@ func (s *commonSuite) setPerms(c *gc.C, readACLs map[string][]string) {
 // is responsible for calling Put on the returned handler.
 func (s *commonSuite) handler(c *gc.C) *v5.ReqHandler {
 	h, err := v5.New(s.store.Pool(), s.srvParams, "")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	rh, err := h.NewReqHandler(new(http.Request))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// It would be nice if we could call s.AddCleanup here
 	// to call rh.Put when the test has completed, but
 	// unfortunately CleanupSuite.TearDownTest runs
@@ -362,7 +362,7 @@ func (s *commonSuite) assertPutAsAdmin(c *gc.C, url string, val interface{}) {
 
 func (s *commonSuite) assertPut0(c *gc.C, url string, val interface{}, asAdmin bool) {
 	body, err := json.Marshal(val)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	p := httptesting.JSONCallParams{
 		Handler: s.srv,
 		URL:     storeURL(url),
@@ -410,7 +410,7 @@ func (s *commonSuite) assertGetIsUnauthorized(c *gc.C, url, expectMessage string
 // error message.
 func (s *commonSuite) assertPutIsUnauthorized(c *gc.C, url string, val interface{}, expectMessage string) {
 	body, err := json.Marshal(val)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,
 		URL:     storeURL(url),
@@ -442,7 +442,7 @@ func (s *commonSuite) doAsUser(user string, f func()) {
 func (s *commonSuite) uploadResource(c *gc.C, id *router.ResolvedURL, name string, content string) {
 	hash := hashOfString(content)
 	_, err := s.store.UploadResource(id, name, strings.NewReader(content), hash, int64(len(content)))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func bakeryDo(client *httpbakery.Client) func(*http.Request) (*http.Response, error) {

--- a/internal/v5/content_test.go
+++ b/internal/v5/content_test.go
@@ -88,7 +88,7 @@ func (s *APISuite) TestServeDiagram(c *gc.C) {
 	url := newResolvedURL("cs:~charmers/bundle/wordpressbundle-42", 42)
 	s.addRequiredCharms(c, bundle)
 	err := s.store.AddBundleWithArchive(url, bundle)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -150,7 +150,7 @@ func (s *APISuite) TestServeDiagramNoPosition(c *gc.C) {
 	url := newResolvedURL("cs:~charmers/bundle/wordpressbundle-42", 42)
 	s.addRequiredCharms(c, bundle)
 	err := s.store.AddBundleWithArchive(url, bundle)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -202,7 +202,7 @@ func (s *APISuite) TestServeReadMe(c *gc.C) {
 		content := fmt.Sprintf("some content %d", i)
 		if test.name != "" {
 			err := ioutil.WriteFile(filepath.Join(wordpress.Path, test.name), []byte(content), 0666)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 
 		url.URL.Revision = i
@@ -229,7 +229,7 @@ func (s *APISuite) TestServeReadMe(c *gc.C) {
 func charmWithExtraFile(c *gc.C, name, file, content string) *charm.CharmDir {
 	ch := storetesting.Charms.ClonedDir(c.MkDir(), name)
 	err := ioutil.WriteFile(filepath.Join(ch.Path, file), []byte(content), 0666)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	return ch
 }
 
@@ -240,7 +240,7 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 
 	url := newResolvedURL("cs:~charmers/precise/wordpress-0", -1)
 	err := s.store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, url)
 
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
@@ -267,11 +267,11 @@ func (s *APISuite) TestServeIcon(c *gc.C) {
 	// Reload the charm with an icon that already has viewBox.
 	wordpress = storetesting.Charms.ClonedDir(c.MkDir(), "wordpress")
 	err = ioutil.WriteFile(filepath.Join(wordpress.Path, "icon.svg"), []byte(expected), 0666)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	url.URL.Revision++
 	err = s.store.AddCharmWithArchive(url, wordpress)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.setPublic(c, url)
 
 	// Check that we still get expected svg.
@@ -343,7 +343,7 @@ func (s *APISuite) TestServeDefaultIconForBadXML(c *gc.C) {
 func (s *APISuite) TestProcessIconWorksOnDefaultIcon(c *gc.C) {
 	var buf bytes.Buffer
 	err := v5.ProcessIcon(&buf, strings.NewReader(v5.DefaultIcon))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertXMLEqual(c, buf.Bytes(), []byte(v5.DefaultIcon))
 }
 
@@ -356,7 +356,7 @@ func (s *APISuite) TestProcessIconDoesNotQuoteNewlines(c *gc.C) {
 `
 	var buf bytes.Buffer
 	err := v5.ProcessIcon(&buf, strings.NewReader(icon))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	if strings.Contains(buf.String(), "&#x") {
 		c.Errorf("newlines were quoted in processed icon output")
 	}
@@ -431,7 +431,7 @@ func assertXMLContains(c *gc.C, body []byte, need map[string]func(xml.Token) boo
 		if err == io.EOF {
 			break
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		for what, f := range need {
 			if f(tok) {
 				delete(need, what)

--- a/internal/v5/list_test.go
+++ b/internal/v5/list_test.go
@@ -52,7 +52,7 @@ func (s *ListSuite) SetUpTest(c *gc.C) {
 	s.addCharmsToStore(c)
 	// hide the riak charm
 	err := s.store.SetPerms(charm.MustParseURL("cs:~charmers/riak"), "stable.read", "charmers", "test-user")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *ListSuite) addCharmsToStore(c *gc.C) {
@@ -146,7 +146,7 @@ func (s *ListSuite) TestSuccessfulList(c *gc.C) {
 		})
 		var sr params.ListResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, len(test.results))
 		c.Logf("results: %s", rec.Body.Bytes())
 		for i := range test.results {
@@ -249,7 +249,7 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 			}
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, 1)
 		c.Assert(string(sr.Results[0].Meta), jc.JSONEquals, test.meta)
 	}
@@ -272,9 +272,9 @@ func (s *ListSuite) TestListIncludeError(c *gc.C) {
 	// Now remove one of the blobs. The list should still
 	// work, but only return a single result.
 	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.BlobStore.Remove(entity.BlobName, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Now list again - we should get one result less
 	// (and the error will be logged).
@@ -284,7 +284,7 @@ func (s *ListSuite) TestListIncludeError(c *gc.C) {
 	// uses LoggingSuite.
 	var tw loggo.TestWriter
 	err = loggo.RegisterWriter("test-log", &tw)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -368,7 +368,7 @@ func (s *ListSuite) TestSortingList(c *gc.C) {
 		})
 		var sr params.ListResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, len(test.results), gc.Commentf("expected %#v", test.results))
 		c.Logf("results: %s", rec.Body.Bytes())
 		for i := range test.results {
@@ -384,7 +384,7 @@ func (s *ListSuite) TestSortUnsupportedListField(c *gc.C) {
 	})
 	var e params.Error
 	err := json.Unmarshal(rec.Body.Bytes(), &e)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e.Code, gc.Equals, params.ErrBadRequest)
 	c.Assert(e.Message, gc.Equals, "invalid sort field: unrecognized sort parameter \"text\"")
 }
@@ -406,7 +406,7 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 	})
 	var sr params.ListResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(sr.Results, gc.HasLen, 4, gc.Commentf("expected %#v", testresults))
 	c.Logf("results: %s", rec.Body.Bytes())
 	for i := range testresults {
@@ -424,7 +424,7 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 		URL:     storeURL("list?sort=name"),
 	})
 	err = json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(sr.Results, gc.HasLen, 4, gc.Commentf("expected %#v", testresults))
 	c.Logf("results: %s", rec.Body.Bytes())
 	for i := range testresults {
@@ -434,7 +434,7 @@ func (s *ListSuite) TestGetLatestRevisionOnly(c *gc.C) {
 
 func (s *ListSuite) assertPut(c *gc.C, url string, val interface{}) {
 	body, err := json.Marshal(val)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
 		URL:     storeURL(url),
@@ -467,7 +467,7 @@ func (s *ListSuite) TestListWithAdminCredentials(c *gc.C) {
 	}
 	var sr params.ListResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertListResultSet(c, sr, expected)
 }
 
@@ -487,7 +487,7 @@ func (s *ListSuite) TestListWithUserMacaroon(c *gc.C) {
 	}
 	var sr params.ListResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertListResultSet(c, sr, expected)
 }
 
@@ -495,9 +495,9 @@ func (s *ListSuite) TestSearchWithBadAdminCredentialsAndACookie(c *gc.C) {
 	m, err := s.store.Bakery.NewMacaroon([]checkers.Caveat{
 		idmclient.UserDeclaration("test-user"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	macaroonCookie, err := httpbakery.NewCookie(macaroon.Slice{m})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler:  s.srv,
 		URL:      storeURL("list"),
@@ -514,7 +514,7 @@ func (s *ListSuite) TestSearchWithBadAdminCredentialsAndACookie(c *gc.C) {
 	}
 	var sr params.ListResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertListResultSet(c, sr, expected)
 }
 

--- a/internal/v5/log_test.go
+++ b/internal/v5/log_test.go
@@ -226,7 +226,7 @@ func (s *logSuite) TestGetLogs(c *gc.C) {
 	for _, key := range []string{"info1", "error1", "info2", "warning1", "error2", "info3", "error3", "stats"} {
 		resp := logResponses[key]
 		err := s.store.AddLog(&resp.Data, paramsLogLevels[resp.Level], paramsLogTypes[resp.Type], resp.URLs)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 	afterAdding := time.Now().Add(time.Second)
 
@@ -248,7 +248,7 @@ func (s *logSuite) TestGetLogs(c *gc.C) {
 		var logs []*params.LogResponse
 		decoder := json.NewDecoder(rec.Body)
 		err := decoder.Decode(&logs)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		// Check and then reset the response time so that the whole body
 		// can be more easily compared later.
@@ -351,7 +351,7 @@ func (s *logSuite) TestGetLogsErrorInvalidLog(c *gc.C) {
 		Type:  mongodoc.IngestionType,
 		Time:  time.Now(),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// The log is just ignored.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
@@ -387,7 +387,7 @@ func (s *logSuite) TestPostLogs(c *gc.C) {
 	// Ensure the log message has been added to the database.
 	var doc mongodoc.Log
 	err := s.store.DB.Logs().Find(nil).One(&doc)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(doc.Data), gc.Equals, `"info data"`)
 	c.Assert(doc.Level, gc.Equals, mongodoc.InfoLevel)
 	c.Assert(doc.Type, gc.Equals, mongodoc.IngestionType)
@@ -413,7 +413,7 @@ func (s *logSuite) TestPostLogsMultipleEntries(c *gc.C) {
 		Type:  params.IngestionType,
 	}}
 	body, err := json.Marshal(logs)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Send the request.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -433,7 +433,7 @@ func (s *logSuite) TestPostLogsMultipleEntries(c *gc.C) {
 	// TODO avoid reordering logs by adding a sequence number.
 	var docs []mongodoc.Log
 	err = s.store.DB.Logs().Find(nil).Sort("level").All(&docs)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(docs, gc.HasLen, 2)
 	c.Check(string(docs[0].Data), gc.Equals, string(infoData))
 	c.Check(docs[0].Level, gc.Equals, mongodoc.InfoLevel)

--- a/internal/v5/relations_test.go
+++ b/internal/v5/relations_test.go
@@ -295,9 +295,9 @@ func (s *RelationsSuite) TestMetaCharmRelated(c *gc.C) {
 		})
 		// Clean up the entities in the store.
 		_, err := s.store.DB.Entities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		_, err = s.store.DB.BaseEntities().RemoveAll(nil)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }
 
@@ -600,7 +600,7 @@ func (s *RelationsSuite) TestMetaBundlesContaining(c *gc.C) {
 		})
 		if test.addCharm != nil {
 			err := s.store.DB.Entities().Remove(bson.D{{"_id", &test.addCharm.URL}})
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 }
@@ -613,7 +613,7 @@ func (s *RelationsSuite) TestMetaBundlesContainingBundleACL(c *gc.C) {
 		if url.URL.Name == "useless" {
 			// The useless bundle is not available for "everyone".
 			err := s.store.SetPerms(&url.URL, "stable.read", url.URL.User)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 
@@ -641,11 +641,11 @@ func sameMetaAnyResponses(expect interface{}) httptesting.BodyAsserter {
 		}
 		var got []*params.MetaAnyResponse
 		err := json.Unmarshal(m, &got)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		sort.Sort(metaAnyResponseById(got))
 		sort.Sort(metaAnyResponseById(expectMeta))
 		data, err := json.Marshal(got)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(string(data), jc.JSONEquals, expect)
 	}
 }

--- a/internal/v5/resources_test.go
+++ b/internal/v5/resources_test.go
@@ -64,13 +64,13 @@ func (s *ResourceSuite) TestPost(c *gc.C) {
 
 	// Check that the resource has really been uploaded.
 	r, err := s.store.ResolveResource(id, "someResource", 1, "")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	blob, err := s.store.OpenResourceBlob(r)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer blob.Close()
 	data, err := ioutil.ReadAll(blob)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(data), gc.Equals, content)
 }
 
@@ -148,13 +148,13 @@ func (s *ResourceSuite) TestMultipartPost(c *gc.C) {
 
 	// Check that the resource has really been uploaded.
 	r, err := s.store.ResolveResource(id, "someResource", 1, "")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	blob, err := s.store.OpenResourceBlob(r)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer blob.Close()
 	data, err := ioutil.ReadAll(blob)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(string(data), gc.Equals, allContents)
 
 	// Check that the upload info has been removed.
@@ -200,12 +200,12 @@ func (s *ResourceSuite) TestGet(c *gc.C) {
 
 	// If we publish the resource, it should be available with no revision.
 	err := s.store.Publish(id, map[string]int{"someResource": 2}, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Make it public so that we can check that the cache-control
 	// headers change appropriately.
 	err = s.store.SetPerms(&id.URL, "stable.read", params.Everyone)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	resp = httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -463,7 +463,7 @@ func (s *ResourceSuite) TestDownloadPrivateCharmResource(c *gc.C) {
 			},
 		},
 	}))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	content := "some content"
 	s.uploadResource(c, id, "someResource", content)
 
@@ -513,7 +513,7 @@ func (s *ResourceSuite) TestMetaResources(c *gc.C) {
 		"resource1": 0,
 		"resource2": 0,
 	}, params.StableChannel)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      s.srv,
@@ -612,7 +612,7 @@ func (s *ResourceSuite) TestMetaResourcesSingleResourceNotUploaded(c *gc.C) {
 	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
 	meta := storetesting.MetaWithResources(nil, "someResource")
 	err := s.store.AddCharmWithArchive(id, storetesting.NewCharm(meta))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,

--- a/internal/v5/search_test.go
+++ b/internal/v5/search_test.go
@@ -51,11 +51,11 @@ func (s *SearchSuite) SetUpTest(c *gc.C) {
 	s.commonSuite.SetUpTest(c)
 	s.addCharmsToStore(c)
 	err := s.store.SetPerms(charm.MustParseURL("cs:~charmers/riak"), "stable.read", "charmers", "test-user")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.UpdateSearch(newResolvedURL("~charmers/trusty/riak-0", 0))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.esSuite.ES.RefreshIndex(s.esSuite.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 }
 
 func (s *SearchSuite) addCharmsToStore(c *gc.C) {
@@ -257,12 +257,12 @@ func (s *SearchSuite) TestParseSearchParams(c *gc.C) {
 		var req http.Request
 		var err error
 		req.Form, err = url.ParseQuery(test.query)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		sp, err := v5.ParseSearchParams(&req)
 		if test.expectError != "" {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 		} else {
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		c.Assert(sp, jc.DeepEquals, test.expectParams)
 	}
@@ -430,7 +430,7 @@ func (s *SearchSuite) TestSuccessfulSearches(c *gc.C) {
 		})
 		var sr params.SearchResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, len(test.results))
 		c.Logf("results: %s", rec.Body.Bytes())
 		assertResultSet(c, sr, test.results)
@@ -444,7 +444,7 @@ func (s *SearchSuite) TestPaginatedSearch(c *gc.C) {
 	})
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(sr.Results, gc.HasLen, 1)
 	c.Assert(sr.Total, gc.Equals, 2)
 }
@@ -543,7 +543,7 @@ func (s *SearchSuite) TestMetadataFields(c *gc.C) {
 			}
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(sr.Results, gc.HasLen, 1)
 		c.Assert(string(sr.Results[0].Meta), jc.JSONEquals, test.meta)
 	}
@@ -559,7 +559,7 @@ func (s *SearchSuite) TestSearchError(c *gc.C) {
 	c.Assert(rec.Code, gc.Equals, http.StatusInternalServerError)
 	var resp params.Error
 	err = json.Unmarshal(rec.Body.Bytes(), &resp)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(resp.Code, gc.Equals, params.ErrorCode(""))
 	c.Assert(resp.Message, gc.Matches, "error performing search: search failed: .*")
 }
@@ -582,9 +582,9 @@ func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
 	// work, but only return a single result.
 	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
 
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = s.store.BlobStore.Remove(entity.BlobName, nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Now search again - we should get one result less
 	// (and the error will be logged).
@@ -594,7 +594,7 @@ func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
 	// uses LoggingSuite.
 	var tw loggo.TestWriter
 	err = loggo.RegisterWriter("test-log", &tw)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -678,7 +678,7 @@ func (s *SearchSuite) TestSorting(c *gc.C) {
 		})
 		var sr params.SearchResponse
 		err := json.Unmarshal(rec.Body.Bytes(), &sr)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		// Not using assertResultSet(c, sr, test.results) as it does sort internally
 		c.Assert(sr.Results, gc.HasLen, len(test.results), gc.Commentf("expected %#v", test.results))
 		c.Logf("results: %s", rec.Body.Bytes())
@@ -695,7 +695,7 @@ func (s *SearchSuite) TestSortUnsupportedField(c *gc.C) {
 	})
 	var e params.Error
 	err := json.Unmarshal(rec.Body.Bytes(), &e)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(e.Code, gc.Equals, params.ErrBadRequest)
 	c.Assert(e.Message, gc.Equals, "invalid sort field: unrecognized sort parameter \"foo\"")
 }
@@ -712,18 +712,18 @@ func (s *SearchSuite) TestDownloadsBoost(c *gc.C) {
 		s.addPublicCharm(c, getSearchCharm(n), url)
 		for i := 0; i < cnt; i++ {
 			err := s.store.IncrementDownloadCounts(url)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 	}
 	err := s.esSuite.ES.RefreshIndex(s.esSuite.TestIndex)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
 		URL:     storeURL("search?owner=downloads-test"),
 	})
 	var sr params.SearchResponse
 	err = json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(sr.Results, gc.HasLen, 3)
 	c.Assert(sr.Results[0].Id.Name, gc.Equals, "varnish")
 	c.Assert(sr.Results[1].Id.Name, gc.Equals, "wordpress")
@@ -747,7 +747,7 @@ func (s *SearchSuite) TestSearchWithAdminCredentials(c *gc.C) {
 	}
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertResultSet(c, sr, expected)
 }
 
@@ -767,7 +767,7 @@ func (s *SearchSuite) TestSearchWithUserMacaroon(c *gc.C) {
 	}
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertResultSet(c, sr, expected)
 }
 
@@ -775,9 +775,9 @@ func (s *SearchSuite) TestSearchDoesNotCreateExtraMacaroons(c *gc.C) {
 	// Ensure that there's a macaroon already in the store
 	// that can be reused.
 	_, err := s.store.Bakery.NewMacaroon(nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	n, err := s.store.DB.Macaroons().Find(nil).Count()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(n, gc.Equals, 1)
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: s.srv,
@@ -786,7 +786,7 @@ func (s *SearchSuite) TestSearchDoesNotCreateExtraMacaroons(c *gc.C) {
 	})
 	c.Assert(rec.Code, gc.Equals, http.StatusOK)
 	n, err = s.store.DB.Macaroons().Find(nil).Count()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(n, gc.Equals, 1)
 }
 
@@ -807,7 +807,7 @@ func (s *SearchSuite) TestSearchWithUserInGroups(c *gc.C) {
 	}
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertResultSet(c, sr, expected)
 }
 
@@ -828,7 +828,7 @@ func (s *SearchSuite) TestSearchWithBadAdminCredentialsAndACookie(c *gc.C) {
 	}
 	var sr params.SearchResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &sr)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertResultSet(c, sr, expected)
 }
 

--- a/internal/v5/stats_test.go
+++ b/internal/v5/stats_test.go
@@ -137,7 +137,7 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 
 		var err error
 		_, countsBefore, err = s.store.ArchiveDownloadCounts(ref, true)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 
 		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 			Handler:  s.srv,
@@ -151,7 +151,7 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 		c.Assert(rec.Code, gc.Equals, test.status)
 
 		_, countsAfter, err = s.store.ArchiveDownloadCounts(ref, true)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(countsAfter.Total-countsBefore.Total, gc.Equals, int64(1))
 		if test.previousMonth {
 			c.Assert(countsAfter.LastDay-countsBefore.LastDay, gc.Equals, int64(0))
@@ -244,7 +244,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 		if test.partialUpdate {
 			var err error
 			_, countsBefore, err = s.store.ArchiveDownloadCounts(ref, true)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 		}
 		httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 			Handler:      s.srv,
@@ -261,7 +261,7 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 		})
 		if test.partialUpdate {
 			_, countsAfter, err := s.store.ArchiveDownloadCounts(ref, true)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(countsAfter.Total-countsBefore.Total, gc.Equals, int64(1))
 			c.Assert(countsAfter.LastDay-countsBefore.LastDay, gc.Equals, int64(1))
 		}
@@ -328,14 +328,14 @@ func (s *StatsSuite) TestStatsCounter(c *gc.C) {
 
 	for _, key := range [][]string{{"a", "b"}, {"a", "b"}, {"a", "c"}, {"a"}} {
 		err := s.store.IncCounter(key)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	var all []interface{}
 	err := s.store.DB.StatCounters().Find(nil).All(&all)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	data, err := json.Marshal(all)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Logf("%s", data)
 
 	expected := map[string]int64{
@@ -378,7 +378,7 @@ func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
 	}
 	for _, key := range incs {
 		err := s.store.IncCounter(key)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	tests := []struct {
@@ -479,7 +479,7 @@ func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {
 		t = t.Add(time.Duration(i) * charmstore.StatsGranularity)
 
 		err := s.store.IncCounterAtTime(inc.key, t)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 
 	tests := []struct {

--- a/internal/v5/status_test.go
+++ b/internal/v5/status_test.go
@@ -221,7 +221,7 @@ func (s *APISuite) TestStatusBaseEntitiesError(c *gc.C) {
 		Name: "django",
 	}
 	err := s.store.DB.BaseEntities().Insert(entity)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	s.AssertDebugStatus(c, false, map[string]params.DebugStatus{
 		"base_entities": {
@@ -245,7 +245,7 @@ func (s *APISuite) AssertDebugStatus(c *gc.C, complete bool, status map[string]p
 	c.Assert(rec.Header().Get("Content-Type"), gc.Equals, "application/json")
 	var gotStatus map[string]params.DebugStatus
 	err := json.Unmarshal(rec.Body.Bytes(), &gotStatus)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	for key, r := range gotStatus {
 		if _, found := status[key]; !complete && !found {
 			delete(gotStatus, key)
@@ -275,7 +275,7 @@ func (s *statusWithElasticSearchSuite) TestStatusWithElasticSearch(c *gc.C) {
 	})
 	var results map[string]params.DebugStatus
 	err := json.Unmarshal(rec.Body.Bytes(), &results)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(results["elasticsearch"].Name, gc.Equals, "Elastic search is running")
 	c.Assert(results["elasticsearch"].Value, jc.Contains, "cluster_name:")
 }

--- a/server_test.go
+++ b/server_test.go
@@ -63,7 +63,7 @@ func (s *ServerSuite) TestNewServerWithVersions(c *gc.C) {
 	db := s.Session.DB("foo")
 
 	h, err := charmstore.NewServer(db, nil, "", s.config, charmstore.V4)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -120,6 +120,6 @@ func (s *ServerESSuite) TestNewServerWithElasticsearch(c *gc.C) {
 	db := s.Session.DB("foo")
 
 	srv, err := charmstore.NewServer(db, s.ES, s.TestIndex, s.config, charmstore.V4)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	srv.Close()
 }


### PR DESCRIPTION
Trivial automatic change. Also use Equals instead of jc.ErrorIsNil for
consistency and because ErrorIsNil doesn't add significant value.
