### PR TITLE
Track more things for API responses.

### DIFF
--- a/internal/charmstore/debug.go
+++ b/internal/charmstore/debug.go
@@ -225,14 +225,15 @@ type handler struct {
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rw := monitoring.NewResponseWriter(w)
 	monReq := monitoring.NewRequest(r, "debug")
-	defer monReq.Done()
+	defer monReq.Done(rw.Status)
 	if _, path := h.mux.Handler(r); path != "" {
 		monReq.SetKind(path)
 	} else {
 		monReq.SetKind("unknown")
 	}
-	h.mux.ServeHTTP(w, r)
+	h.mux.ServeHTTP(rw, r)
 }
 
 func authorized(c ServerParams, h http.Handler) http.Handler {

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -241,9 +241,10 @@ func prometheusHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// Use prometheus to monitor its own requests...
 		monReq := monitoring.NewRequest(req, "prometheus")
-		defer monReq.Done()
+		rw := monitoring.NewResponseWriter(w)
+		defer monReq.Done(rw.Status)
 		monReq.SetKind("metrics")
-		h.ServeHTTP(w, req)
+		h.ServeHTTP(rw, req)
 	})
 }
 

--- a/internal/monitoring/monitoring.go
+++ b/internal/monitoring/monitoring.go
@@ -13,7 +13,7 @@ var (
 		Subsystem: "handler",
 		Name:      "request_duration",
 		Help:      "The duration of a web request in seconds.",
-	}, []string{"method", "root", "kind"})
+	}, []string{"method", "root", "kind", "status", "endpoint"})
 
 	uploadProcessingDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "charmstore",

--- a/internal/monitoring/request.go
+++ b/internal/monitoring/request.go
@@ -3,6 +3,7 @@
 package monitoring // import "gopkg.in/juju/charmstore.v5/internal/monitoring"
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -42,8 +43,9 @@ func (r *Request) SetKind(kind string) {
 }
 
 // Done records that the request is complete, and records any metrics for the request since the last call to Reset.
-func (r *Request) Done() {
-	requestDuration.WithLabelValues(r.request.Method, r.root, r.kind).Observe(float64(time.Since(r.startTime)) / float64(time.Second))
+func (r *Request) Done(status func() int) {
+	statusStr := fmt.Sprint(status())
+	requestDuration.WithLabelValues(r.request.Method, r.root, r.kind, statusStr, r.request.URL.Path).Observe(float64(time.Since(r.startTime)) / float64(time.Second))
 }
 
 // Kind returns the kind that has been set. This is useful for testing.

--- a/internal/monitoring/responsewriter.go
+++ b/internal/monitoring/responsewriter.go
@@ -1,0 +1,40 @@
+package monitoring
+
+import "net/http"
+
+// ResponseWriter wraps the http.ResponseWriter to give us the ability to
+// retrieve the HTTP status code at any point after the response has been written.
+//
+// Note: This is does not implement any of the optional methods implemented by
+// ResponseWriters. (i.e. CloseNotifier, Flusher, Hijacker)
+type ResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+// NewResponseWriter creates a new *ResponseWriter from a provided http.ResponseWriter
+func NewResponseWriter(w http.ResponseWriter) *ResponseWriter {
+	return &ResponseWriter{ResponseWriter: w}
+}
+
+// WriteHeader records the HTTP status before calling WriteHeader on the underlying
+// http.ResponseWriter.
+func (w *ResponseWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+// Write records the HTTP status before calling Write on the underlying
+// http.ResponseWriter. If the status has not been set by this point, it is
+// set to 200 OK (something the underlying http.ResponseWriter will do anyway).
+func (w *ResponseWriter) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// Status returns the status of the ResponseWriter. It will be 0 if not set yet.
+func (w *ResponseWriter) Status() int {
+	return w.status
+}


### PR DESCRIPTION
This adds endpoint and HTTP status tracking to Prometheus to allows us to gain more insightful metrics.