### PR TITLE
internal/blobstore: buffer uploads to swift

### DIFF
--- a/cmd/charmd/main.go
+++ b/cmd/charmd/main.go
@@ -96,7 +96,9 @@ func serve(conf *config.Config) error {
 			return errgo.Mask(err)
 		}
 	}
-
+	if conf.TempDir == "" {
+		conf.TempDir = os.TempDir()
+	}
 	logger.Infof("setting up the API server")
 	cfg := charmstore.ServerParams{
 		AuthUsername:                   conf.AuthUsername,
@@ -131,7 +133,7 @@ func serve(conf *config.Config) error {
 			TenantName: conf.SwiftTenant,
 		}
 		cfg.NewBlobBackend = func(db *mgo.Database) blobstore.Backend {
-			return blobstore.NewSwiftBackend(cred, conf.SwiftAuthMode.Mode, conf.SwiftBucket)
+			return blobstore.NewSwiftBackend(cred, conf.SwiftAuthMode.Mode, conf.SwiftBucket, conf.TempDir)
 		}
 	default:
 		return errgo.Newf("unknown blob store type")

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	DockerRegistryAuthCertificates X509Certificates  `yaml:"docker-registry-auth-certs"`
 	DockerRegistryAuthKey          X509PrivateKey    `yaml:"docker-registry-auth-key"`
 	DockerRegistryTokenDuration    DurationString    `yaml:"docker-registry-token-duration"`
+	TempDir                        string            `yaml:"tempdir"`
 }
 
 type BlobStoreType string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,6 +90,7 @@ docker-registry-auth-key: |
   9NhvqPQt4xyddg==
   -----END EC PRIVATE KEY-----
 docker-registry-token-duration: 1h10m
+tempdir: /var/tmp/charmstore
 `
 
 func (s *ConfigSuite) readConfig(c *gc.C, content string) (*config.Config, error) {
@@ -154,6 +155,7 @@ func (s *ConfigSuite) TestRead(c *gc.C) {
 			Key: mustParseECPrivateKey("MGgCAQEEHM9ekg7h0LAhNBaiSJolcfDNtyfS94DyUblrFu+gBwYFK4EEACGhPAM6AARlWtA/iSeUYFDZw4yxiaBzRURa7wOY4WUVryz/KbzKIG+wJ9rv+39XndXN6kue9NhvqPQt4xyddg=="),
 		},
 		DockerRegistryTokenDuration: config.DurationString{time.Hour + 10*time.Minute},
+		TempDir:                     "/var/tmp/charmstore",
 	})
 }
 

--- a/internal/charmstore/addentity_test.go
+++ b/internal/charmstore/addentity_test.go
@@ -196,10 +196,8 @@ var uploadEntityErrorsTests = []struct {
 	url:         "~charmers/precise/wordpress-0",
 	upload:      storetesting.NewCharm(nil),
 	blobSize:    99999,
-	expectError: "cannot read charm archive: seek past end of file",
-	// It would be nice if the above error was better and
-	// the cause was:
-	// expectCause: params.ErrInvalidEntity,
+	expectError: "cannot put archive blob: size mismatch",
+	expectCause: params.ErrInvalidEntity,
 }, {
 	about:       "charm uploaded to bundle URL",
 	url:         "~charmers/bundle/foo-0",

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -179,7 +179,7 @@ func (s *commonSuite) startServer(c *gc.C) {
 		StatsCacheMaxAge:      time.Nanosecond,
 		MaxMgoSessions:        s.maxMgoSessions,
 		MinUploadPartSize:     10,
-		NewBlobBackend:        s.newBlobBackend,
+		NewBlobBackend:        s.newBlobBackend(c),
 		DockerRegistryAddress: "dockerregistry.example.com",
 	}
 	keyring := httpbakery.NewPublicKeyRing(nil, nil)
@@ -225,8 +225,10 @@ func (s *commonSuite) startServer(c *gc.C) {
 	s.store = s.srv.Pool().Store()
 }
 
-func (s *commonSuite) newBlobBackend(db *mgo.Database) blobstore.Backend {
-	return blobstore.NewSwiftBackend(s.openstackCred, identity.AuthUserPass, "testc")
+func (s *commonSuite) newBlobBackend(c *gc.C) func(db *mgo.Database) blobstore.Backend {
+	return func(db *mgo.Database) blobstore.Backend {
+		return blobstore.NewSwiftBackend(s.openstackCred, identity.AuthUserPass, "testc", c.MkDir())
+	}
 }
 
 func (s *commonSuite) addPublicCharmFromRepo(c *gc.C, charmName string, rurl *router.ResolvedURL) (*router.ResolvedURL, charm.Charm) {


### PR DESCRIPTION
Swift uploads were previously buffered internally in the goose
library. This makes the buffering more explicit and uses disk storage
if necessary.