### PR TITLE
internal/v5: Disable revision-info when flag set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: go
 go_import_path: "gopkg.in/juju/charmstore.v5"
-go: 
+env:
+  global:
+   - MONGODB_VERSION=2.6.10
+go:
   - "1.11.x"
   - "1.12.x"
 script: GO111MODULE=on go test ./...
 services:
-  - mongodb
   - elasticsearch
 before_script:
   - sleep 10
 before_install:
   - "curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb && sudo dpkg -i --force-confnew elasticsearch-2.4.6.deb && sudo service elasticsearch restart"
+  - curl -O http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz
+  - tar xfz mongodb-linux-x86_64-$MONGODB_VERSION.tgz
+  - export PATH=`pwd`/mongodb-linux-x86_64-$MONGODB_VERSION/bin:$PATH
+  - mkdir -p data/db
+  - mongod --dbpath=data/db &

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -816,6 +816,11 @@ func (h *ReqHandler) metaStats(entity *mongodoc.Entity, id *router.ResolvedURL, 
 // GET id/meta/revision-info
 // https://github.com/juju/charmstore/blob/v5/docs/API.md#get-idmetarevision-info
 func (h *ReqHandler) metaRevisionInfo(id *router.ResolvedURL, path string, flags url.Values, req *http.Request) (interface{}, error) {
+	if h.Handler.config.DisableSlowMetadata {
+		return &params.RevisionInfoResponse{
+			Revisions: make([]*charm.URL, 0),
+		}, nil
+	}
 	mon := monitoring.NewMetaDuration("revision-info")
 	defer mon.Done()
 	searchURL := id.PreferredURL()


### PR DESCRIPTION
Note: I'm currently unable to get tests running. I doubt it's an issue, but let's confirm that before merging.