### PR TITLE
internal/mongodoc: implement storage scheme for hashes

### DIFF
--- a/internal/mongodoc/hash.go
+++ b/internal/mongodoc/hash.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongodoc
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// Hashes holds a slice of hash objects
+// that will encode to MongoDB in a space-efficient
+// way. Each of the strings must be a hex-encoded
+// SHA384 checksum as produced by blobstore.NewHash.
+type Hashes []string
+
+// SetBSON implements bson.Setter by unmarshaling
+// the document from a byte slice.
+func (h *Hashes) SetBSON(raw bson.Raw) error {
+	var slice []byte
+	if err := raw.Unmarshal(&slice); err != nil {
+		return errgo.Mask(err)
+	}
+	if len(slice)%sha512.Size384 != 0 {
+		return errgo.Newf("length %d not a multiple of hash size", len(slice))
+	}
+	hashes := make([]string, len(slice)/sha512.Size384)
+	for i := range hashes {
+		hashes[i] = hex.EncodeToString(slice[i*sha512.Size384 : (i+1)*sha512.Size384])
+	}
+	*h = hashes
+	return nil
+}
+
+// GetBSON implements bson.Getter by marshaling
+// the hash slice to a contiguous byte slice.
+func (hs Hashes) GetBSON() (interface{}, error) {
+	slice := make([]byte, len(hs)*sha512.Size384)
+	for i, h := range hs {
+		if len(h) != sha512.Size384*2 {
+			return nil, errgo.Newf("invalid hash length of %q", h)
+		}
+		_, err := hex.Decode(slice[i*sha512.Size384:(i+1)*sha512.Size384], []byte(h))
+		if err != nil {
+			return nil, errgo.Notef(err, "invalid hash encoding %q", h)
+		}
+	}
+	return slice, nil
+}

--- a/internal/mongodoc/hash_test.go
+++ b/internal/mongodoc/hash_test.go
@@ -1,0 +1,104 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package mongodoc_test
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"fmt"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/mongodoc"
+)
+
+type HashSuite struct{}
+
+var _ = gc.Suite(&HashSuite{})
+
+var unmarshalTests = []struct {
+	from        []byte
+	expect      mongodoc.Hashes
+	expectError string
+}{{
+	from:   byteRep('a', sha512.Size384, 'b', sha512.Size384),
+	expect: mongodoc.Hashes{fakeHash('a'), fakeHash('b')},
+}, {
+	from:   []byte{},
+	expect: mongodoc.Hashes{},
+}, {
+	from:        byteRep('a', 5),
+	expectError: "length 5 not a multiple of hash size",
+}}
+
+func (*HashSuite) TestUnmarshal(c *gc.C) {
+	type byteRepr struct {
+		X []byte
+	}
+	for i, test := range unmarshalTests {
+		c.Logf("test %d", i)
+		data, err := bson.Marshal(&byteRepr{test.from})
+		c.Assert(err, gc.Equals, nil)
+		var x struct {
+			X mongodoc.Hashes
+		}
+		err = bson.Unmarshal(data, &x)
+		if test.expectError != "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+		} else {
+			c.Assert(err, gc.Equals, nil)
+			c.Assert(x.X, jc.DeepEquals, test.expect)
+			// Make sure it round trips OK.
+			data1, err := bson.Marshal(x)
+			c.Assert(err, gc.Equals, nil)
+			c.Assert(data1, jc.DeepEquals, data)
+		}
+	}
+}
+
+var marshalErrorTests = []struct {
+	from        mongodoc.Hashes
+	expectError string
+}{{
+	from:        mongodoc.Hashes{""},
+	expectError: `invalid hash length of ""`,
+}, {
+	from:        mongodoc.Hashes{"abc"},
+	expectError: `invalid hash length of "abc"`,
+}, {
+	from:        mongodoc.Hashes{"abcd"},
+	expectError: `invalid hash length of "abcd"`,
+}, {
+	from:        mongodoc.Hashes{"z68412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9"},
+	expectError: `invalid hash encoding "z684.*": encoding/hex: invalid byte: U\+007A 'z'`,
+}}
+
+func (*HashSuite) TestMarshalError(c *gc.C) {
+	for i, test := range marshalErrorTests {
+		c.Logf("test %d", i)
+		x := struct {
+			X mongodoc.Hashes
+		}{test.from}
+		_, err := bson.Marshal(x)
+		c.Assert(err, gc.ErrorMatches, test.expectError)
+	}
+}
+
+func fakeHash(b byte) string {
+	var r [sha512.Size384]byte
+	for i := range r {
+		r[i] = b
+	}
+	return fmt.Sprintf("%x", r[:])
+}
+
+func byteRep(n ...int) []byte {
+	var b []byte
+	for i := 0; i < len(n); i += 2 {
+		b = append(b, bytes.Repeat([]byte{byte(n[i])}, n[i+1])...)
+	}
+	return b
+}

--- a/internal/mongodoc/resource_test.go
+++ b/internal/mongodoc/resource_test.go
@@ -15,9 +15,7 @@ import (
 
 const fakeBlobHash = "0123456789abcdef0123456789abcdef0123456789abcdef"
 
-var (
-	_ = gc.Suite(&ResourceSuite{})
-)
+var _ = gc.Suite(&ResourceSuite{})
 
 type ResourceSuite struct{}
 


### PR DESCRIPTION
With the new blob storage scheme, we want to store
the hash of all parts within the mongodoc entities
(because we're not planning to keep refcounts separately)
so the multipart index needs to store the hashes too.

To save space, we store the hashes as a contiguous
byte array (this saves about 10 bytes per index entry)
but we use a Go representation that is more convenient.