### PR TITLE
internal/charmstore: make mongo backend work when session dies

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/goose.v2/identity"
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 
 	"gopkg.in/juju/charmstore.v5-unstable/config"
@@ -50,6 +51,14 @@ stats-cache-max-age: 1h
 search-cache-max-age: 15m
 request-timeout: 500ms
 max-mgo-sessions: 10
+blobstore: swift
+swift-auth-url: 'https://foo.com'
+swift-username: bob
+swift-secret: secret
+swift-bucket: bucket
+swift-region: somewhere
+swift-tenant: a-tenant
+swift-authmode: userpass
 `
 
 func (s *ConfigSuite) readConfig(c *gc.C, content string) (*config.Config, error) {
@@ -94,6 +103,14 @@ func (s *ConfigSuite) TestRead(c *gc.C) {
 		RequestTimeout:    config.DurationString{500 * time.Millisecond},
 		MaxMgoSessions:    10,
 		SearchCacheMaxAge: config.DurationString{15 * time.Minute},
+		BlobStore:         config.SwiftBlobStore,
+		SwiftAuthURL:      "https://foo.com",
+		SwiftUsername:     "bob",
+		SwiftSecret:       "secret",
+		SwiftBucket:       "bucket",
+		SwiftRegion:       "somewhere",
+		SwiftTenant:       "a-tenant",
+		SwiftAuthMode:     &config.SwiftAuthMode{identity.AuthUserPass},
 	})
 }
 
@@ -106,6 +123,10 @@ func (s *ConfigSuite) TestReadConfigError(c *gc.C) {
 func (s *ConfigSuite) TestValidateConfigError(c *gc.C) {
 	cfg, err := s.readConfig(c, "")
 	c.Assert(err, gc.ErrorMatches, "missing fields mongo-url, api-addr, auth-username, auth-password in config file")
+	c.Assert(cfg, gc.IsNil)
+
+	cfg, err = s.readConfig(c, "blobstore: swift\n")
+	c.Assert(err, gc.ErrorMatches, "missing fields mongo-url, api-addr, auth-username, auth-password, swift-auth-url, swift-username, swift-secret, swift-bucket, swift-region, swift-tenant, swift-auth-mode in config file")
 	c.Assert(cfg, gc.IsNil)
 }
 

--- a/internal/blobstore/swift.go
+++ b/internal/blobstore/swift.go
@@ -39,7 +39,7 @@ func (s *swiftBackend) Get(name string) (r ReadSeekCloser, size int64, err error
 	r2, headers, err := s.client.GetReadSeeker(s.container, name)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return nil, 0, errgo.WithCausef(err, ErrNotFound, "")
+			return nil, 0, errgo.WithCausef(nil, ErrNotFound, "")
 		}
 		return nil, 0, errgo.Mask(err)
 	}
@@ -70,7 +70,7 @@ func (s *swiftBackend) Put(name string, r io.Reader, size int64, hash string) er
 func (s *swiftBackend) Remove(name string) error {
 	err := s.client.DeleteObject(s.container, name)
 	if err != nil && errors.IsNotFound(err) {
-		return errgo.WithCausef(err, ErrNotFound, "")
+		return errgo.WithCausef(nil, ErrNotFound, "")
 	}
 	return errgo.Mask(err)
 }
@@ -88,7 +88,7 @@ func (r swiftBackendReader) Read(buf []byte) (int, error) {
 		return n, err
 	}
 	if errors.IsNotFound(err) {
-		return n, errgo.WithCausef(err, ErrNotFound, "")
+		return n, errgo.WithCausef(nil, ErrNotFound, "")
 	}
 	return n, errgo.Mask(err)
 }

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/natefinch/lumberjack.v2"
 
+	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/monitoring"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 )
@@ -89,44 +90,25 @@ type ServerParams struct {
 
 	// MinUploadPartSize holds the minimum size of
 	// an upload part. If it's zero, a default value will be used.
-	MinUploadPartSize int64 `json:"min-upload-part-size"`
+	MinUploadPartSize int64
 
 	// MaxUploadPartSize holds the maximum size of
 	// an upload part. If it's zero, a default value will be used.
-	MaxUploadPartSize int64 `json:"max-upload-part-size"`
+	MaxUploadPartSize int64
 
 	// MaxUploadParts holds the maximum number of upload
 	// parts that can be uploaded in a single upload.
 	// If it's zero, a default value will be used.
-	MaxUploadParts int `json:"max-upload-parts"`
+	MaxUploadParts int
 
 	// RunBlobStoreGC holds whether the server will run
 	// the blobstore garbage collector worker.
 	RunBlobStoreGC bool
 
-	// BlobStore holds the type of blobstore to use.
-	BlobStore string `yaml:"blobstore"`
-
-	// SwiftAuthURL holds the swift auth url, equivalent to OS_AUTH_URL.
-	SwiftAuthURL string `yaml:"swift-auth-url"`
-
-	// SwiftUsername holds the swift username, equivalent to OS_USERNAME..
-	SwiftUsername string `yaml:"swift-username"`
-
-	// SwiftSecret holds the swift password, equivalent to OS_PASSWORD.
-	SwiftSecret string `yaml:"swift-secret"`
-
-	// SwiftBucket holds the swift bucket to use for blobs.
-	SwiftBucket string `yaml:"swift-bucket"`
-
-	// SwiftRegion holds the swift region to use for blobs.
-	SwiftRegion string `yaml:"swift-region"`
-
-	// SwiftTenant holds the swift tenant to use for connecting to swift.
-	SwiftTenant string `yaml:"swift-tenant"`
-
-	// SwiftAuthMode holds the swift auth mode to use for connecting to swift.
-	SwiftAuthMode string `yaml:"swift-authmode"`
+	// NewBlobBackend returns a new blobstore backend
+	// that may use the given MongoDB database.
+	// If this is nil, a MongoDB backend will be used.
+	NewBlobBackend func(db *mgo.Database) blobstore.Backend
 }
 
 const defaultRootKeyExpiryDuration = 24 * time.Hour

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -18,11 +18,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
-	"gopkg.in/goose.v2/client"
-	"gopkg.in/goose.v2/identity"
-	"gopkg.in/goose.v2/swift"
-	"gopkg.in/goose.v2/testing/httpsuite"
-	"gopkg.in/goose.v2/testservices/openstackservice"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
@@ -39,57 +34,22 @@ import (
 var serverParams = charmstore.ServerParams{
 	AuthUsername: "test-user",
 	AuthPassword: "test-password",
-	SwiftBucket:  "testbucket",
 }
 
 type APISuite struct {
 	jujutesting.IsolatedMgoSuite
 	srv   *charmstore.Server
 	store *charmstore.Store
-	httpsuite.HTTPSuite
-	openstack openstackservice.Openstack
 }
 
 var _ = gc.Suite(&APISuite{})
 
-func (s *APISuite) SetUpSuite(c *gc.C) {
-	s.IsolatedMgoSuite.SetUpSuite(c)
-	s.HTTPSuite.SetUpSuite(c)
-}
-
-func (s *APISuite) TearDownSuite(c *gc.C) {
-	s.HTTPSuite.TearDownSuite(c)
-	s.IsolatedMgoSuite.TearDownSuite(c)
-}
-
 func (s *APISuite) SetUpTest(c *gc.C) {
-	s.HTTPSuite.SetUpTest(c)
 	s.IsolatedMgoSuite.SetUpTest(c)
-	cred := &identity.Credentials{
-		URL:        s.Server.URL,
-		User:       "fred",
-		Secrets:    "scrt",
-		Region:     "heaven",
-		TenantName: "awesomo",
-	}
-	openstack, logMsg := openstackservice.New(cred, identity.AuthUserPass, false)
-	for _, msg := range logMsg {
-		c.Logf(msg)
-	}
-	openstack.SetupHTTP(nil)
-	s.openstack = *openstack
-	serverParams.SwiftUsername = cred.User
-	serverParams.SwiftSecret = cred.Secrets
-	serverParams.SwiftAuthURL = s.openstack.URLs["identity"]
-	client := client.NewClient(cred, identity.AuthUserPass, nil)
-	sw := swift.New(client)
-	sw.CreateContainer(serverParams.SwiftBucket, swift.Private)
 	s.srv, s.store = newServer(c, s.Session, serverParams)
 }
 
 func (s *APISuite) TearDownTest(c *gc.C) {
-	s.openstack.Stop()
-	s.HTTPSuite.TearDownTest(c)
 	s.store.Close()
 	s.store.Pool().Close()
 	s.srv.Close()

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -1306,7 +1306,7 @@ func (s *ArchiveSuite) TestDeleteError(c *gc.C) {
 			Method:       "DELETE",
 			ExpectStatus: http.StatusInternalServerError,
 			ExpectBody: params.Error{
-				Message: `cannot delete "cs:~charmers/utopic/mysql-42": cannot remove blob no-such-name: resource at path "global/no-such-name" not found`,
+				Message: `cannot delete "cs:~charmers/utopic/mysql-42": cannot remove blob no-such-name: blob not found`,
 			},
 		})
 	})

--- a/server.go
+++ b/server.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	"gopkg.in/juju/charmstore.v5-unstable/elasticsearch"
+	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/legacy"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/v4"
@@ -105,46 +106,25 @@ type ServerParams struct {
 
 	// MinUploadPartSize holds the minimum size of
 	// an upload part. If it's zero, a default value will be used.
-	MinUploadPartSize int64 `json:"min-upload-part-size"`
+	MinUploadPartSize int64
 
 	// MaxUploadPartSize holds the maximum size of
 	// an upload part. If it's zero, a default value will be used.
-	MaxUploadPartSize int64 `json:"max-upload-part-size"`
+	MaxUploadPartSize int64
 
 	// MaxUploadParts holds the maximum number of upload
 	// parts that can be uploaded in a single upload.
 	// If it's zero, a default value will be used.
-	MaxUploadParts int `json:"max-upload-parts"`
+	MaxUploadParts int
 
 	// RunBlobStoreGC holds whether the server will run
 	// the blobstore garbage collector worker.
 	RunBlobStoreGC bool
 
-	// BlobStore holds the type of blobstore to use. Defaults to gridfs via
-	// juju/blobstore. Other values are swift. Future values may be s3, azure,
-	// gcloud, ceph.
-	BlobStore string `yaml:"blobstore"`
-
-	// SwiftAuthURL holds the swift auth url, equivalent to OS_AUTH_URL.
-	SwiftAuthURL string `yaml:"swift-auth-url"`
-
-	// SwiftUsername holds the swift username, equivalent to OS_USERNAME..
-	SwiftUsername string `yaml:"swift-username"`
-
-	// SwiftSecret holds the swift password, equivalent to OS_PASSWORD.
-	SwiftSecret string `yaml:"swift-secret"`
-
-	// SwiftBucket holds the swift bucket to use for blobs.
-	SwiftBucket string `yaml:"swift-bucket"`
-
-	// SwiftRegion holds the swift region to use for blobs.
-	SwiftRegion string `yaml:"swift-region"`
-
-	// SwiftTenant holds the swift tenant to use for connecting to swift.
-	SwiftTenant string `yaml:"swift-tenant"`
-
-	// SwiftAuthMode holds the swift auth mode to use for connecting to swift.
-	SwiftAuthMode string `yaml:"swift-authmode"`
+	// NewBlobBackend returns a new blobstore backend
+	// that may use the given MongoDB database.
+	// If this is nil, a MongoDB backend will be used.
+	NewBlobBackend func(db *mgo.Database) blobstore.Backend
 }
 
 // NewServer returns a new handler that handles charm store requests and stores


### PR DESCRIPTION
Also factor the direct Swift dependency out of the
charmstore server parameters, and stop using
a Swift blobstore in some packages where it
doesn't give extra test confidence.
