### PR TITLE
internal/blobstore: remember multipart hashes in multipart index

### DIFF
--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -484,6 +484,10 @@ func (s *blobStoreSuite) TestFinishUploadSuccess(c *gc.C) {
 			uint32(len(content0)),
 			uint32(len(content1)),
 		},
+		Hashes: []string{
+			hashOf(content0),
+			hashOf(content1),
+		},
 	})
 }
 
@@ -502,6 +506,9 @@ func (s *blobStoreSuite) TestFinishUploadSuccessOnePart(c *gc.C) {
 	c.Assert(idx, jc.DeepEquals, &mongodoc.MultipartIndex{
 		Sizes: []uint32{
 			uint32(len(content0)),
+		},
+		Hashes: []string{
+			hashOf(content0),
 		},
 	})
 }
@@ -529,6 +536,9 @@ func (s *blobStoreSuite) TestFinishUploadAgain(c *gc.C) {
 		Sizes: []uint32{
 			uint32(len(content0)),
 		},
+		Hashes: []string{
+			hashOf(content0),
+		},
 	})
 
 	// We should get exactly the same thing if we call
@@ -541,6 +551,9 @@ func (s *blobStoreSuite) TestFinishUploadAgain(c *gc.C) {
 	c.Assert(idx, jc.DeepEquals, &mongodoc.MultipartIndex{
 		Sizes: []uint32{
 			uint32(len(content0)),
+		},
+		Hashes: []string{
+			hashOf(content0),
 		},
 	})
 }

--- a/internal/blobstore/multipart.go
+++ b/internal/blobstore/multipart.go
@@ -314,10 +314,12 @@ func (s *Store) FinishUpload(uploadId string, parts []Part) (idx *mongodoc.Multi
 		return nil, "", errgo.Mask(err)
 	}
 	idx = &mongodoc.MultipartIndex{
-		Sizes: make([]uint32, len(parts)),
+		Sizes:  make([]uint32, len(parts)),
+		Hashes: make(mongodoc.Hashes, len(parts)),
 	}
 	for i := range udoc.Parts {
 		idx.Sizes[i] = uint32(udoc.Parts[i].Size)
+		idx.Hashes[i] = udoc.Parts[i].Hash
 	}
 	return idx, hash, nil
 }

--- a/internal/mongodoc/resource.go
+++ b/internal/mongodoc/resource.go
@@ -47,7 +47,8 @@ type Resource struct {
 
 // MultipartIndex holds the index of all the parts of a multipart blob.
 type MultipartIndex struct {
-	Sizes []uint32
+	Sizes  []uint32
+	Hashes Hashes
 }
 
 // Validate ensures that the doc is valid.


### PR DESCRIPTION
Since we're moving to a hash-addressed scheme for blobs,
we'll need to remember the hashes of each part of a multipart
blob.

No migration necessary for this because the multipart support
hasn't been deployed in production yet.