### PR TITLE
internal/charmstore: allow adding resource with specific revision

### DIFF
--- a/internal/charmstore/store_test.go
+++ b/internal/charmstore/store_test.go
@@ -4254,7 +4254,7 @@ func (s *StoreSuite) TestGC(c *gc.C) {
 		"abcdefghijklmnopqrstuvxwyz",
 	}
 	uid := putMultipart(c, store.BlobStore, time.Time{}, contents...)
-	_, err = store.AddResourceWithUploadId(id3, "someResource", uid)
+	_, err = store.AddResourceWithUploadId(id3, "someResource", -1, uid)
 	c.Assert(err, gc.Equals, nil)
 
 	contents = []string{
@@ -4262,7 +4262,7 @@ func (s *StoreSuite) TestGC(c *gc.C) {
 		"ABCDEFGHIJKLMNOPQURSTUVWXYZ",
 	}
 	uid = putMultipart(c, store.BlobStore, time.Time{}, contents...)
-	resource2, err := store.AddResourceWithUploadId(id3, "someResource", uid)
+	resource2, err := store.AddResourceWithUploadId(id3, "someResource", -1, uid)
 	c.Assert(err, gc.Equals, nil)
 
 	type blobInfo struct {

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -473,7 +473,7 @@ func (s *commonSuite) doAsUser(user string, f func()) {
 // charm with the given id.
 func (s *commonSuite) uploadResource(c *gc.C, id *router.ResolvedURL, name string, content string) {
 	hash := hashOfString(content)
-	_, err := s.store.UploadResource(id, name, strings.NewReader(content), hash, int64(len(content)))
+	_, err := s.store.UploadResource(id, name, -1, strings.NewReader(content), hash, int64(len(content)))
 	c.Assert(err, gc.Equals, nil)
 }
 
@@ -481,7 +481,7 @@ func (s *commonSuite) uploadResource(c *gc.C, id *router.ResolvedURL, name strin
 // charm. The digest will be calculated using hashOf(content) and will
 // have the prefix "test-hash".
 func (s *commonSuite) addDockerResource(c *gc.C, id *router.ResolvedURL, name string, content string) {
-	_, err := s.store.AddDockerResource(id, name, "", "test-hash:"+hashOfString(content))
+	_, err := s.store.AddDockerResource(id, name, -1, "", "test-hash:"+hashOfString(content))
 	c.Assert(err, gc.Equals, nil)
 }
 

--- a/internal/v5/resources.go
+++ b/internal/v5/resources.go
@@ -206,9 +206,9 @@ func (h *ReqHandler) serveUploadResource(id *router.ResolvedURL, w http.Response
 	}
 	var rdoc *mongodoc.Resource
 	if uploadId != "" {
-		rdoc, err = h.Store.AddResourceWithUploadId(id, name, uploadId)
+		rdoc, err = h.Store.AddResourceWithUploadId(id, name, -1, uploadId)
 	} else {
-		rdoc, err = h.Store.UploadResource(id, name, req.Body, hash, req.ContentLength)
+		rdoc, err = h.Store.UploadResource(id, name, -1, req.Body, hash, req.ContentLength)
 	}
 	if err != nil {
 		return errgo.Mask(err)
@@ -237,7 +237,7 @@ func (h *ReqHandler) serveUploadDockerResource(id *router.ResolvedURL, resourceN
 		return badRequestf(nil, "digest not provided")
 	}
 	// TODO check that ImageName parses as a valid docker resource
-	rdoc, err := h.Store.AddDockerResource(id, resourceName, p.ImageName, p.Digest)
+	rdoc, err := h.Store.AddDockerResource(id, resourceName, -1, p.ImageName, p.Digest)
 	if err != nil {
 		return errgo.Mask(err)
 	}


### PR DESCRIPTION
This is a preparatory step before allowing PUT of resources
in the v5 API.