### PR TITLE
internal/dockerauth: Create JWT auth tokens for docker-registry

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,6 +1,7 @@
 github.com/ajstarks/svgo	git	89e3ac64b5b3e403a5e7c35ea4f98d45db7b4518	2014-10-04T21:11:59Z
 github.com/beorn7/perks	git	4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9	2016-08-04T10:47:26Z
 github.com/cloud-green/monitoring	git	666e3beca3cb4f6b5c8f176ba80daf2b3adbd84e	2017-11-27T13:22:20Z
+github.com/dgrijalva/jwt-go	git	01aeca54ebda6e0fbfafd0a524d234159c05ec20	2016-07-05T20:30:06Z
 github.com/golang/protobuf	git	925541529c1fa6821df4e44ce2723319eb2be768	2018-01-25T21:43:03Z
 github.com/gorilla/handlers	git	13d73096a474cac93275c679c7b8a2dc17ddba82	2017-02-24T19:39:55Z
 github.com/juju/errors	git	c7d06af17c68cd34c835053720b21f6549d9b0ee	2017-07-03T01:00:42Z
@@ -10,7 +11,7 @@ github.com/juju/gojsonschema	git	e1ad140384f254c82f89450d9a7c8dd38a632838	2015-0
 github.com/juju/httpprof	git	14bf14c307672fd2456bdbf35d19cf0ccd3cf565	2014-12-17T16:00:36Z
 github.com/juju/httprequest	git	266fd1e9debf09c037a63f074d099a2da4559ece	2016-10-06T15:09:09Z
 github.com/juju/idmclient	git	fb1dc7175251ac8e2dc460897313e05175cbbc0d	2016-11-07T14:02:50Z
-github.com/juju/loggo	git	8232ab8918d91c72af1a9fb94d3edbe31d88b790	2017-06-05T01:46:07Z
+github.com/juju/loggo	git	584905176618da46b895b176c721b02c476b6993	2018-05-24T02:20:52Z
 github.com/juju/mempool	git	24974d6c264fe5a29716e7d56ea24c4bd904b7cc	2016-02-05T10:49:27Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
@@ -27,7 +28,7 @@ github.com/prometheus/client_model	git	99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c	
 github.com/prometheus/common	git	6fb6fce6f8b75884b92e1889c150403fc0872c5e	2018-02-28T09:25:48Z
 github.com/prometheus/procfs	git	d274e363d5759d1c916232217be421f1cc89c5fe	2018-02-28T15:07:32Z
 github.com/rogpeppe/fastuuid	git	6724a57986aff9bff1a1770e9347036def7c89f6	2015-01-06T09:32:20Z
-golang.org/x/crypto	git	91a49db82a88618983a78a06c1cbd4e00ab749ab	2018-02-28T16:13:26Z
+golang.org/x/crypto	git	159ae71589f303f9fbfd7528413e0fe944b9c1cb	2018-05-24T12:53:53Z
 golang.org/x/net	git	d25186b37f34ebdbbea8f488ef055638dfab272d	2018-03-06T06:01:52Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	442357a80af5c6bf9b6d51ae791a39c3421004f3	2016-12-22T12:58:16Z

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -7,6 +7,7 @@
 package charmstore // import "gopkg.in/juju/charmstore.v5/internal/charmstore"
 
 import (
+	"crypto/rsa"
 	"net/http"
 	"strings"
 	"time"
@@ -109,6 +110,10 @@ type ServerParams struct {
 	// that may use the given MongoDB database.
 	// If this is nil, a MongoDB backend will be used.
 	NewBlobBackend func(db *mgo.Database) blobstore.Backend
+
+	// DockerRegistryAuthorizerKey contains the key to use to sign
+	// docker registry authorization tokens.
+	DockerRegistryAuthorizerKey *rsa.PrivateKey
 }
 
 const defaultRootKeyExpiryDuration = 24 * time.Hour

--- a/internal/dockerauth/export_test.go
+++ b/internal/dockerauth/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dockerauth
+
+type TokenResponse tokenResponse

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@
 package charmstore // import "gopkg.in/juju/charmstore.v5"
 
 import (
+	"crypto/rsa"
 	"fmt"
 	"net/http"
 	"sort"
@@ -125,6 +126,10 @@ type ServerParams struct {
 	// that may use the given MongoDB database.
 	// If this is nil, a MongoDB backend will be used.
 	NewBlobBackend func(db *mgo.Database) blobstore.Backend
+
+	// DockerRegistryAuthorizerKey contains the key to use to sign
+	// docker registry authorization tokens.
+	DockerRegistryAuthorizerKey *rsa.PrivateKey
 }
 
 // NewServer returns a new handler that handles charm store requests and stores


### PR DESCRIPTION
Initial implementation of docker-registry token creation. Currently
this makes no attempt to determine if the requesting user is actually
authorized.