### PR TITLE
internal/v5: resource upload requires pull as well as push

### DIFF
--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -114,6 +114,7 @@ func serve(conf *config.Config) error {
 		MaxUploadPartSize:              conf.MaxUploadPartSize,
 		MaxUploadParts:                 conf.MaxUploadParts,
 		RunBlobStoreGC:                 true,
+		DockerRegistryAddress:          conf.DockerRegistryAddress,
 		DockerRegistryAuthCertificates: conf.DockerRegistryAuthCertificates.Certificates,
 		DockerRegistryAuthKey:          conf.DockerRegistryAuthKey.Key,
 	}
@@ -149,7 +150,10 @@ func serve(conf *config.Config) error {
 		charmstore.V5,
 	}
 	if conf.DockerRegistryAuthKey.Key != nil {
+		logger.Infof("serving docker auth API")
 		vers = append(vers, charmstore.DockerAuth)
+	} else {
+		logger.Infof("no docker key: skipping docker auth API")
 	}
 	server, err := charmstore.NewServer(db, es, "cs", cfg, vers...)
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -129,19 +129,19 @@ func (s *ConfigSuite) TestRead(c *gc.C) {
 				mustParseKey("lsvcDkapKoFxIyjX9/eQgb3s41KVwPMISFwAJdVCZ70="),
 			},
 		},
