### PR TITLE
internal/monitoring: Track when ElasticSearch is syncing.

### DIFF
--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -193,6 +193,8 @@ func NewServer(db *mgo.Database, si *SearchIndex, config ServerParams, versions 
 		return nil, errgo.Notef(err, "database migration failed")
 	}
 	store.Go(func(store *Store) {
+		monitoring.SetElasticSearchSyncing(true)
+		defer monitoring.SetElasticSearchSyncing(false)
 		if err := store.syncSearch(); err != nil {
 			logger.Errorf("Cannot populate elasticsearch: %v", err)
 		}

--- a/internal/monitoring/elasticsearch.go
+++ b/internal/monitoring/elasticsearch.go
@@ -1,0 +1,12 @@
+package monitoring
+
+// SetElasticSearchSyncing sets the charmstore_elastic_search_syncing gauge to
+// 1 if inProgress, 0 otherwise (as per common practice for tracking
+// "booleans" in ElasticSearch).
+func SetElasticSearchSyncing(inProgress bool) {
+	var f float64
+	if inProgress {
+		f = 1.0
+	}
+	esSyncing.Set(f)
+}

--- a/internal/monitoring/monitoring.go
+++ b/internal/monitoring/monitoring.go
@@ -49,6 +49,13 @@ var (
 		Name:      "mean_blob_size",
 		Help:      "The mean stored blob size",
 	})
+
+	esSyncing = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "charmstore",
+		Subsystem: "elastic_search",
+		Name:      "syncing",
+		Help:      "Set to 1 when Elastic Search sync is happening.",
+	})
 )
 
 // BlobStats holds statistics about blobs in the blob store.
@@ -76,5 +83,6 @@ func init() {
 	prometheus.MustRegister(blobCount)
 	prometheus.MustRegister(maxBlobSize)
 	prometheus.MustRegister(meanBlobSize)
+	prometheus.MustRegister(esSyncing)
 	prometheus.MustRegister(monitoring.NewMgoStatsCollector("charmstore"))
 }


### PR DESCRIPTION
We are only tracking when ES sync happens here. We don't explicitly care about precise duration as it's fairly meaningless. Having this change will show us when it's happening and for how long (i.e. is it seconds or hours?), and is easy to graph/analyse.