### PR TITLE
internal/v5: add promulgated-id and unpromulgated-id endpoints

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1707,6 +1707,18 @@ Example: `GET ~bob/trusty/wordpress-42/meta/id-series`
 }
 ```
 
+#### GET *id*/meta/unpromulgated-id
+
+The `unpromulgated-id` path is like `meta/id` but always returns the
+id with an owner - the canonical form of the charm or bundle id.
+
+#### GET *id*/meta/promulgated-id
+
+The `promulgated-id` path is like `meta/id` but if the entity has been
+promulgated, it returns the promulgated id (without owner).
+If the entity has never been promulgated, it returns a "metadata not found" error
+(or the entry is omitted when within a bulk metadata request).
+
 #### GET *id*/meta/owner
 
 The `owner` path returns information on the owner of the charm or bundle.

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -142,12 +142,16 @@ func newReqHandler() ReqHandler {
 
 	// Delete new endpoints that we don't want to provide in v4.
 	delete(handlers.Id, "publish")
-	delete(handlers.Meta, "published")
 	delete(handlers.Id, "resource")
+
+	delete(handlers.Meta, "published")
 	delete(handlers.Meta, "resources")
 	delete(handlers.Meta, "resources/")
 	delete(handlers.Meta, "can-ingest")
 	delete(handlers.Meta, "can-write")
+	delete(handlers.Meta, "promulgated-id")
+	delete(handlers.Meta, "unpromulgated-id")
+
 	delete(handlers.Global, "upload")
 	delete(handlers.Global, "upload/")
 

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -273,6 +273,8 @@ func RouterHandlers(h *ReqHandler) *router.Handlers {
 			"id-user":          h.EntityHandler(h.metaIdUser, "_id"),
 			"id-revision":      h.EntityHandler(h.metaIdRevision, "_id"),
 			"id-series":        h.EntityHandler(h.metaIdSeries, "_id"),
+			"unpromulgated-id": h.EntityHandler(h.metaUnpromulgatedId, "_id"),
+			"promulgated-id":   h.EntityHandler(h.metaPromulgatedId, "_id", "promulgated-url"),
 			"manifest":         h.EntityHandler(h.metaManifest, "blobhash"),
 			"owner":            h.EntityHandler(h.metaOwner, "_id"),
 			"perm":             h.puttableBaseEntityHandler(h.metaPerm, h.putMetaPerm, "channelacls"),
@@ -860,19 +862,6 @@ func (h *ReqHandler) metaIdSeries(entity *mongodoc.Entity, id *router.ResolvedUR
 	}, nil
 }
 
-// GET id/meta/id
-// https://github.com/juju/charmstore/blob/v5/docs/API.md#get-idmetaid
-func (h *ReqHandler) metaId(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
-	u := id.PreferredURL()
-	return params.IdResponse{
-		Id:       u,
-		User:     u.User,
-		Series:   u.Series,
-		Name:     u.Name,
-		Revision: u.Revision,
-	}, nil
-}
-
 // GET id/meta/id-name
 // https://github.com/juju/charmstore/blob/v5/docs/API.md#get-idmetaid-name
 func (h *ReqHandler) metaIdName(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
@@ -887,6 +876,37 @@ func (h *ReqHandler) metaIdRevision(entity *mongodoc.Entity, id *router.Resolved
 	return params.IdRevisionResponse{
 		Revision: id.PreferredURL().Revision,
 	}, nil
+}
+
+// GET id/meta/id
+// https://github.com/juju/charmstore/blob/v5/docs/API.md#get-idmetaid
+func (h *ReqHandler) metaId(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
+	return newIdResponse(id.PreferredURL()), nil
+}
+
+// GET id/meta/unpromulgated-id
+// https://github.com/juju/charmstore/blob/v5/docs/API.md#get-idmetaunpromulgatedid
+func (h *ReqHandler) metaUnpromulgatedId(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
+	return newIdResponse(&id.URL), nil
+}
+
+// GET id/meta/promulgated-id
+// https://github.com/juju/charmstore/blob/v5/docs/API.md#get-idmetapromulgatedid
+func (h *ReqHandler) metaPromulgatedId(entity *mongodoc.Entity, id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
+	if entity.PromulgatedURL == nil {
+		return nil, nil
+	}
+	return newIdResponse(entity.PromulgatedURL), nil
+}
+
+func newIdResponse(u *charm.URL) *params.IdResponse {
+	return &params.IdResponse{
+		Id:       u,
+		User:     u.User,
+		Series:   u.Series,
+		Name:     u.Name,
+		Revision: u.Revision,
+	}
 }
 
 // GET id/meta/supported-series


### PR DESCRIPTION
Currently there is no easy way to find out the canonical entity
Id from an arbitrary id, nor is there a way to find the promulgated
id. This adds both those as meta endpoints.