-		StatsCacheMaxAge:  config.DurationString{time.Hour},
-		RequestTimeout:    config.DurationString{500 * time.Millisecond},
-		MaxMgoSessions:    10,
-		SearchCacheMaxAge: config.DurationString{15 * time.Minute},
-		BlobStore:         config.SwiftBlobStore,
-		SwiftAuthURL:      "https://foo.com",
-		SwiftUsername:     "bob",
-		SwiftSecret:       "secret",
-		SwiftBucket:       "bucket",
-		SwiftRegion:       "somewhere",
-		SwiftTenant:       "a-tenant",
-		SwiftAuthMode:     &config.SwiftAuthMode{identity.AuthUserPass},
-		LoggingConfig:     "INFO",
+		StatsCacheMaxAge:      config.DurationString{time.Hour},
+		RequestTimeout:        config.DurationString{500 * time.Millisecond},
+		MaxMgoSessions:        10,
+		SearchCacheMaxAge:     config.DurationString{15 * time.Minute},
+		BlobStore:             config.SwiftBlobStore,
+		SwiftAuthURL:          "https://foo.com",
+		SwiftUsername:         "bob",
+		SwiftSecret:           "secret",
+		SwiftBucket:           "bucket",
+		SwiftRegion:           "somewhere",
+		SwiftTenant:           "a-tenant",
+		SwiftAuthMode:         &config.SwiftAuthMode{identity.AuthUserPass},
+		LoggingConfig:         "INFO",
 		DockerRegistryAddress: "0.1.3.5:1000",
 		DockerRegistryAuthCertificates: config.X509Certificates{
 			Certificates: []*x509.Certificate{
@@ -159,6 +159,113 @@ func (s *ConfigSuite) TestReadConfigError(c *gc.C) {
 	cfg, err := config.Read(path.Join(c.MkDir(), "charmd.conf"))
 	c.Assert(err, gc.ErrorMatches, ".* no such file or directory")
 	c.Assert(cfg, gc.IsNil)
+}
+
+func (s *ConfigSuite) TestReadConfigWithNonEmptyCertsWithNoCerts(c *gc.C) {
+	configText := `
+audit-log-file: /var/log/charmstore/audit.log
+audit-log-max-size: 500
+audit-log-max-age: 1
+mongo-url: localhost:23456
+api-addr: blah:2324
+foo: 1
+bar: false
+auth-username: myuser
+auth-password: mypasswd
+identity-location: localhost:18082
+identity-public-key: +qNbDWly3kRTDVv2UN03hrv/CBt4W6nxY5dHdw+KJFA=
+identity-api-url: "http://example.com/identity"
+terms-public-key: +qNbDWly3kRTDVv2UN03hrv/CBt4W6nxY5dHdw+KJFB=
+terms-location: localhost:8092
+agent-username: agentuser
+agent-key:
+  private: lsvcDkapKoFxIyjX9/eQgb3s41KVwPMISFwAJdVCZ70=
+  public: +qNbDWly3kRTDVv2UN03hrv/CBt4W6nxY5dHdw+KJFA=
+stats-cache-max-age: 1h
+search-cache-max-age: 15m
+request-timeout: 500ms
+max-mgo-sessions: 10
+blobstore: swift
+swift-auth-url: 'https://foo.com'
+swift-username: bob
+swift-secret: secret
+swift-bucket: bucket
+swift-region: somewhere
+swift-tenant: a-tenant
+swift-authmode: userpass
+logging-config: INFO
+docker-registry-address: 0.1.3.5:1000
+docker-registry-auth-certs: some text
+docker-registry-auth-key: |
+  -----BEGIN EC PRIVATE KEY-----
+  MGgCAQEEHM9ekg7h0LAhNBaiSJolcfDNtyfS94DyUblrFu+gBwYFK4EEACGhPAM6
+  AARlWtA/iSeUYFDZw4yxiaBzRURa7wOY4WUVryz/KbzKIG+wJ9rv+39XndXN6kue
+  9NhvqPQt4xyddg==
+  -----END EC PRIVATE KEY-----
+`
+
+	_, err := s.readConfig(c, configText)
+	c.Assert(err, gc.ErrorMatches, `cannot parse .*: no certificates found`)
+}
+
+func (s *ConfigSuite) TestReadConfigWithNonEmptyKeyWithNoKey(c *gc.C) {
+	configText := `
+audit-log-file: /var/log/charmstore/audit.log
+audit-log-max-size: 500
+audit-log-max-age: 1
+mongo-url: localhost:23456
+api-addr: blah:2324
+foo: 1
+bar: false
+auth-username: myuser
+auth-password: mypasswd
+identity-location: localhost:18082
+identity-public-key: +qNbDWly3kRTDVv2UN03hrv/CBt4W6nxY5dHdw+KJFA=
+identity-api-url: "http://example.com/identity"
+terms-public-key: +qNbDWly3kRTDVv2UN03hrv/CBt4W6nxY5dHdw+KJFB=
+terms-location: localhost:8092
+agent-username: agentuser
+agent-key:
+  private: lsvcDkapKoFxIyjX9/eQgb3s41KVwPMISFwAJdVCZ70=
+  public: +qNbDWly3kRTDVv2UN03hrv/CBt4W6nxY5dHdw+KJFA=
+stats-cache-max-age: 1h
+search-cache-max-age: 15m
+request-timeout: 500ms
+max-mgo-sessions: 10
+blobstore: swift
+swift-auth-url: 'https://foo.com'
+swift-username: bob
+swift-secret: secret
+swift-bucket: bucket
+swift-region: somewhere
+swift-tenant: a-tenant
+swift-authmode: userpass
+logging-config: INFO
+docker-registry-address: 0.1.3.5:1000
+docker-registry-auth-certs: |
+  -----BEGIN CERTIFICATE-----
+  MIIBSDCB+KADAgECAgEBMAoGCCqGSM49BAMCMA8xDTALBgNVBAMTBHJvb3QwHhcN
+  MTgwNTMwMDYxNzQ1WhcNMjMwNTMwMDYxNzQ1WjAPMQ0wCwYDVQQDEwR0ZXN0ME4w
+  EAYHKoZIzj0CAQYFK4EEACEDOgAEZVrQP4knlGBQ2cOMsYmgc0VEWu8DmOFlFa8s
+  /ym8yiBvsCfa7/t/V53VzepLnvTYb6j0LeMcnXajUDBOMAwGA1UdEwEB/wQCMAAw
+  HQYDVR0OBBYEFG1euQX6O6FbNV4lTu0CYAnFCpc8MB8GA1UdIwQYMBaAFNopWnFZ
+  iUBhd2W9d8NKbkRf8gujMAoGCCqGSM49BAMCAz8AMDwCHEPZ9X8JQRe5KBAMUTfo
+  wngH3J2yXb1nQXzLR4cCHEbutF5CmWNzWzcek2JfQMOl7aFjcBxAerJGgRU=
+  -----END CERTIFICATE-----
+  -----BEGIN CERTIFICATE-----
+  MIIBKzCB2qADAgECAgEAMAoGCCqGSM49BAMCMA8xDTALBgNVBAMTBHJvb3QwHhcN
+  MTgwNTMwMDYxNDQyWhcNMjgwNTI5MDYxNDQyWjAPMQ0wCwYDVQQDEwRyb290ME4w
+  EAYHKoZIzj0CAQYFK4EEACEDOgAEp5HUPVxs3wdpFF/HrimbFPVWkG+v6RacjFyP
+  ujEylCfsONDOvYFzzz3x6/kxpQBl0ZYCHSJSDzKjMjAwMA8GA1UdEwEB/wQFMAMB
+  Af8wHQYDVR0OBBYEFNopWnFZiUBhd2W9d8NKbkRf8gujMAoGCCqGSM49BAMCA0AA
+  MD0CHQC7z3ryynKOXgm/flVbOytXmAgnc8n2I7jLGMKhAhwmW2IwwXFWcH/nX9K/
+  e9AIP3l4dkWUxrNGRqwW
+  -----END CERTIFICATE-----
+docker-registry-auth-key: some key text
+`
+
+	_, err := s.readConfig(c, configText)
+	c.Assert(err, gc.ErrorMatches, `cannot parse .*: no private key found`)
 }
 
 func (s *ConfigSuite) TestValidateConfigError(c *gc.C) {

--- a/internal/dockerauth/api.go
+++ b/internal/dockerauth/api.go
@@ -129,7 +129,7 @@ func (h *handler) Token(p httprequest.Params, req *tokenRequest) (*tokenResponse
 			if err == nil {
 				filteredActions = append(filteredActions, a)
 			} else {
-				logger.Infof("check failed: %v", err)
+				logger.Debugf("docker token check failed for operation %q: %v", a, err)
 			}
 		}
 		if len(filteredActions) == 0 {
@@ -163,7 +163,7 @@ func (c dockerRepoChecker) Condition() string {
 
 func (c dockerRepoChecker) Check(_, arg string) error {
 	if c.repoName != arg {
-		return errgo.Newf("invalid repository name")
+		return errgo.Newf("invalid repository name; got %q want %q", c.repoName, arg)
 	}
 	return nil
 }


### PR DESCRIPTION
Also make it harder to create a config file with a key or certificate
that is non-empty but doesn't contain a valid key or cert,
and actually pass the docker registry address through to the server.