### PR TITLE
internal/v5: fix panic on partial resource part upload

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2511,8 +2511,7 @@ type UploadInfoResponse struct {
 	UploadId string
 
 	// Parts holds all the known parts of the upload.
-	// Parts that haven't been uploaded yet will have nil
-	// elements.
+	// Parts that haven't been uploaded yet will have all fields zero (not present).
 	Parts Parts
 
     // Expires holds when the upload id expires (encoded

--- a/internal/v5/upload.go
+++ b/internal/v5/upload.go
@@ -157,13 +157,14 @@ func (h *ReqHandler) serveUploadPart(w http.ResponseWriter, req *http.Request) e
 		var parts params.Parts
 		parts.Parts = make([]params.Part, len(uploadInfo.Parts))
 		for i, part := range uploadInfo.Parts {
-			parts.Parts[i] = params.Part{
-				Offset:   part.Offset,
-				Complete: part.Complete,
-				Hash:     part.Hash,
-				Size:     part.Size,
+			if part != nil {
+				parts.Parts[i] = params.Part{
+					Offset:   part.Offset,
+					Complete: part.Complete,
+					Hash:     part.Hash,
+					Size:     part.Size,
+				}
 			}
-
 		}
 		return httprequest.WriteJSON(w, http.StatusOK, params.UploadInfoResponse{
 			UploadId:    uploadId,


### PR DESCRIPTION
Clients are not required to upload parts sequentially.
If they did not, and then resumed an upload, a part could
be nil, which would result in a panic.