### PR TITLE
reorder stats key

### DIFF
--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -2409,13 +2408,13 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 			// Simulate the entity was downloaded at the specified dates.
 			for daysAgo, downloads := range downloadsPerDay {
 				date := today.AddDate(0, 0, -daysAgo)
-				key := []string{params.StatsArchiveDownload, url.URL.Series, url.URL.Name, url.URL.User, strconv.Itoa(url.URL.Revision)}
+				key := charmstore.EntityStatsKey(&url.URL, params.StatsArchiveDownload)
 				for i := 0; i < downloads; i++ {
 					err := s.store.IncCounterAtTime(key, date)
 					c.Assert(err, gc.Equals, nil)
 				}
 				if url.PromulgatedRevision > -1 {
-					key := []string{params.StatsArchiveDownloadPromulgated, url.URL.Series, url.URL.Name, "", strconv.Itoa(url.PromulgatedRevision)}
+					key := charmstore.EntityStatsKey(url.PromulgatedURL(), params.StatsArchiveDownloadPromulgated)
 					for i := 0; i < downloads; i++ {
 						err := s.store.IncCounterAtTime(key, date)
 						c.Assert(err, gc.Equals, nil)

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -771,24 +771,6 @@ func (h *ReqHandler) metaStats(entity *mongodoc.Entity, id *router.ResolvedURL, 
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}
-	if entity.Series == "" {
-		// Concatenate all the supported series for a multi-series entity.
-		for _, series := range entity.SupportedSeries {
-			preferredURL.Series = series
-			countsSeries, countsAllRevisionsSeries, err := h.Store.ArchiveDownloadCounts(preferredURL, refresh)
-			if err != nil {
-				return nil, errgo.Mask(err)
-			}
-			counts.Total += countsSeries.Total
-			counts.LastDay += countsSeries.LastDay
-			counts.LastWeek += countsSeries.LastWeek
-			counts.LastMonth += countsSeries.LastMonth
-			countsAllRevisions.Total += countsAllRevisionsSeries.Total
-			countsAllRevisions.LastDay += countsAllRevisionsSeries.LastDay
-			countsAllRevisions.LastWeek += countsAllRevisionsSeries.LastWeek
-			countsAllRevisions.LastMonth += countsAllRevisionsSeries.LastMonth
-		}
-	}
 	// Return the response.
 	return &params.StatsResponse{
 		ArchiveDownloadCount: counts.Total,

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -2884,13 +2883,13 @@ func (s *APISuite) TestMetaStats(c *gc.C) {
 			// Simulate the entity was downloaded at the specified dates.
 			for daysAgo, downloads := range downloadsPerDay {
 				date := today.AddDate(0, 0, -daysAgo)
-				key := []string{params.StatsArchiveDownload, url.URL.Series, url.URL.Name, url.URL.User, strconv.Itoa(url.URL.Revision)}
+				key := charmstore.EntityStatsKey(&url.URL, params.StatsArchiveDownload)
 				for i := 0; i < downloads; i++ {
 					err := s.store.IncCounterAtTime(key, date)
 					c.Assert(err, gc.Equals, nil)
 				}
 				if url.PromulgatedRevision > -1 {
-					key := []string{params.StatsArchiveDownloadPromulgated, url.URL.Series, url.URL.Name, "", strconv.Itoa(url.PromulgatedRevision)}
+					key := charmstore.EntityStatsKey(url.PromulgatedURL(), params.StatsArchiveDownloadPromulgated)
 					for i := 0; i < downloads; i++ {
 						err := s.store.IncCounterAtTime(key, date)
 						c.Assert(err, gc.Equals, nil)
@@ -2928,13 +2927,13 @@ func (s *APISuite) TestMetaStatsWhenChangedtoMultiSeries(c *gc.C) {
 	downloadsPerDay := map[int]int{2: 5}
 	for daysAgo, downloads := range downloadsPerDay {
 		date := today.AddDate(0, 0, -daysAgo)
-		key := []string{params.StatsArchiveDownload, url.URL.Series, url.URL.Name, url.URL.User, strconv.Itoa(url.URL.Revision)}
+		key := charmstore.EntityStatsKey(&url.URL, params.StatsArchiveDownload)
 		for i := 0; i < downloads; i++ {
 			err := s.store.IncCounterAtTime(key, date)
 			c.Assert(err, gc.Equals, nil)
 		}
 		if url.PromulgatedRevision > -1 {
-			key := []string{params.StatsArchiveDownloadPromulgated, url.URL.Series, url.URL.Name, "", strconv.Itoa(url.PromulgatedRevision)}
+			key := charmstore.EntityStatsKey(url.PromulgatedURL(), params.StatsArchiveDownloadPromulgated)
 			for i := 0; i < downloads; i++ {
 				err := s.store.IncCounterAtTime(key, date)
 				c.Assert(err, gc.Equals, nil)
@@ -2973,7 +2972,7 @@ func (s *APISuite) TestMetaStatsWhenChangedtoMultiSeries(c *gc.C) {
 			Month: 5,
 		},
 	}
-	s.assertGet(c, "django-1/meta/stats", expectResponse)
+	s.assertGet(c, "~charmers/django-1/meta/stats", expectResponse)
 
 	// Clean up the collections.
 	_, err := s.store.DB.Entities().RemoveAll(nil)

--- a/internal/v5/archive.go
+++ b/internal/v5/archive.go
@@ -150,11 +150,9 @@ func (h *ReqHandler) updateStatsArchiveUpload(id *charm.URL, err *error) {
 	// Upload stats don't include revision: it is assumed that each
 	// entity revision is only uploaded once.
 	id.Revision = -1
-	kind := params.StatsArchiveUpload
-	if *err != nil {
-		kind = params.StatsArchiveFailedUpload
+	if *err == nil {
+		h.Store.IncCounterAsync(charmstore.EntityStatsKey(id, params.StatsArchiveUpload))
 	}
-	h.Store.IncCounterAsync(charmstore.EntityStatsKey(id, kind))
 }
 
 func (h *ReqHandler) servePostArchive(id *charm.URL, w http.ResponseWriter, req *http.Request) (err error) {

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -159,10 +159,10 @@ func (s *ArchiveSuite) TestGetCounters(c *gc.C) {
 		)
 
 		// Check that the downloads count for the entity has been updated.
-		key := []string{params.StatsArchiveDownload, "utopic", "mysql", id.URL.User, "42"}
+		key := charmstore.EntityStatsKey(&id.URL, params.StatsArchiveDownload)
 		stats.CheckCounterSum(c, s.store, key, false, 1)
 		// Check that the promulgated download count for the entity has also been updated
-		key = []string{params.StatsArchiveDownloadPromulgated, "utopic", "mysql", "", "42"}
+		key = charmstore.EntityStatsKey(id.PromulgatedURL(), params.StatsArchiveDownloadPromulgated)
 		stats.CheckCounterSum(c, s.store, key, false, 1)
 	}
 }
@@ -843,44 +843,12 @@ func (s *ArchiveSuite) TestPostCounters(c *gc.C) {
 		c.Skip("MongoDB JavaScript not available")
 	}
 
-	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress", nil)
+	id := newResolvedURL("~charmers/precise/wordpress-0", -1)
+	s.assertUploadCharm(c, "POST", id, "wordpress", nil)
 
 	// Check that the upload count for the entity has been updated.
-	key := []string{params.StatsArchiveUpload, "precise", "wordpress", "charmers"}
+	key := charmstore.EntityStatsKey(id.URL.WithRevision(-1), params.StatsArchiveUpload)
 	stats.CheckCounterSum(c, s.store, key, false, 1)
-}
-
-func (s *ArchiveSuite) TestPostFailureCounters(c *gc.C) {
-	if !storetesting.MongoJSEnabled() {
-		c.Skip("MongoDB JavaScript not available")
-	}
-
-	hash, _ := hashOf(invalidZip())
-	doPost := func(url string, expectCode int) {
-		rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
-			Handler: s.srv,
-			URL:     storeURL(url),
-			Method:  "POST",
-			Header: http.Header{
-				"Content-Type": {"application/zip"},
-			},
-			Body:     invalidZip(),
-			Username: testUsername,
-			Password: testPassword,
-		})
-		c.Assert(rec.Code, gc.Equals, expectCode, gc.Commentf("body: %s", rec.Body.Bytes()))
-	}
-
-	// Send a first invalid request (revision specified).
-	doPost("~charmers/utopic/wordpress-42/archive", http.StatusBadRequest)
-	// Send a second invalid request (no hash).
-	doPost("~charmers/utopic/wordpress/archive", http.StatusBadRequest)
-	// Send a third invalid request (invalid zip).
-	doPost("~charmers/utopic/wordpress/archive?hash="+hash, http.StatusBadRequest)
-
-	// Check that the failed upload count for the entity has been updated.
-	key := []string{params.StatsArchiveFailedUpload, "utopic", "wordpress", "charmers"}
-	stats.CheckCounterSum(c, s.store, key, false, 3)
 }
 
 func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
@@ -1389,7 +1357,7 @@ func (s *ArchiveSuite) TestDeleteCounters(c *gc.C) {
 	})
 
 	// Check that the delete count for the entity has been updated.
-	key := []string{params.StatsArchiveDelete, "utopic", "mysql", "charmers", "41"}
+	key := charmstore.EntityStatsKey(charm.MustParseURL("~charmers/utopic/mysql-41"), params.StatsArchiveDelete)
 	stats.CheckCounterSum(c, s.store, key, false, 1)
 }
 


### PR DESCRIPTION
This means that we can summarize over all series
for a charm in a single request.

We also change the Counters logic to add a fast path for
non-list stats queries.

We also avoid adding ArchiveUploadFailed entries to the stats
as they're the most common entry and we don't need the noise.

Also change the stats granularity to one hour so we get
less records overall.

Note that this is targeted at the "faster-stats" feature branch because it can't
be used until the relevant migration has been done.