### PR TITLE
internal/charmstore: report blob stats

### DIFF
--- a/internal/charmstore/migrations.go
+++ b/internal/charmstore/migrations.go
@@ -226,6 +226,8 @@ type blobRefDoc struct {
 	// PutTime stores the last time a new reference
 	// was made to the blob with Put.
 	PutTime time.Time
+	// Size holds the size of the blob.
+	Size int64 `bson:"size"`
 }
 
 // legacyBlobstoreResourceDoc is the persistent representation of a Resource.
@@ -354,6 +356,7 @@ func createBlobRefsCollection(db StoreDatabase) error {
 			Hash:    doc.SHA384Hash,
 			Name:    doc.Path,
 			PutTime: time.Now(),
+			Size:    doc.Length,
 		})
 		if n++; n < 100 {
 			continue

--- a/internal/monitoring/monitoring.go
+++ b/internal/monitoring/monitoring.go
@@ -28,11 +28,53 @@ var (
 		Name:      "blobstore_gc_duration",
 		Help:      "The processing duration a garbage collection in seconds",
 	})
+
+	blobCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "charmstore",
+		Subsystem: "archive",
+		Name:      "blob_count",
+		Help:      "The total number of stored blobs.",
+	})
+
+	maxBlobSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "charmstore",
+		Subsystem: "archive",
+		Name:      "max_blob_size",
+		Help:      "The maximum stored blob size",
+	})
+
+	meanBlobSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "charmstore",
+		Subsystem: "archive",
+		Name:      "mean_blob_size",
+		Help:      "The mean stored blob size",
+	})
 )
+
+// BlobStats holds statistics about blobs in the blob store.
+type BlobStats struct {
+	// Count holds the total number of blobs stored.
+	Count int
+	// MaxSize holds the size of the largest blob.
+	MaxSize int64
+	// MeanSize holds the average blob size.
+	MeanSize int64
+	// TODO add counts/sizes for different
+	// kinds of blob?
+}
+
+func SetBlobStoreStats(s BlobStats) {
+	blobCount.Set(float64(s.Count))
+	maxBlobSize.Set(float64(s.MaxSize))
+	meanBlobSize.Set(float64(s.MeanSize))
+}
 
 func init() {
 	prometheus.MustRegister(requestDuration)
 	prometheus.MustRegister(uploadProcessingDuration)
 	prometheus.MustRegister(blobstoreGCDuration)
+	prometheus.MustRegister(blobCount)
+	prometheus.MustRegister(maxBlobSize)
+	prometheus.MustRegister(meanBlobSize)
 	prometheus.MustRegister(monitoring.NewMgoStatsCollector("charmstore"))
 }


### PR DESCRIPTION
We add a size field to the blobref collection so
that we can easily find the sizes when garbage
collecting. We leave reporting on entity/resource
blob sizes for another day.