### PR TITLE
Bump juju/utils dependency w/ fixes.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -33,6 +33,7 @@ golang.org/x/sys	git	7a6e5648d140666db5d920909e082ca00a87ba2c	2017-02-01T05:12:4
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z
 gopkg.in/goose.v2	git	455416024500800de8dadbcacfa22681b6bb818d	2017-09-04T09:17:38Z
+gopkg.in/httprequest.v1	git	35158f716c228fdf58b5a5b80cf331302d10160a	2017-11-03T09:19:05Z
 gopkg.in/juju/charm.v6-unstable	git	25231c01229677e02c5ea0e0ef1c89ee14a200ad	2017-02-22T13:11:15Z
 gopkg.in/juju/charmrepo.v2-unstable	git	2426290a14b0cfaddf38e4cc0dcecdf866e300eb	2017-03-10T20:02:09Z
 gopkg.in/juju/jujusvg.v2	git	d82160011935ef79fc7aca84aba2c6f74700fe75	2016-06-09T10:52:15Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -15,7 +15,7 @@ github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/schema	git	1e25943f8c6fd6815282d6f1ac87091d21e14e19	2016-03-01T11:16:46Z
 github.com/juju/testing	git	b8689951f6db31943dd8c3d540b8c4dd368cf850	2016-10-31T10:37:13Z
-github.com/juju/utils	git	9b65c33e54c793d74a4ed99c15111c44faddb8e4	2017-10-25T16:38:56Z
+github.com/juju/utils	git	1d3aa4661175bbdb5ded53d2b86b6106bbdc0a4f	2018-02-07T01:23:44Z
 github.com/juju/version	git	ef897ad7f130870348ce306f61332f5335355063	2015-11-27T20:34:00Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/juju/xml	git	eb759a627588d35166bc505fceb51b88500e291e	2015-04-13T13:11:21Z

