### PR TITLE
internal/blobstore: only swift needs to know about container

### DIFF
--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"testing"
 	"testing/iotest"
 	"time"
 
@@ -23,10 +22,6 @@ import (
 	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
 )
 
-func TestPackage(t *testing.T) {
-	jujutesting.MgoTestPackage(t, nil)
-}
-
 type BlobStoreSuite struct {
 	jujutesting.IsolatedMgoSuite
 	store *blobstore.Store
@@ -38,7 +33,7 @@ func (s *BlobStoreSuite) SetUpTest(c *gc.C) {
 	s.IsolatedMgoSuite.SetUpTest(c)
 	db := s.Session.DB("db")
 	mstore := blobstore.NewMongoStore(db, "blobstore")
-	s.store = blobstore.New(db, "blobstore", "", mstore)
+	s.store = blobstore.New(db, "blobstore", mstore)
 }
 
 func (s *BlobStoreSuite) TestPutTwice(c *gc.C) {

--- a/internal/blobstore/mongodb.go
+++ b/internal/blobstore/mongodb.go
@@ -26,8 +26,8 @@ func NewMongoStore(db *mgo.Database, prefix string) ObjectStore {
 	}
 }
 
-func (m *mongoStore) Get(container, name string) (ReadSeekCloser, int64, error) {
-	r, s, err := m.GetForEnvironment(container, name)
+func (m *mongoStore) Get(name string) (ReadSeekCloser, int64, error) {
+	r, s, err := m.GetForEnvironment("", name)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, 0, errgo.WithCausef(err, ErrNotFound, "")
@@ -37,10 +37,10 @@ func (m *mongoStore) Get(container, name string) (ReadSeekCloser, int64, error) 
 	return r.(ReadSeekCloser), s, nil
 }
 
-func (m *mongoStore) Put(container, name string, r io.Reader, size int64, hash string) error {
-	return m.PutForEnvironmentAndCheckHash(container, name, r, size, hash)
+func (m *mongoStore) Put(name string, r io.Reader, size int64, hash string) error {
+	return m.PutForEnvironmentAndCheckHash("", name, r, size, hash)
 }
 
-func (m *mongoStore) Remove(container, name string) error {
-	return m.RemoveForEnvironment(container, name)
+func (m *mongoStore) Remove(name string) error {
+	return m.RemoveForEnvironment("", name)
 }

--- a/internal/blobstore/package_test.go
+++ b/internal/blobstore/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package blobstore_test
+
+import (
+	"testing"
+
+	jujutesting "github.com/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	jujutesting.MgoTestPackage(t, nil)
+}

--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -104,7 +104,6 @@ func NewPool(db *mgo.Database, si *SearchIndex, bakeryParams *bakery.NewServiceP
 	}
 	var objectstore blobstore.ObjectStore
 	if config.BlobStore == "swift" {
-
 		cred := &identity.Credentials{
 			URL:        config.SwiftAuthURL,
 			User:       config.SwiftUsername,
@@ -121,7 +120,7 @@ func NewPool(db *mgo.Database, si *SearchIndex, bakeryParams *bakery.NewServiceP
 		case "authuserpassv3":
 			authmode = identity.AuthUserPassV3
 		}
-		objectstore = blobstore.NewSwiftStore(cred, authmode)
+		objectstore = blobstore.NewSwiftStore(cred, authmode, config.SwiftBucket)
 	} else {
 		objectstore = blobstore.NewMongoStore(db, "entitystore")
 	}
@@ -216,7 +215,7 @@ func (p *Pool) RequestStore() (*Store, error) {
 }
 
 func (p *Pool) newBlobStore(db StoreDatabase) *blobstore.Store {
-	bs := blobstore.New(db.Database, "entitystore", p.config.SwiftBucket, p.objectstore)
+	bs := blobstore.New(db.Database, "entitystore", p.objectstore)
 	if p.config.MinUploadPartSize != 0 {
 		bs.MinPartSize = p.config.MinUploadPartSize
 	}

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -1306,7 +1306,7 @@ func (s *ArchiveSuite) TestDeleteError(c *gc.C) {
 			Method:       "DELETE",
 			ExpectStatus: http.StatusInternalServerError,
 			ExpectBody: params.Error{
-				Message: `cannot delete "cs:~charmers/utopic/mysql-42": cannot remove blob no-such-name: resource at path "environs/testc/no-such-name" not found`,
+				Message: `cannot delete "cs:~charmers/utopic/mysql-42": cannot remove blob no-such-name: resource at path "global/no-such-name" not found`,
 			},
 		})
 	})


### PR DESCRIPTION
The concept of "container" was exposed in the ObjectStore
interface, but it's not inherent to an object store - of
the two current implementations, only one needs
to know about containers currently.

This also fixes the MongoDB blobstore implementation
so that it continues to use the same paths as the
currently deployed version, so deploying without
Swift won't cause all the blobs to "disappear".