### PR TITLE
internal/blobstore: restrict Swift required services

### DIFF
--- a/internal/blobstore/swift.go
+++ b/internal/blobstore/swift.go
@@ -29,6 +29,7 @@ func NewSwiftBackend(cred *identity.Credentials, authmode identity.AuthMode, con
 		authmode,
 		gooseLogger{},
 	)
+	c.SetRequiredServiceTypes([]string{"object-store"})
 	return &swiftBackend{
 		client:    swift.New(c),
 		container: container,

--- a/internal/charmstore/blobstoregc.go
+++ b/internal/charmstore/blobstoregc.go
@@ -44,10 +44,12 @@ func (gc *blobstoreGC) Wait() error {
 func (gc *blobstoreGC) run() error {
 	for {
 		gcDuration := monitoring.NewBlobstoreGCDuration()
+		logger.Infof("starting blobstore garbage collection")
 		if err := gc.doGC(); err != nil {
 			// Note: don't log the duration when there's an error.
 			logger.Errorf("%v", err)
 		} else {
+			logger.Infof("completed blobstore garbage collection")
 			gcDuration.Done()
 		}
 		select {


### PR DESCRIPTION
When talking to some Swift services, only the object
store is available and the client will fail in that case
unless SetRequiredServiceTypes is called, so do that.

Also log a message when garbage collection starts and finishes.