--- a/internal/legacy/api.go
+++ b/internal/legacy/api.go
@@ -73,6 +73,7 @@ import (
 	"time"
 
 	"github.com/juju/mempool"
+	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable"
@@ -117,7 +118,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	req.ParseForm()
 	rh, err := h.newReqHandler()
 	if err != nil {
-		router.WriteError(w, err)
+		router.WriteError(context.TODO(), w, err)
 		return
 	}
 	defer rh.close()

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -15,9 +15,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/juju/httprequest"
 	"github.com/juju/utils/parallel"
+	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/httprequest.v1"
 	charm "gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
@@ -303,7 +304,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if err := req.ParseForm(); err != nil {
-		WriteError(w, errgo.Notef(err, "cannot parse form"))
+		WriteError(context.TODO(), w, errgo.Notef(err, "cannot parse form"))
 		return
 	}
 	r.handler.ServeHTTP(w, req)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -18,6 +18,7 @@ import (
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
+	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
@@ -2178,7 +2179,7 @@ func (s *RouterSuite) TestWriteJSON(c *gc.C) {
 
 func (s *RouterSuite) TestWriteError(c *gc.C) {
 	rec := httptest.NewRecorder()
-	WriteError(rec, errgo.Newf("an error"))
+	WriteError(context.TODO(), rec, errgo.Newf("an error"))
 	var errResp params.Error
 	err := json.Unmarshal(rec.Body.Bytes(), &errResp)
 	c.Assert(err, gc.Equals, nil)
@@ -2190,7 +2191,7 @@ func (s *RouterSuite) TestWriteError(c *gc.C) {
 		Message: "a message",
 		Code:    "some code",
 	}
-	WriteError(rec, &errResp0)
+	WriteError(context.TODO(), rec, &errResp0)
 	var errResp1 params.Error
 	err = json.Unmarshal(rec.Body.Bytes(), &errResp1)
 	c.Assert(err, gc.Equals, nil)

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -15,12 +15,12 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/juju/httprequest"
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/testing/httptesting"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/httprequest.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -8,10 +8,11 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/juju/httprequest"
 	"github.com/juju/loggo"
 	"github.com/juju/mempool"
+	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/httprequest.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2"
@@ -56,7 +57,7 @@ func New(pool *charmstore.Pool, config charmstore.ServerParams, rootPath string)
 func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	rh, err := h.NewReqHandler(req)
 	if err != nil {
-		router.WriteError(w, err)
+		router.WriteError(context.TODO(), w, err)
 		return
 	}
 	defer rh.Close()

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -15,11 +15,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/httprequest"
 	"github.com/juju/idmclient"
 	"github.com/juju/loggo"
 	"github.com/juju/mempool"
+	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/httprequest.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
@@ -322,7 +323,7 @@ func newReqHandler() *ReqHandler {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	rh, err := h.NewReqHandler(req)
 	if err != nil {
-		router.WriteError(w, err)
+		router.WriteError(context.TODO(), w, err)
 		return
 	}
 	defer rh.Close()
@@ -577,7 +578,7 @@ var errNotImplemented = errgo.Newf("method not implemented")
 // GET /debug
 // https://github.com/juju/charmstore/blob/v5-unstable/docs/API.md#get-debug
 func (h *ReqHandler) serveDebug(w http.ResponseWriter, req *http.Request) {
-	router.WriteError(w, errNotImplemented)
+	router.WriteError(context.TODO(), w, errNotImplemented)
 }
 
 // GET id/expand-id

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -3121,7 +3121,7 @@ var publishErrorsTests = []struct {
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: `cannot unmarshal publish request body: cannot unmarshal into field: unexpected content type text/invalid; want application/json; content: "{\"Channels\":[\"edge\"]}"`,
+		Message: `cannot unmarshal publish request body: cannot unmarshal into field PublishRequest: unexpected content type text/invalid; want application/json; content: "{\"Channels\":[\"edge\"]}"`,
 	},
 }, {
 	about:        "invalid body",
@@ -3131,7 +3131,7 @@ var publishErrorsTests = []struct {
 	expectStatus: http.StatusBadRequest,
 	expectBody: params.Error{
 		Code:    params.ErrBadRequest,
-		Message: "cannot unmarshal publish request body: cannot unmarshal into field: cannot unmarshal request body: invalid character 'b' looking for beginning of value",
+		Message: "cannot unmarshal publish request body: cannot unmarshal into field PublishRequest: cannot unmarshal request body: invalid character 'b' looking for beginning of value",
 	},
 }, {
 	about:        "entity to be published not found",

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -14,8 +14,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/juju/httprequest"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/httprequest.v1"
 	"gopkg.in/juju/charm.v6-unstable"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 	"gopkg.in/mgo.v2/bson"

--- a/internal/v5/pprof.go
+++ b/internal/v5/pprof.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	"github.com/juju/httpprof"
+	"golang.org/x/net/context"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/router"
 )
@@ -34,7 +35,7 @@ func newPprofHandler(auth adminAuthenticator) http.Handler {
 
 func (h *pprofHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if err := h.auth.authenticateAdmin(req); err != nil {
-		router.WriteError(w, err)
+		router.WriteError(context.TODO(), w, err)
 		return
 	}
 	h.mux.ServeHTTP(w, req)

--- a/internal/v5/resources.go
+++ b/internal/v5/resources.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/httprequest"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/httprequest.v1"
 	"gopkg.in/juju/charm.v6-unstable/resource"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 

--- a/internal/v5/search.go
+++ b/internal/v5/search.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/juju/utils/parallel"
+	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
@@ -104,7 +105,7 @@ func (h *ReqHandler) addMetaData(results []*mongodoc.Entity, include []string, r
 // GET search/interesting[?limit=limit][&include=meta]
 // https://github.com/juju/charmstore/blob/v4/docs/API.md#get-searchinteresting
 func (h *ReqHandler) serveSearchInteresting(w http.ResponseWriter, req *http.Request) {
-	router.WriteError(w, errNotImplemented)
+	router.WriteError(context.TODO(), w, errNotImplemented)
 }
 
 // ParseSearchParms extracts the search paramaters from the request

--- a/internal/v5/status.go
+++ b/internal/v5/status.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/juju/utils/debugstatus"
+	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/mgo.v2/bson"
 
@@ -22,6 +23,7 @@ import (
 func (h *ReqHandler) serveDebugStatus(_ http.Header, req *http.Request) (interface{}, error) {
 	h.Store.SetReconnectTimeout(500 * time.Millisecond)
 	return debugstatus.Check(
+		context.TODO(),
 		debugstatus.ServerStartTime,
 		debugstatus.Connection(h.Store.DB.Session),
 		debugstatus.MongoCollections(h.Store.DB),
@@ -31,7 +33,7 @@ func (h *ReqHandler) serveDebugStatus(_ http.Header, req *http.Request) (interfa
 	), nil
 }
 
-func (h *ReqHandler) checkElasticSearch() (key string, result debugstatus.CheckResult) {
+func (h *ReqHandler) checkElasticSearch(context.Context) (key string, result debugstatus.CheckResult) {
 	key = "elasticsearch"
 	result.Name = "Elastic search is running"
 	if h.Store.ES == nil || h.Store.ES.Database == nil {
@@ -49,7 +51,7 @@ func (h *ReqHandler) checkElasticSearch() (key string, result debugstatus.CheckR
 	return key, result
 }
 
-func (h *ReqHandler) checkEntities() (key string, result debugstatus.CheckResult) {
+func (h *ReqHandler) checkEntities(context.Context) (key string, result debugstatus.CheckResult) {
 	result.Name = "Entities in charm store"
 	charms, err := h.Store.DB.Entities().Find(bson.D{{"series", bson.D{{"$ne", "bundle"}}}}).Count()
 	if err != nil {
@@ -71,7 +73,7 @@ func (h *ReqHandler) checkEntities() (key string, result debugstatus.CheckResult
 	return "entities", result
 }
 
-func (h *ReqHandler) checkBaseEntities() (key string, result debugstatus.CheckResult) {
+func (h *ReqHandler) checkBaseEntities(context.Context) (key string, result debugstatus.CheckResult) {
 	resultKey := "base_entities"
 	result.Name = "Base entities in charm store"
 

--- a/internal/v5/upload.go
+++ b/internal/v5/upload.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/httprequest"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/httprequest.v1"
 	"gopkg.in/juju/charmrepo.v2-unstable/csclient/params"
 
 	"gopkg.in/juju/charmstore.v5-unstable/internal/blobstore"


### PR DESCRIPTION
Bumped juju/utils version in juju/juju which broke charmstore.v5-unstable due to API changes.

Update charmstore.v5-unstable in regards to those API changes (as well as bump the juju/utils version to match too).