### PR TITLE
internal/monitoring: Fix endpoint metrics.

### DIFF
--- a/internal/charmstore/debug.go
+++ b/internal/charmstore/debug.go
@@ -228,11 +228,6 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rw := monitoring.NewResponseWriter(w)
 	monReq := monitoring.NewRequest(r, "debug")
 	defer monReq.Done(rw.Status)
-	if _, path := h.mux.Handler(r); path != "" {
-		monReq.SetKind(path)
-	} else {
-		monReq.SetKind("unknown")
-	}
 	h.mux.ServeHTTP(rw, r)
 }
 

--- a/internal/charmstore/server.go
+++ b/internal/charmstore/server.go
@@ -248,9 +248,9 @@ func prometheusHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// Use prometheus to monitor its own requests...
 		monReq := monitoring.NewRequest(req, "prometheus")
+		monReq.SetEndpoint("/metrics")
 		rw := monitoring.NewResponseWriter(w)
 		defer monReq.Done(rw.Status)
-		monReq.SetKind("metrics")
 		h.ServeHTTP(rw, req)
 	})
 }

--- a/internal/monitoring/monitoring.go
+++ b/internal/monitoring/monitoring.go
@@ -13,7 +13,7 @@ var (
 		Subsystem: "handler",
 		Name:      "request_duration",
 		Help:      "The duration of a web request in seconds.",
-	}, []string{"method", "root", "kind", "status", "endpoint"})
+	}, []string{"method", "root", "status", "endpoint"})
 
 	uploadProcessingDuration = prometheus.NewSummary(prometheus.SummaryOpts{
 		Namespace: "charmstore",

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -48,7 +48,7 @@ var routerGetTests = []struct {
 	resolveURL                func(*charm.URL) (*ResolvedURL, error)
 	authorize                 func(*ResolvedURL, *http.Request) error
 	exists                    func(*ResolvedURL, *http.Request) (bool, error)
-	monitorKind               string
+	monitorEndpoint           string
 }{{
 	about: "global handler",
 	handlers: Handlers{
@@ -68,7 +68,7 @@ var routerGetTests = []struct {
 		Method: "GET",
 		Path:   "",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/foo",
 }, {
 	about: "global handler with sub-path and flags",
 	handlers: Handlers{
@@ -92,7 +92,7 @@ var routerGetTests = []struct {
 			"b": {"two"},
 		},
 	},
-	monitorKind: "foo/bar/",
+	monitorEndpoint: "/foo/bar/",
 }, {
 	about:        "invalid form",
 	urlStr:       "/foo?a=%",
@@ -113,7 +113,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:precise/wordpress-34",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "development id handler",
 	handlers: Handlers{
@@ -153,7 +153,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:win81/visualstudio-2012",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "wily id handler",
 	handlers: Handlers{
@@ -167,7 +167,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:wily/wordpress-34",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "id handler with no series in id",
 	handlers: Handlers{
@@ -181,7 +181,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:wordpress-34",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "id handler with no revision in id",
 	handlers: Handlers{
@@ -195,7 +195,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:precise/wordpress",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "id handler with channel and name only",
 	handlers: Handlers{
@@ -223,7 +223,7 @@ var routerGetTests = []struct {
 		CharmURL: "cs:precise/wordpress-34",
 		Path:     "/blah/arble",
 	},
-	monitorKind: "foo/",
+	monitorEndpoint: "/:id/foo/",
 }, {
 	about: "id handler with allowed extra path but none given",
 	handlers: Handlers{
@@ -263,7 +263,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:~joe/precise/wordpress-34",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "wily handler with user",
 	handlers: Handlers{
@@ -277,7 +277,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:~joe/wily/wordpress-34",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "id handler with user and extra path",
 	handlers: Handlers{
@@ -292,7 +292,7 @@ var routerGetTests = []struct {
 		CharmURL: "cs:~joe/precise/wordpress-34",
 		Path:     "/blah/arble",
 	},
-	monitorKind: "foo/",
+	monitorEndpoint: "/:id/foo/",
 }, {
 	about: "development id handler with user and extra path",
 	handlers: Handlers{
@@ -331,7 +331,7 @@ var routerGetTests = []struct {
 	expectBody: params.Error{
 		Message: "errorIdHandler error",
 	},
-	monitorKind: "foo/",
+	monitorEndpoint: "/:id/foo/",
 }, {
 	about: "id handler that returns a not-found error",
 	handlers: Handlers{
@@ -347,7 +347,7 @@ var routerGetTests = []struct {
 		Message: "not found",
 		Code:    params.ErrNotFound,
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "id handler that returns some other kind of coded error",
 	handlers: Handlers{
@@ -363,7 +363,7 @@ var routerGetTests = []struct {
 		Message: "a message",
 		Code:    "foo",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "id with unspecified series and revision, not resolved",
 	handlers: Handlers{
@@ -378,7 +378,7 @@ var routerGetTests = []struct {
 		Method:   "GET",
 		CharmURL: "cs:~joe/wordpress",
 	},
-	monitorKind: "foo",
+	monitorEndpoint: "/:id/foo",
 }, {
 	about: "id with error on resolving",
 	handlers: Handlers{
@@ -392,6 +392,7 @@ var routerGetTests = []struct {
 	expectBody: params.Error{
 		Message: "resolve URL error",
 	},
+	monitorEndpoint: "/:id/meta",
 }, {
 	about: "id with error on resolving that has a Cause",
 	handlers: Handlers{
@@ -406,6 +407,7 @@ var routerGetTests = []struct {
 		Message: "not found",
 		Code:    params.ErrNotFound,
 	},
+	monitorEndpoint: "/:id/meta",
 }, {
 	about: "meta list",
 	handlers: Handlers{
@@ -417,10 +419,10 @@ var routerGetTests = []struct {
 			"baz":  testMetaHandler(4),
 		},
 	},
-	urlStr:       "/precise/wordpress-42/meta",
-	expectStatus: http.StatusOK,
-	expectBody:   []string{"bar", "baz", "foo"},
-	monitorKind:  "meta",
+	urlStr:          "/precise/wordpress-42/meta",
+	expectStatus:    http.StatusOK,
+	expectBody:      []string{"bar", "baz", "foo"},
+	monitorEndpoint: "/:id/meta",
 }, {
 	about: "meta list at root",
 	handlers: Handlers{
@@ -432,10 +434,10 @@ var routerGetTests = []struct {
 			"baz":  testMetaHandler(4),
 		},
 	},
-	urlStr:       "/meta",
-	expectStatus: http.StatusOK,
-	expectBody:   []string{"bar", "baz", "foo"},
-	monitorKind:  "meta",
+	urlStr:          "/meta",
+	expectStatus:    http.StatusOK,
+	expectBody:      []string{"bar", "baz", "foo"},
+	monitorEndpoint: "/meta/",
 }, {
 	about: "meta list at root with trailing /",
 	handlers: Handlers{
@@ -447,10 +449,10 @@ var routerGetTests = []struct {
 			"baz":  testMetaHandler(4),
 		},
 	},
-	urlStr:       "/meta/",
-	expectStatus: http.StatusOK,
-	expectBody:   []string{"bar", "baz", "foo"},
-	monitorKind:  "meta",
+	urlStr:          "/meta/",
+	expectStatus:    http.StatusOK,
+	expectBody:      []string{"bar", "baz", "foo"},
+	monitorEndpoint: "/meta/",
 }, {
 	about: "meta handler",
 	handlers: Handlers{
@@ -464,7 +466,7 @@ var routerGetTests = []struct {
 	expectBody: &metaHandlerTestResp{
 		CharmURL: "cs:precise/wordpress-42",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/foo",
 }, {
 	about: "meta handler with additional elements",
 	handlers: Handlers{
@@ -479,7 +481,7 @@ var routerGetTests = []struct {
 		CharmURL: "cs:precise/wordpress-42",
 		Path:     "/bar/baz",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/foo/bar/baz",
 }, {
 	about: "meta handler with params",
 	handlers: Handlers{
@@ -497,7 +499,7 @@ var routerGetTests = []struct {
 			"two": {"b"},
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/foo",
 }, {
 	about:                     "meta handler that's not found",
 	urlStr:                    "/precise/wordpress-42/meta/foo",
@@ -507,7 +509,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrNotFound,
 		Message: `unknown metadata "foo"`,
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/foo",
 }, {
 	about:                     "meta sub-handler that's not found",
 	urlStr:                    "/precise/wordpress-42/meta/foo/bar",
@@ -517,7 +519,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrNotFound,
 		Message: `unknown metadata "foo/bar"`,
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/foo/bar",
 }, {
 	about: "meta handler with nil data",
 	handlers: Handlers{
@@ -532,7 +534,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrMetadataNotFound,
 		Message: "metadata not found",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/foo",
 }, {
 	about: "meta handler with typed nil data",
 	handlers: Handlers{
@@ -547,7 +549,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrMetadataNotFound,
 		Message: "metadata not found",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/foo",
 }, {
 	about:  "meta handler with field selector",
 	urlStr: "/precise/wordpress-42/meta/foo",
@@ -567,7 +569,7 @@ var routerGetTests = []struct {
 		},
 		Id: newResolvedURL("cs:~charmers/precise/wordpress-42", 42),
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/foo",
 }, {
 	about:  "meta handler returning error with code",
 	urlStr: "/precise/wordpress-42/meta/foo",
@@ -582,7 +584,7 @@ var routerGetTests = []struct {
 		Code:    "arble",
 		Message: "a message",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/foo",
 }, {
 	about:  "unauthorized meta handler",
 	urlStr: "/precise/wordpress-42/meta/foo",
@@ -598,6 +600,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrUnauthorized,
 		Message: "bad wolf",
 	},
+	monitorEndpoint: "/:id/meta/foo",
 }, {
 	about:        "meta/any, no includes, id exists",
 	urlStr:       "/precise/wordpress-42/meta/any",
@@ -605,7 +608,7 @@ var routerGetTests = []struct {
 	expectBody: params.MetaAnyResponse{
 		Id: charm.MustParseURL("cs:precise/wordpress-42"),
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/any",
 }, {
 	about:        "meta/any, no includes, id does not exist",
 	urlStr:       "/precise/wordpress/meta/any",
@@ -615,6 +618,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrNotFound,
 		Message: "not found",
 	},
+	monitorEndpoint: "/:id/meta/any",
 }, {
 	about:  "meta/any, some includes all using same key",
 	urlStr: "/precise/wordpress-42/meta/any?include=field1-1&include=field2&include=field1-2",
@@ -657,7 +661,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/any",
 }, {
 	about:  "meta/any, includes with additional path elements",
 	urlStr: "/precise/wordpress-42/meta/any?include=item1/foo&include=item2/bar&include=item1",
@@ -702,7 +706,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/any",
 }, {
 	about:  "meta/any, nil metadata omitted",
 	urlStr: "/precise/wordpress-42/meta/any?include=ok&include=nil",
@@ -723,7 +727,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/any",
 }, {
 	about:  "meta/any, handler returns error with cause",
 	urlStr: "/precise/wordpress-42/meta/any?include=error",
@@ -738,7 +742,7 @@ var routerGetTests = []struct {
 		Code:    "foo",
 		Message: "a message",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/:id/meta/any",
 }, {
 	about:  "bulk meta handler, single id",
 	urlStr: "/meta/foo?id=precise/wordpress-42",
@@ -754,7 +758,7 @@ var routerGetTests = []struct {
 			CharmURL: "cs:precise/wordpress-42",
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo",
 }, {
 	about:  "bulk meta handler, single id with invalid channel",
 	urlStr: "/meta/foo?id=~user/bad-wolf/wily/wordpress-42",
@@ -769,7 +773,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: `charm or bundle URL has invalid form: "~user/bad-wolf/wily/wordpress-42"`,
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo",
 }, {
 	about:  "bulk meta handler, several ids",
 	urlStr: "/meta/foo?id=precise/wordpress-42&id=utopic/foo-32&id=django",
@@ -791,7 +795,7 @@ var routerGetTests = []struct {
 			CharmURL: "cs:precise/django-0",
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo",
 }, {
 	about:  "bulk meta/any handler, several ids",
 	urlStr: "/meta/any?id=precise/wordpress-42&id=utopic/foo-32&id=django-47&include=foo&include=bar/something",
@@ -841,7 +845,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/any",
 }, {
 	about:  "bulk meta/any handler, several ids, invalid channel",
 	urlStr: "/meta/any?id=precise/wordpress-42&id=staging/trusty/django&include=foo&include=bar/something",
@@ -857,7 +861,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: `charm or bundle URL has invalid form: "staging/trusty/django"`,
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/any",
 }, {
 	about:  "bulk meta/any handler, discharge required",
 	urlStr: "/meta/any?id=precise/wordpress-42&include=foo",
@@ -872,7 +876,7 @@ var routerGetTests = []struct {
 	expectBody: params.Error{
 		Message: "discharge required",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/any",
 }, {
 	about:  "bulk meta/any handler, discharge required, ignore authorization",
 	urlStr: "/meta/any?id=precise/wordpress-42&include=foo&ignore-auth=1",
@@ -885,7 +889,7 @@ var routerGetTests = []struct {
 	expectWillIncludeMetadata: []string{"foo"},
 	expectStatus:              http.StatusOK,
 	expectBody:                map[string]params.MetaAnyResponse{},
-	monitorKind:               "meta",
+	monitorEndpoint:           "/meta/any",
 }, {
 	about:  "bulk meta/any handler, some unauthorized, ignore authorization",
 	urlStr: "/meta/any?id=precise/wordpress-42&id=utopic/foo-32&include=foo&ignore-auth=1",
@@ -907,7 +911,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/any",
 }, {
 	about:  "bulk meta/any handler, unauthorized",
 	urlStr: "/meta/any?id=precise/wordpress-42&include=foo",
@@ -922,7 +926,7 @@ var routerGetTests = []struct {
 	expectBody: params.Error{
 		Message: "bad wolf",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/any",
 }, {
 	about:  "bulk meta/any handler, unauthorized, ignore authorization",
 	urlStr: "/meta/any?id=precise/wordpress-42&include=foo&ignore-auth=1",
@@ -935,7 +939,7 @@ var routerGetTests = []struct {
 	expectWillIncludeMetadata: []string{"foo"},
 	expectStatus:              http.StatusOK,
 	expectBody:                map[string]params.MetaAnyResponse{},
-	monitorKind:               "meta",
+	monitorEndpoint:           "/meta/any",
 }, {
 	about:        "bulk meta/any handler, invalid ignore-auth flag",
 	urlStr:       "/meta/any?id=precise/wordpress-42&include=foo&ignore-auth=meh",
@@ -944,7 +948,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: `unexpected bool value "meh" (must be "0" or "1")`,
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/any",
 }, {
 	about:  "bulk meta handler with unresolved id",
 	urlStr: "/meta/foo/bar?id=wordpress",
@@ -962,7 +966,7 @@ var routerGetTests = []struct {
 			Path:     "/bar",
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo/bar",
 }, {
 	about:  "bulk meta handler with extra flags",
 	urlStr: "/meta/foo/bar?id=wordpress&arble=bletch&z=w&z=p",
@@ -984,7 +988,7 @@ var routerGetTests = []struct {
 			},
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo/bar",
 }, {
 	about:  "bulk meta handler with no ids",
 	urlStr: "/meta/foo/bar",
@@ -998,7 +1002,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: "no ids specified in meta request",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo/bar",
 }, {
 	about:  "bulk meta handler with unresolvable id",
 	urlStr: "/meta/foo?id=unresolved&id=~foo/precise/wordpress-23",
@@ -1020,7 +1024,7 @@ var routerGetTests = []struct {
 			CharmURL: "cs:precise/wordpress-99",
 		},
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo",
 }, {
 	about:  "bulk meta handler with id resolution error",
 	urlStr: "/meta/foo?id=resolveerror&id=precise/wordpress-23",
@@ -1040,7 +1044,7 @@ var routerGetTests = []struct {
 	expectBody: params.Error{
 		Message: "an error",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo",
 }, {
 	about:  "bulk meta handler with some nil data",
 	urlStr: "/meta/foo?id=bundle/something-24&id=precise/wordpress-23",
@@ -1056,7 +1060,7 @@ var routerGetTests = []struct {
 	expectBody: map[string]string{
 		"bundle/something-24": "bundlefoo",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo",
 }, {
 	about:  "bulk meta handler with entity not found",
 	urlStr: "/meta/foo?id=bundle/something-24&id=precise/wordpress-23",
@@ -1075,7 +1079,7 @@ var routerGetTests = []struct {
 	expectBody: map[string]string{
 		"bundle/something-24": "something",
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo",
 }, {
 	about:        `cannot parse URL "robots.txt": name "robots.txt" not valid`,
 	urlStr:       "/robots.txt/meta/any",
@@ -1085,7 +1089,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrNotFound,
 		Message: `cannot parse URL "robots.txt": name "robots.txt" not valid`,
 	},
-	monitorKind: "",
+	monitorEndpoint: "",
 }, {
 	about:                     "bulk meta handler, invalid id",
 	urlStr:                    "/meta/foo?id=robots.txt",
@@ -1096,7 +1100,7 @@ var routerGetTests = []struct {
 		Code:    params.ErrBadRequest,
 		Message: `cannot parse URL "robots.txt": name "robots.txt" not valid`,
 	},
-	monitorKind: "meta",
+	monitorEndpoint: "/meta/foo",
 }}
 
 // resolveTo returns a URL resolver that resolves
@@ -1177,7 +1181,7 @@ func (s *RouterSuite) TestRouterGet(c *gc.C) {
 		})
 		c.Assert(queryCount, gc.Equals, test.expectQueryCount)
 		c.Assert(includedMetadata, jc.DeepEquals, test.expectWillIncludeMetadata)
-		c.Assert(router.Monitor.Kind(), gc.Equals, test.monitorKind)
+		c.Assert(router.Monitor.Endpoint(), gc.Equals, test.monitorEndpoint)
 	}
 }
 

--- a/internal/v4/api.go
+++ b/internal/v4/api.go
@@ -21,7 +21,6 @@ import (
 	"gopkg.in/juju/charmstore.v5/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5/internal/entitycache"
 	"gopkg.in/juju/charmstore.v5/internal/mongodoc"
-	"gopkg.in/juju/charmstore.v5/internal/monitoring"
 	"gopkg.in/juju/charmstore.v5/internal/router"
 	"gopkg.in/juju/charmstore.v5/internal/v5"
 )
@@ -56,16 +55,13 @@ func New(p charmstore.APIHandlerParams) (Handler, error) {
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	rw := monitoring.NewResponseWriter(w)
 	rh, err := h.NewReqHandler(req)
 	if err != nil {
 		router.WriteError(context.TODO(), w, err)
 		return
 	}
 	defer rh.Close()
-	rh.Router.Monitor.Reset(req, "v4")
-	defer rh.Router.Monitor.Done(rw.Status)
-	rh.ServeHTTP(rw, req)
+	rh.ServeHTTP(w, req)
 }
 
 func NewAPIHandler(p charmstore.APIHandlerParams) (charmstore.HTTPCloseHandler, error) {


### PR DESCRIPTION
Here we fix the endpoint metrics so that that they are neatly grouped rather than outputting the entity names and causing time series pollution.
(e.g. `/wordpress/meta/common-info`, `/mysql/meta/common-info` etc are now simply tracked as `/:id/meta/common-info`).

`Kind` (which was very buggy and at times random) is replaced with `Endpoint` which holds this above info. The rough metrics on v4 are removed too.

This PR will give us the ability to gain lots of insights on API usage per endpoint. The next PR will add granular metrics for metadata, under a separate namespace to keep Prometheus clean and queryable.