### PR TITLE
internal/store: delete resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,3 +47,5 @@ require (
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	gopkg.in/yaml.v2 v2.2.1
 )
+
+go 1.13


### PR DESCRIPTION
Add support in the store for deleting resources. This has the same
semantics as deleting entities.