### PR TITLE
internal/blobstore: rename ObjectStore to Backend

### DIFF
--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -34,6 +34,10 @@ func NewHash() hash.Hash {
 type Backend interface {
 	// Get gets a reader for the object with the given name
 	// and its size. The returned reader should be closed after use.
+	// If the object doesn't exist, an error with an ErrNotFound
+	// cause should be returned.
+	// If the object is removed while reading, the read
+	// error's cause should be ErrNotFound.
 	Get(name string) (r ReadSeekCloser, size int64, err error)
 
 	// Put puts an object by reading its data from the given reader.
@@ -49,7 +53,7 @@ type Backend interface {
 // blob hash.
 type Store struct {
 	uploadc *mgo.Collection
-	backend  Backend
+	backend Backend
 
 	// The following fields are given default values by
 	// New but may be changed away from the defaults
@@ -71,7 +75,7 @@ type Store struct {
 func New(db *mgo.Database, prefix string, backend Backend) *Store {
 	return &Store{
 		uploadc:     db.C(prefix + ".upload"),
-		backend:      backend,
+		backend:     backend,
 		MinPartSize: defaultMinPartSize,
 		MaxParts:    defaultMaxParts,
 		MaxPartSize: defaultMaxPartSize,

--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -29,14 +29,19 @@ func NewHash() hash.Hash {
 	return sha512.New384()
 }
 
-// ObjectStore represents an object store. Even juju/blobstore is used like an
-// object store.
-type ObjectStore interface {
-	// Get gets an object.
+// Backend represents the underlying data store used by blobstore.Store
+// to store blob data.
+type Backend interface {
+	// Get gets a reader for the object with the given name
+	// and its size. The returned reader should be closed after use.
 	Get(name string) (r ReadSeekCloser, size int64, err error)
-	// Put puts an object.
+
+	// Put puts an object by reading its data from the given reader.
+	// The data read from the reader should have the given
+	// size and hex-encoded SHA384 hash.
 	Put(name string, r io.Reader, size int64, hash string) error
-	// Remove removes an object.
+
+	// Remove removes the object with the given name.
 	Remove(name string) error
 }
 
@@ -44,7 +49,7 @@ type ObjectStore interface {
 // blob hash.
 type Store struct {
 	uploadc *mgo.Collection
-	ostore  ObjectStore
+	backend  Backend
 
 	// The following fields are given default values by
 	// New but may be changed away from the defaults
@@ -63,10 +68,10 @@ type Store struct {
 
 // New returns a new blob store that writes to the given database,
 // prefixing its collections with the given prefix.
-func New(db *mgo.Database, prefix string, ostore ObjectStore) *Store {
+func New(db *mgo.Database, prefix string, backend Backend) *Store {
 	return &Store{
 		uploadc:     db.C(prefix + ".upload"),
-		ostore:      ostore,
+		backend:      backend,
 		MinPartSize: defaultMinPartSize,
 		MaxParts:    defaultMaxParts,
 		MaxPartSize: defaultMaxPartSize,
@@ -77,7 +82,7 @@ func New(db *mgo.Database, prefix string, ostore ObjectStore) *Store {
 // storage, with the provided name. The content should have the given
 // size and hash.
 func (s *Store) Put(r io.Reader, name string, size int64, hash string) error {
-	return s.ostore.Put(name, r, size, hash)
+	return s.backend.Put(name, r, size, hash)
 }
 
 // Open opens the entry with the given name. It returns an error
@@ -86,7 +91,7 @@ func (s *Store) Open(name string, index *mongodoc.MultipartIndex) (ReadSeekClose
 	if index != nil {
 		return newMultiReader(s, name, index)
 	}
-	r, size, err := s.ostore.Get(name)
+	r, size, err := s.backend.Get(name)
 	if err != nil {
 		return nil, 0, errgo.Mask(err, errgo.Is(ErrNotFound))
 	}
@@ -95,7 +100,7 @@ func (s *Store) Open(name string, index *mongodoc.MultipartIndex) (ReadSeekClose
 
 // Remove the given name from the Store.
 func (s *Store) Remove(name string, index *mongodoc.MultipartIndex) error {
-	err := s.ostore.Remove(name)
+	err := s.backend.Remove(name)
 	if errors.IsNotFound(err) {
 		return errgo.WithCausef(err, ErrNotFound, "")
 	}

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -86,7 +86,7 @@ func (s *SwiftStoreSuite) TearDownTest(c *gc.C) {
 
 type blobStoreSuite struct {
 	jujutesting.IsolatedMgoSuite
-	store          *blobstore.Store
+	store      *blobstore.Store
 	newBackend func(db *mgo.Database) blobstore.Backend
 }
 
@@ -559,7 +559,7 @@ func (s *blobStoreSuite) TestFinishUploadCalledWhenCalculatingHash(c *gc.C) {
 	err := s.store.PutPart(id, 0, strings.NewReader(content0), int64(len(content0)), hashOf(content0))
 	c.Assert(err, gc.Equals, nil)
 
-	const size1 = 2 * 1024 * 1024
+	const size1 = 20 * 1024 * 1024
 	hash1 := hashOfReader(c, newDataSource(1, size1))
 	err = s.store.PutPart(id, 1, newDataSource(1, size1), int64(size1), hash1)
 	c.Assert(err, gc.Equals, nil)

--- a/internal/blobstore/mongodb.go
+++ b/internal/blobstore/mongodb.go
@@ -12,21 +12,21 @@ import (
 	"gopkg.in/mgo.v2"
 )
 
-type mongoStore struct {
+type mongoBackend struct {
 	blobstore.ManagedStorage
 }
 
-// NewMongoStore returns an ObjectStore which uses mongodb gridfs for its
-// operations with the given database and gridfs prefix. This uses a
-// "ManagedStorage" layer on top of gridfs from github.com/juju/blobstore.
-func NewMongoStore(db *mgo.Database, prefix string) ObjectStore {
+// NewMongoBackend returns a backend implementation which stores
+// data in the given MongoDB database, using prefix as a prefix for
+// the collections created.
+func NewMongoBackend(db *mgo.Database, prefix string) Backend {
 	rs := blobstore.NewGridFS(db.Name, prefix, db.Session)
-	return &mongoStore{
+	return &mongoBackend{
 		ManagedStorage: blobstore.NewManagedStorage(db, rs),
 	}
 }
 
-func (m *mongoStore) Get(name string) (ReadSeekCloser, int64, error) {
+func (m *mongoBackend) Get(name string) (ReadSeekCloser, int64, error) {
 	r, s, err := m.GetForEnvironment("", name)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -37,10 +37,10 @@ func (m *mongoStore) Get(name string) (ReadSeekCloser, int64, error) {
 	return r.(ReadSeekCloser), s, nil
 }
 
-func (m *mongoStore) Put(name string, r io.Reader, size int64, hash string) error {
+func (m *mongoBackend) Put(name string, r io.Reader, size int64, hash string) error {
 	return m.PutForEnvironmentAndCheckHash("", name, r, size, hash)
 }
 
-func (m *mongoStore) Remove(name string) error {
+func (m *mongoBackend) Remove(name string) error {
 	return m.RemoveForEnvironment("", name)
 }

--- a/internal/blobstore/multipart.go
+++ b/internal/blobstore/multipart.go
@@ -367,7 +367,7 @@ func (s *Store) copyBlob(w io.Writer, name string) error {
 	}
 	defer rc.Close()
 	if _, err := io.Copy(w, rc); err != nil {
-		if errgo.Cause(err) == mgo.ErrNotFound {
+		if errgo.Cause(err) == ErrNotFound {
 			return errgo.WithCausef(err, ErrNotFound, "error reading blob %q", name)
 		}
 		return errgo.Notef(err, "error reading blob %q", name)

--- a/internal/blobstore/swift.go
+++ b/internal/blobstore/swift.go
@@ -45,7 +45,7 @@ func (s *swiftBackend) Get(name string) (r ReadSeekCloser, size int64, err error
 	}
 	lengthstr := headers.Get("Content-Length")
 	size, err = strconv.ParseInt(lengthstr, 10, 64)
-	return r2.(ReadSeekCloser), size, err
+	return swiftBackendReader{r2.(ReadSeekCloser)}, size, err
 }
 
 func (s *swiftBackend) Put(name string, r io.Reader, size int64, hash string) error {
@@ -55,7 +55,7 @@ func (s *swiftBackend) Put(name string, r io.Reader, size int64, hash string) er
 	if err != nil {
 		// TODO: investigate if PutReader can return err but the object still be
 		// written. Should there be cleanup here?
-		return err
+		return errgo.Mask(err)
 	}
 	if hash != fmt.Sprintf("%x", h.Sum(nil)) {
 		err := s.client.DeleteObject(s.container, name)
@@ -72,7 +72,25 @@ func (s *swiftBackend) Remove(name string) error {
 	if err != nil && errors.IsNotFound(err) {
 		return errgo.WithCausef(err, ErrNotFound, "")
 	}
-	return err
+	return errgo.Mask(err)
+}
+
+// swiftBackendReader translates not-found errors as
+// produced by Swift into not-found errors as expected
+// by the Backend.Get interface contract.
+type swiftBackendReader struct {
+	ReadSeekCloser
+}
+
+func (r swiftBackendReader) Read(buf []byte) (int, error) {
+	n, err := r.ReadSeekCloser.Read(buf)
+	if err == nil || err == io.EOF {
+		return n, err
+	}
+	if errors.IsNotFound(err) {
+		return n, errgo.WithCausef(err, ErrNotFound, "")
+	}
+	return n, errgo.Mask(err)
 }
 
 // gooseLogger implements the logger interface required


### PR DESCRIPTION
The name "ObjectStore" is somewhat confusing, as
it has almost exactly the same meaning as "BlobStore",
which is what the package implements.

To try to make things clearer, we rename ObjectStore to
Backend to more accurately reflect the role
of the type in the blobstore implementation.