### PR TITLE
Add charmstore helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ version/init.go
 .vscode
 dist
 .*.swp
+charts/charmstore/charts/*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ version/init.go
 /charmstore-*.tar.xz
 
 .vscode
+dist
+.*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:16.04
+COPY dist/bin /srv/charmstore/bin
+VOLUME ["/srv/charmstore/etc"]

--- a/Makefile
+++ b/Makefile
@@ -135,23 +135,22 @@ charmstore-$(VERSION).tar.xz: $(VERSIONDEPS)
 	tar cv -C charmstore-release . | xz > $@
 	-rm -r charmstore-release
 
+DOCKER := microk8s.docker
+DOCKER_REGISTRY := localhost:32000
+
 # Docker targets, defaulting to a microk8s with registry enabled.
 .PHONY: docker
-docker: DOCKER := microk8s.docker
 docker:
 	$(MAKE) GOBIN=$(shell pwd)/dist/bin install MAKE_GODEPS=true
 	$(DOCKER) build -t charmstore:$(VERSION) .
 	$(DOCKER) tag charmstore:$(VERSION) charmstore:latest
 
 .PHONY: docker-image
-docker-image: DOCKER := microk8s.docker
 docker-image: docker
 	-mkdir -p dist/docker
 	$(DOCKER) save charmstore:$(VERSION) | gzip -9 > dist/docker/charmstore-$(VERSION).tar.gz
 
 .PHONY: docker-push
-docker-push: DOCKER := microk8s.docker
-docker-push: DOCKER_REGISTRY := localhost:32000
 docker-push: docker
 	$(DOCKER) tag charmstore:$(VERSION) $(DOCKER_REGISTRY)/charmstore:$(VERSION)
 	$(DOCKER) push $(DOCKER_REGISTRY)/charmstore:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,29 @@ charmstore-$(VERSION).tar.xz: $(VERSIONDEPS)
 	tar cv -C charmstore-release . | xz > $@
 	-rm -r charmstore-release
 
+# Docker targets, defaulting to a microk8s with registry enabled.
+.PHONY: docker
+docker: DOCKER := microk8s.docker
+docker:
+	$(MAKE) GOBIN=$(shell pwd)/dist/bin install MAKE_GODEPS=true
+	$(DOCKER) build -t charmstore:$(VERSION) .
+	$(DOCKER) tag charmstore:$(VERSION) charmstore:latest
+
+.PHONY: docker-image
+docker-image: DOCKER := microk8s.docker
+docker-image: docker
+	-mkdir -p dist/docker
+	$(DOCKER) save charmstore:$(VERSION) | gzip -9 > dist/docker/charmstore-$(VERSION).tar.gz
+
+.PHONY: docker-push
+docker-push: DOCKER := microk8s.docker
+docker-push: DOCKER_REGISTRY := localhost:32000
+docker-push: docker
+	$(DOCKER) tag charmstore:$(VERSION) $(DOCKER_REGISTRY)/charmstore:$(VERSION)
+	$(DOCKER) push $(DOCKER_REGISTRY)/charmstore:$(VERSION)
+	$(DOCKER) tag charmstore:latest $(DOCKER_REGISTRY)/charmstore:latest
+	$(DOCKER) push $(DOCKER_REGISTRY)/charmstore:latest
+
 help:
 	@echo -e 'Charmstore - list of make targets:\n'
 	@echo 'make - Build the package.'

--- a/charts/charmstore/.helmignore
+++ b/charts/charmstore/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/charmstore/Chart.yaml
+++ b/charts/charmstore/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: charmstore
+version: 0.1.0

--- a/charts/charmstore/charts/charmstoreproxy/.helmignore
+++ b/charts/charmstore/charts/charmstoreproxy/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/charmstore/charts/charmstoreproxy/Chart.yaml
+++ b/charts/charmstore/charts/charmstoreproxy/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Frontend for charmstore
+name: charmstoreproxy
+version: 0.1.0

--- a/charts/charmstore/charts/charmstoreproxy/templates/NOTES.txt
+++ b/charts/charmstore/charts/charmstoreproxy/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "charmstoreproxy.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "charmstoreproxy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "charmstoreproxy.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "charmstoreproxy.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/charmstore/charts/charmstoreproxy/templates/_helpers.tpl
+++ b/charts/charmstore/charts/charmstoreproxy/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "charmstoreproxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "charmstoreproxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "charmstoreproxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/charmstore/charts/charmstoreproxy/templates/configmap.yaml
+++ b/charts/charmstore/charts/charmstoreproxy/templates/configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "charmstoreproxy.fullname" . }}
+  labels:
+    app: {{ template "charmstoreproxy.name" . }}
+    chart: {{ template "charmstoreproxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+    haproxy.cfg: |-
+        defaults
+            log global
+            mode http
+            option httplog
+            option dontlognull
+            retries 3
+            timeout queue 20000
+            timeout client 50000
+            timeout connect 5000
+            timeout server 50000
+        
+        frontend haproxy-0-80
+            bind 0.0.0.0:80
+            mode http
+            default_backend charmstore_public
+        
+        backend charmstore_public
+            mode http
+            balance leastconn
+            reqrep ^([^\ :]*)\ /charmstore/(.*)     \1\ /\2
+            server charmstore {{ .Release.Name }}-charmstore.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.port }} check port {{ .Values.port }}

--- a/charts/charmstore/charts/charmstoreproxy/templates/deployment.yaml
+++ b/charts/charmstore/charts/charmstoreproxy/templates/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "charmstoreproxy.fullname" . }}
+  labels:
+    app: {{ template "charmstoreproxy.name" . }}
+    chart: {{ template "charmstoreproxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "charmstoreproxy.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "charmstoreproxy.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      volumes:
+        - name: haproxy-conf
+          configMap:
+            name: {{ template "charmstoreproxy.fullname" . }}
+      initContainers:
+        - name: {{ .Chart.Name }}-check-config
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ['haproxy', '-c', '-f', '/usr/local/etc/haproxy/haproxy.cfg']
+          volumeMounts:
+            - name: haproxy-conf
+              mountPath: /usr/local/etc/haproxy
+              readOnly: true
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: haproxy-conf
+              mountPath: /usr/local/etc/haproxy
+              readOnly: true
+          command: ['haproxy', '-f', '/usr/local/etc/haproxy/haproxy.cfg']
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/charmstore/charts/charmstoreproxy/templates/ingress.yaml
+++ b/charts/charmstore/charts/charmstoreproxy/templates/ingress.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "charmstoreproxy.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "charmstoreproxy.name" . }}
+    chart: {{ template "charmstoreproxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+    - host: {{ .Values.fqdn }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+{{- end }}

--- a/charts/charmstore/charts/charmstoreproxy/templates/service.yaml
+++ b/charts/charmstore/charts/charmstoreproxy/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "charmstoreproxy.fullname" . }}
+  labels:
+    app: {{ template "charmstoreproxy.name" . }}
+    chart: {{ template "charmstoreproxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "charmstoreproxy.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/charmstore/charts/charmstoreproxy/values.yaml
+++ b/charts/charmstore/charts/charmstoreproxy/values.yaml
@@ -1,0 +1,42 @@
+# Default values for charmstoreproxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: haproxy
+  tag: 1.8.13
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+fqdn: jaas.local
+port: 8080
+
+ingress:
+  enabled: true
+  path: /charmstore
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/rewrite-target: "/charmstore"
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/charmstore/requirements.lock
+++ b/charts/charmstore/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mongodb
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 4.3.4
+digest: sha256:7e5a20797e32f6e33654dd83c3f70946b498172d16e0d24932185664a2eef08a
+generated: 2018-09-12T10:46:56.073128197-05:00

--- a/charts/charmstore/requirements.yaml
+++ b/charts/charmstore/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: mongodb
+    repository: "alias:stable"
+    version: "4.3.4"

--- a/charts/charmstore/templates/NOTES.txt
+++ b/charts/charmstore/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "charmstore.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "charmstore.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "charmstore.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "charmstore.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/charmstore/templates/_helpers.tpl
+++ b/charts/charmstore/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "charmstore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "charmstore.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "charmstore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/charmstore/templates/configmap.yaml
+++ b/charts/charmstore/templates/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "charmstore.fullname" . }}
+  labels:
+    app: {{ template "charmstore.name" . }}
+    chart: {{ template "charmstore.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+    config.yaml: |-
+        mongo-url: {{ .Release.Name }}-mongodb.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.mongodb.service.port }}
+        api-addr: :{{ .Values.charmstoreproxy.port }}
+        identity-location: {{ .Values.identity.url }}
+        identity-public-key: {{ .Values.identity.publicKey }}
+        terms-location: {{ .Values.terms.url }}
+        terms-public-key: {{ .Values.terms.publicKey }}
+        auth-username: {{ .Values.auth.username }}
+        auth-password: {{ .Values.auth.password }}

--- a/charts/charmstore/templates/deployment.yaml
+++ b/charts/charmstore/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "charmstore.fullname" . }}
+  labels:
+    app: {{ template "charmstore.name" . }}
+    chart: {{ template "charmstore.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "charmstore.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "charmstore.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      volumes:
+        - name: charmd-conf
+          configMap:
+            name: {{ template "charmstore.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ['/srv/charmstore/bin/charmd', '/srv/charmstore/etc/config.yaml']
+          volumeMounts:
+            - name: charmd-conf
+              mountPath: /srv/charmstore/etc
+              readOnly: true
+          ports:
+            - name: http
+              containerPort: {{ .Values.charmstoreproxy.port }}
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.charmstoreproxy.port }}
+            #httpGet:
+              #path: /
+              #port: http
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.charmstoreproxy.port }}
+            #httpGet:
+              #path: /
+              #port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/charmstore/templates/service.yaml
+++ b/charts/charmstore/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "charmstore.fullname" . }}
+  labels:
+    app: {{ template "charmstore.name" . }}
+    chart: {{ template "charmstore.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.charmstoreproxy.port }}
+      targetPort: {{ .Values.charmstoreproxy.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "charmstore.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/charmstore/values.yaml
+++ b/charts/charmstore/values.yaml
@@ -1,0 +1,49 @@
+# Default values for charmstore.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: localhost:32000/charmstore
+  tag: latest
+  pullPolicy: Always
+
+identity:
+  url:  https://api.jujucharms.com/identity
+  publicKey: hmHaPgCC1UfuhYHUSX5+aihSAZesqpVdjRv0mgfIwjo=
+
+terms:
+  url: https://api.jujucharms.com/terms
+  publicKey: LeU0MxqM9W3M6Cuq6q6nlwp+SW8GhWMJM5KMJf6BLRk=
+
+auth:
+  username: admin
+  password: nimda
+
+charmstoreproxy:
+  port: 8080
+
+mongodb:
+  usePassword: false
+
+service:
+  type: ClusterIP
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/scripts/helm-rbac-fix.bash
+++ b/charts/scripts/helm-rbac-fix.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+kubectl create serviceaccount --namespace kube-system tiller || true
+kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller || true
+kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'

--- a/charts/scripts/sysdeps.bash
+++ b/charts/scripts/sysdeps.bash
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+HERE=$(cd $(dirname $0); pwd)
+
+set -eu
+
+sudo snap install microk8s --classic --edge
+microk8s.enable dns registry storage
+sudo snap install helm
+
+# Install and configure kubectl
+sudo snap install kubectl --classic
+mkdir -p $HOME/.kube
+if [ ! -e "$HOME/.kube/config" ]; then
+	microk8s.config > $HOME/.kube/config
+fi
+
+# Install and configure helm
+helm 2>&1 >/dev/null || true
+microk8s.config > $HOME/snap/helm/common/kube/config
+helm init || helm init --upgrade
+$HERE/helm-rbac-fix.bash
+


### PR DESCRIPTION
I'd like to start developing & testing against JAAS services more easily. For Omnibus I've found this is much easier to set up and manage with Docker containers running in microk8s, than using mojo, or the ad-hoc pile of Makefiles, charms and scripts that is omnibus-layers, or trying to build everything from scratch and run manually, juggling local ports and config.

To deploy charmstore on microk8s with this branch:
- Run `charts/scripts/sysdeps.bash`
- `make docker-push`
- `helm install ./charts/charmstore`

Once all pods are up (`kubectl get all`), charmstore will be accessible at `curl -H 'Host: jaas.local' localhost/charmstore/debug/info`, etc. Edit /etc/hosts and then you won't need to set the header.

I've got similar PRs into Omnibus (CanonicalLtd/omnibus#1698) and Terms (CanonicalLtd/terms-service#151). My goal is to be able to run _any_ subset of JAAS in microk8s on a laptop.