### PR TITLE
internal/blobstore: implement garbage collection

### DIFF
--- a/internal/blobstore/mongodb.go
+++ b/internal/blobstore/mongodb.go
@@ -28,7 +28,7 @@ func (m *mongoBackend) Get(name string) (ReadSeekCloser, int64, error) {
 	f, err := m.fs.Open(name)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, 0, errgo.WithCausef(err, ErrNotFound, "")
+			return nil, 0, errgo.WithCausef(err, ErrNotFound, "backend blob not found")
 		}
 		return nil, 0, errgo.Mask(err)
 	}

--- a/internal/blobstore/multipart.go
+++ b/internal/blobstore/multipart.go
@@ -223,6 +223,25 @@ func (s *Store) checkPartSizes(parts []*PartInfo, part int, size int64) error {
 	return nil
 }
 
+// addUploadRefs adds to refs any hash references held
+// by the uploads collection.
+func (s *Store) addUploadRefs(refs *Refs) error {
+	var uploadDoc uploadDoc
+	iter := s.uploadc.Find(nil).Iter()
+	for iter.Next(&uploadDoc) {
+		refs.Add(uploadDoc.Hash)
+		for _, part := range uploadDoc.Parts {
+			if part != nil {
+				refs.Add(part.Hash)
+			}
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return errgo.Notef(err, "cannot iterate through uploads")
+	}
+	return nil
+}
+
 // UploadInfo returns information on a given upload. It returns
 // ErrNotFound if the upload has been deleted.
 func (s *Store) UploadInfo(uploadId string) (UploadInfo, error) {

--- a/internal/charmstore/addentity.go
+++ b/internal/charmstore/addentity.go
@@ -133,8 +133,8 @@ func (s *Store) UploadEntity(url *router.ResolvedURL, blob io.Reader, blobHash s
 	if err != nil {
 		return errgo.Mask(err)
 	}
-	m_upload := monitoring.NewUploadProcessingDuration()
-	defer m_upload.ObserveMetric()
+	uploadDuration := monitoring.NewUploadProcessingDuration()
+	defer uploadDuration.Done()
 	r, _, err := s.BlobStore.Open(blobHash, nil)
 	if err != nil {
 		return errgo.Notef(err, "cannot open newly created blob")

--- a/internal/charmstore/blobstoregc.go
+++ b/internal/charmstore/blobstoregc.go
@@ -8,6 +8,8 @@ import (
 
 	"gopkg.in/errgo.v1"
 	tomb "gopkg.in/tomb.v2"
+
+	"gopkg.in/juju/charmstore.v5-unstable/internal/monitoring"
 )
 
 var gcInterval = time.Hour
@@ -41,8 +43,12 @@ func (gc *blobstoreGC) Wait() error {
 
 func (gc *blobstoreGC) run() error {
 	for {
+		gcDuration := monitoring.NewBlobstoreGCDuration()
 		if err := gc.doGC(); err != nil {
+			// Note: don't log the duration when there's an error.
 			logger.Errorf("%v", err)
+		} else {
+			gcDuration.Done()
 		}
 		select {
 		case <-gc.tomb.Dying():

--- a/internal/monitoring/monitoring.go
+++ b/internal/monitoring/monitoring.go
@@ -14,16 +14,25 @@ var (
 		Name:      "request_duration",
 		Help:      "The duration of a web request in seconds.",
 	}, []string{"method", "root", "kind"})
+
 	uploadProcessingDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "charmstore",
 		Subsystem: "archive",
 		Name:      "processing_duration",
 		Help:      "The processing duration of a charm upload in seconds.",
 	})
+
+	blobstoreGCDuration = prometheus.NewSummary(prometheus.SummaryOpts{
+		Namespace: "charmstore",
+		Subsystem: "archive",
+		Name:      "blobstore_gc_duration",
+		Help:      "The processing duration a garbage collection in seconds",
+	})
 )
 
 func init() {
 	prometheus.MustRegister(requestDuration)
 	prometheus.MustRegister(uploadProcessingDuration)
+	prometheus.MustRegister(blobstoreGCDuration)
 	prometheus.MustRegister(monitoring.NewMgoStatsCollector("charmstore"))
 }

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -1316,6 +1316,10 @@ func hashOf(r io.Reader) (hashSum string, size int64) {
 	return fmt.Sprintf("%x", hash.Sum(nil)), n
 }
 
+func hashOfString(s string) string {
+	return hashOfBytes([]byte(s))
+}
+
 // assertCacheControl asserts that the cache control headers are
 // appropriately set. The isPublic parameter specifies
 // whether the id in the request represents a public charm or bundle.

--- a/internal/v4/list_test.go
+++ b/internal/v4/list_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/juju/idmclient"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
@@ -19,6 +20,7 @@ import (
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 	"gopkg.in/macaroon.v2-unstable"
+	"gopkg.in/mgo.v2/bson"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
@@ -259,52 +261,53 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 	}
 }
 
-// TODO reenable this when blobstore garbage collection is implemented.
-//func (s *ListSuite) TestListIncludeError(c *gc.C) {
-//	// Perform a list for all charms, including the
-//	// manifest, which will try to retrieve all charm
-//	// blobs.
-//	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-//		Handler: s.srv,
-//		URL:     storeURL("list?type=charm&include=manifest"),
-//	})
-//	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-//	var resp params.ListResponse
-//	err := json.Unmarshal(rec.Body.Bytes(), &resp)
-//	// cs:riak will not be found because it is not visible to
-//	// "everyone".
-//	c.Assert(resp.Results, gc.HasLen, len(exportListTestCharms)-1)
-//
-//	// Now remove one of the blobs. The list should still
-//	// work, but only return a single result.
-//	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
-//	c.Assert(err, gc.Equals, nil)
-//	err = s.store.BlobStore.Remove(entity.BlobName, nil)
-//	c.Assert(err, gc.Equals, nil)
-//
-//	// Now list again - we should get one result less
-//	// (and the error will be logged).
-//
-//	// Register a logger that so that we can check the logging output.
-//	// It will be automatically removed later because IsolatedMgoESSuite
-//	// uses LoggingSuite.
-//	var tw loggo.TestWriter
-//	err = loggo.RegisterWriter("test-log", &tw)
-//	c.Assert(err, gc.Equals, nil)
-//
-//	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
-//		Handler: s.srv,
-//		URL:     storeURL("list?type=charm&include=manifest"),
-//	})
-//	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-//	resp = params.ListResponse{}
-//	err = json.Unmarshal(rec.Body.Bytes(), &resp)
-//	// cs:riak will not be found because it is not visible to "everyone".
-//	// cs:wordpress will not be found because it has no manifest.
-//	c.Assert(resp.Results, gc.HasLen, len(exportListTestCharms)-2)
-//
-//	c.Assert(tw.Log(), jc.LogMatches, []string{"cannot retrieve metadata for cs:precise/wordpress-23: cannot open archive data for cs:precise/wordpress-23: .*"})
-//}
+func (s *ListSuite) TestListIncludeError(c *gc.C) {
+	// Perform a list for all charms, including the
+	// manifest, which will try to retrieve all charm
+	// blobs.
+	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL("list?type=charm&include=manifest"),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	var resp params.ListResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	// cs:riak will not be found because it is not visible to
+	// "everyone".
+	c.Assert(resp.Results, gc.HasLen, len(exportListTestCharms)-1)
+
+	// Now update the entity to hold an invalid hash.
+	// The list should still work, but only return a single result.
+	err = s.store.UpdateEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), bson.D{{
+		"$set", bson.D{{
+			"blobhash", hashOfString("nope"),
+		}},
+	}})
+	c.Assert(err, gc.Equals, nil)
+
+	// Now list again - we should get one result less
+	// (and the error will be logged).
+
+	// Register a logger that so that we can check the logging output.
+	// It will be automatically removed later because IsolatedMgoESSuite
+	// uses LoggingSuite.
+	var tw loggo.TestWriter
+	err = loggo.RegisterWriter("test-log", &tw)
+	c.Assert(err, gc.Equals, nil)
+
+	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL("list?type=charm&include=manifest"),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	resp = params.ListResponse{}
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	// cs:riak will not be found because it is not visible to "everyone".
+	// cs:wordpress will not be found because it has no manifest.
+	c.Assert(resp.Results, gc.HasLen, len(exportListTestCharms)-2)
+
+	c.Assert(tw.Log(), jc.LogMatches, []string{"cannot retrieve metadata for cs:precise/wordpress-23: cannot open archive data for cs:precise/wordpress-23: .*"})
+}
 
 func (s *ListSuite) TestSortingList(c *gc.C) {
 	tests := []struct {

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -9,11 +9,13 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
+	"gopkg.in/mgo.v2/bson"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
@@ -416,56 +418,56 @@ func (s *SearchSuite) TestSearchError(c *gc.C) {
 	c.Assert(resp.Message, gc.Matches, "error performing search: search failed: .*")
 }
 
-// TODO reenable this when blobstore garbage collection is implemented.
-//func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
-//	// Perform a search for all charms, including the
-//	// manifest, which will try to retrieve all charm
-//	// blobs.
-//	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-//		Handler: s.srv,
-//		URL:     storeURL("search?type=charm&include=manifest"),
-//	})
-//	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-//	var resp params.SearchResponse
-//	err := json.Unmarshal(rec.Body.Bytes(), &resp)
-//	// V4 SPECIFIC
-//	// cs:riak will not be found because it is not visible to "everyone".
-//	// cs:multi-series will be expanded to 4 different results.
-//	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)+3-1)
-//
-//	// Now remove one of the blobs. The list should still
-//	// work, but only return a single result.
-//	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
-//
-//	c.Assert(err, gc.Equals, nil)
-//	err = s.store.BlobStore.Remove(entity.BlobName, nil)
-//	c.Assert(err, gc.Equals, nil)
-//
-//	// Now search again - we should get one result less
-//	// (and the error will be logged).
-//
-//	// Register a logger that so that we can check the logging output.
-//	// It will be automatically removed later because IsolatedMgoESSuite
-//	// uses LoggingSuite.
-//	var tw loggo.TestWriter
-//	err = loggo.RegisterWriter("test-log", &tw)
-//	c.Assert(err, gc.Equals, nil)
-//
-//	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
-//		Handler: s.srv,
-//		URL:     storeURL("search?type=charm&include=manifest"),
-//	})
-//	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-//	resp = params.SearchResponse{}
-//	err = json.Unmarshal(rec.Body.Bytes(), &resp)
-//	// V4 SPECIFIC
-//	// cs:riak will not be found because it is not visible to "everyone".
-//	// cs:multi-series will be expanded to 4 different results.
-//	// cs:wordpress will not be found because it has no manifest.
-//	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)+3-2)
-//
-//	c.Assert(tw.Log(), jc.LogMatches, []string{"cannot retrieve metadata for cs:precise/wordpress-23: cannot open archive data for cs:precise/wordpress-23: .*"})
-//}
+func (s *SearchSuite) TestSearchIncludeError(c *gc.C) {
+	// Perform a search for all charms, including the
+	// manifest, which will try to retrieve all charm
+	// blobs.
+	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL("search?type=charm&include=manifest"),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	var resp params.SearchResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	// V4 SPECIFIC
+	// cs:riak will not be found because it is not visible to "everyone".
+	// cs:multi-series will be expanded to 4 different results.
+	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)+3-1)
+
+	// Now update the entity to hold an invalid hash.
+	// The list should still work, but only return a single result.
+	err = s.store.UpdateEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), bson.D{{
+		"$set", bson.D{{
+			"blobhash", hashOfString("nope"),
+		}},
+	}})
+	c.Assert(err, gc.Equals, nil)
+
+	// Now search again - we should get one result less
+	// (and the error will be logged).
+
+	// Register a logger that so that we can check the logging output.
+	// It will be automatically removed later because IsolatedMgoESSuite
+	// uses LoggingSuite.
+	var tw loggo.TestWriter
+	err = loggo.RegisterWriter("test-log", &tw)
+	c.Assert(err, gc.Equals, nil)
+
+	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL("search?type=charm&include=manifest"),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	resp = params.SearchResponse{}
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	// V4 SPECIFIC
+	// cs:riak will not be found because it is not visible to "everyone".
+	// cs:multi-series will be expanded to 4 different results.
+	// cs:wordpress will not be found because it has no manifest.
+	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)+3-2)
+
+	c.Assert(tw.Log(), jc.LogMatches, []string{"cannot retrieve metadata for cs:precise/wordpress-23: cannot open archive data for cs:precise/wordpress-23: .*"})
+}
 
 func (s *SearchSuite) TestSorting(c *gc.C) {
 	tests := []struct {

--- a/internal/v5/list_test.go
+++ b/internal/v5/list_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/juju/idmclient"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
@@ -19,6 +20,7 @@ import (
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 	"gopkg.in/macaroon.v2-unstable"
+	"gopkg.in/mgo.v2/bson"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 	"gopkg.in/juju/charmstore.v5-unstable/internal/storetesting"
@@ -254,51 +256,52 @@ func (s *ListSuite) TestMetadataFields(c *gc.C) {
 	}
 }
 
-// TODO reenable this when blobstore garbage collection is implemented.
-//func (s *ListSuite) TestListIncludeError(c *gc.C) {
-//	// Perform a list for all charms, including the
-//	// manifest, which will try to retrieve all charm
-//	// blobs.
-//	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-//		Handler: s.srv,
-//		URL:     storeURL("list?type=charm&include=manifest"),
-//	})
-//	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-//	var resp params.ListResponse
-//	err := json.Unmarshal(rec.Body.Bytes(), &resp)
-//	// cs:riak will not be found because it is not visible to "everyone".
-//	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)-1)
-//
-//	// Now remove one of the blobs. The list should still
-//	// work, but only return a single result.
-//	entity, err := s.store.FindEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), nil)
-//	c.Assert(err, gc.Equals, nil)
-//	err = s.store.BlobStore.Remove(entity.BlobName, nil)
-//	c.Assert(err, gc.Equals, nil)
-//
-//	// Now list again - we should get one result less
-//	// (and the error will be logged).
-//
-//	// Register a logger that so that we can check the logging output.
-//	// It will be automatically removed later because IsolatedMgoESSuite
-//	// uses LoggingSuite.
-//	var tw loggo.TestWriter
-//	err = loggo.RegisterWriter("test-log", &tw)
-//	c.Assert(err, gc.Equals, nil)
-//
-//	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
-//		Handler: s.srv,
-//		URL:     storeURL("list?type=charm&include=manifest"),
-//	})
-//	c.Assert(rec.Code, gc.Equals, http.StatusOK)
-//	resp = params.ListResponse{}
-//	err = json.Unmarshal(rec.Body.Bytes(), &resp)
-//	// cs:riak will not be found because it is not visible to "everyone".
-//	// cs:wordpress will not be found because it has no manifest.
-//	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)-2)
-//
-//	c.Assert(tw.Log(), jc.LogMatches, []string{"cannot retrieve metadata for cs:precise/wordpress-23: cannot open archive data for cs:precise/wordpress-23: .*"})
-//}
+func (s *ListSuite) TestListIncludeError(c *gc.C) {
+	// Perform a list for all charms, including the
+	// manifest, which will try to retrieve all charm
+	// blobs.
+	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL("list?type=charm&include=manifest"),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	var resp params.ListResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	// cs:riak will not be found because it is not visible to "everyone".
+	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)-1)
+
+	// Now update the entity to hold an invalid hash.
+	// The list should still work, but only return a single result.
+	err = s.store.UpdateEntity(newResolvedURL("~charmers/precise/wordpress-23", 23), bson.D{{
+		"$set", bson.D{{
+			"blobhash", hashOfString("nope"),
+		}},
+	}})
+	c.Assert(err, gc.Equals, nil)
+
+	// Now list again - we should get one result less
+	// (and the error will be logged).
+
+	// Register a logger that so that we can check the logging output.
+	// It will be automatically removed later because IsolatedMgoESSuite
+	// uses LoggingSuite.
+	var tw loggo.TestWriter
+	err = loggo.RegisterWriter("test-log", &tw)
+	c.Assert(err, gc.Equals, nil)
+
+	rec = httptesting.DoRequest(c, httptesting.DoRequestParams{
+		Handler: s.srv,
+		URL:     storeURL("list?type=charm&include=manifest"),
+	})
+	c.Assert(rec.Code, gc.Equals, http.StatusOK)
+	resp = params.ListResponse{}
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	// cs:riak will not be found because it is not visible to "everyone".
+	// cs:wordpress will not be found because it has no manifest.
+	c.Assert(resp.Results, gc.HasLen, len(exportTestCharms)-2)
+
+	c.Assert(tw.Log(), jc.LogMatches, []string{"cannot retrieve metadata for cs:precise/wordpress-23: cannot open archive data for cs:precise/wordpress-23: .*"})
+}
 
 func (s *ListSuite) TestSortingList(c *gc.C) {
 	tests := []struct {


### PR DESCRIPTION
After some experimentation, it seems that holding
all the hashes in memory is a reasonable approach.
Currently there are ~45000 blobs in the store, giving
a projected memory usage of ~2.5MB for a GC.
This implementation should scale reasonably up
to 1 million blobs (20x current usage) and to 10 million
with minor changes. Beyond that, we may need to
use a different algorithm, but that should be OK
to do without changing the database.