### PR TITLE
internal/v5: allow PUT of multi-series charms and bundles

### DIFF
--- a/internal/charmstore/store.go
+++ b/internal/charmstore/store.go
@@ -548,7 +548,7 @@ func (s *Store) NewRevision(id *charm.URL) (int, error) {
 }
 
 // AddRevision records a new revision of the given id,
-// meaning that any subequent NewRevision call
+// meaning that any subsequent NewRevision call
 // for the id will return a higher revision number.
 func (s *Store) AddRevision(id *router.ResolvedURL) error {
 	if err := s.addRevision(&id.URL); err != nil {

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -228,9 +228,6 @@ func (h *ReqHandler) servePostArchive(id *charm.URL, w http.ResponseWriter, req 
 
 func (h *ReqHandler) servePutArchive(id *charm.URL, w http.ResponseWriter, req *http.Request) (err error) {
 	defer h.updateStatsArchiveUpload(id, &err)
-	if id.Series == "" {
-		return badRequestf(nil, "series not specified")
-	}
 	if id.Revision == -1 {
 		return badRequestf(nil, "revision not specified")
 	}

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -113,6 +113,7 @@ func (s *commonSuite) TearDownSuite(c *gc.C) {
 	if s.esSuite != nil {
 		s.esSuite.TearDownSuite(c)
 	}
+	s.IsolatedMgoSuite.TearDownSuite(c)
 }
 
 func (s *commonSuite) SetUpTest(c *gc.C) {


### PR DESCRIPTION
This seems to be the only barrier to having ingestion enabled for v5
except for resources.