### PR TITLE
meta/perm: less naive implementation of privacy features

### DIFF
--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -34,8 +34,8 @@ import (
 	"gopkg.in/juju/charmstore.v5/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5/internal/router"
 	"gopkg.in/juju/charmstore.v5/internal/storetesting"
-	"gopkg.in/juju/charmstore.v5/internal/v4"
-	"gopkg.in/juju/charmstore.v5/internal/v5"
+	v4 "gopkg.in/juju/charmstore.v5/internal/v4"
+	v5 "gopkg.in/juju/charmstore.v5/internal/v5"
 )
 
 var testPublicKey = bakery.PublicKey{
@@ -390,14 +390,14 @@ var metaEndpoints = []metaEndpoint{{
 			return nil, err
 		}
 		return params.PermResponse{
-			Read: acls.Read,
+			Read:  acls.Read,
 			Write: []string{},
 		}, nil
 	},
 	checkURL: newResolvedURL("~bob/utopic/wordpress-2", -1),
 	assertCheckData: func(c *gc.C, data interface{}) {
 		c.Assert(data, gc.DeepEquals, params.PermResponse{
-			Read: []string{params.Everyone},
+			Read:  []string{params.Everyone},
 			Write: []string{},
 		})
 	},
@@ -774,7 +774,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Do:      bakeryDo(nil),
 			URL:     storeURL("precise/wordpress-24/meta/perm"),
 			ExpectBody: params.PermResponse{
-				Read: []string{"mike"},
+				Read:  []string{"mike"},
 				Write: []string{},
 			},
 		})
@@ -816,7 +816,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Do:      bakeryDo(nil),
 			URL:     storeURL("~charmers/trusty/wordpress-1/meta/perm"),
 			ExpectBody: params.PermResponse{
-				Read: []string{"charmers"},
+				Read:  []string{"charmers"},
 				Write: []string{},
 			},
 		})
@@ -901,7 +901,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 	s.doAsUser("bob", func() {
 		s.assertGet(c, "wordpress/meta/perm", params.PermResponse{
-			Read: []string{params.Everyone},
+			Read:  []string{params.Everyone},
 			Write: []string{},
 		})
 		s.assertGet(c, "wordpress/meta/perm/read", []string{params.Everyone})
@@ -1028,8 +1028,9 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Write: []string{"charmers"},
 		},
 		params.StableChannel: {
-			Read:  []string{"joe"},
-			Write: []string{},
+			Read: []string{"joe"},
+			// The write ACLs is still admin as we don't allow setting an empty slice.
+			Write: []string{"admin"},
 		},
 	})
 

--- a/internal/v5/api.go
+++ b/internal/v5/api.go
@@ -1107,20 +1107,25 @@ func (h *ReqHandler) putMetaPerm(id *router.ResolvedURL, path string, val *json.
 		return errgo.Mask(err)
 	}
 	// TODO use only one UpdateField operation?
-	updater.UpdateField(string("channelacls."+ch+".read"), perms.Read, &audit.Entry{
-		Op:     audit.OpSetPerm,
-		Entity: &id.URL,
-		ACL: &audit.ACL{
-			Read: perms.Read,
-		},
-	})
-	updater.UpdateField(string("channelacls."+ch+".write"), perms.Write, &audit.Entry{
-		Op:     audit.OpSetPerm,
-		Entity: &id.URL,
-		ACL: &audit.ACL{
-			Write: perms.Write,
-		},
-	})
+	// Do not allow empty ACLs that could be send by previous bugged clients.
+	if len(perms.Read) > 0 {
+		updater.UpdateField(string("channelacls."+ch+".read"), perms.Read, &audit.Entry{
+			Op:     audit.OpSetPerm,
+			Entity: &id.URL,
+			ACL: &audit.ACL{
+				Read: perms.Read,
+			},
+		})
+	}
+	if len(perms.Write) > 0 {
+		updater.UpdateField(string("channelacls."+ch+".write"), perms.Write, &audit.Entry{
+			Op:     audit.OpSetPerm,
+			Entity: &id.URL,
+			ACL: &audit.ACL{
+				Write: perms.Write,
+			},
+		})
+	}
 	updater.UpdateSearch()
 	return nil
 }

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -1469,8 +1469,9 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Write: []string{"charmers"},
 		},
 		params.StableChannel: {
-			Read:  []string{"joe"},
-			Write: []string{},
+			Read: []string{"joe"},
+			// The write ACLs is still admin as we don't allow setting an empty slice.
+			Write: []string{"admin"},
 		},
 	})
 

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -380,15 +380,19 @@ var metaEndpoints = []metaEndpoint{{
 		if err != nil {
 			return nil, err
 		}
+		if url.URL.User != "charmers" {
+			acls.Read = []string{"everyone"}
+			acls.Write = []string{}
+		}
 		return params.PermResponse{
-			Read: acls.Read,
-			Write: []string{},
+			Read:  acls.Read,
+			Write: acls.Write,
 		}, nil
 	},
 	checkURL: newResolvedURL("~bob/utopic/wordpress-2", -1),
 	assertCheckData: func(c *gc.C, data interface{}) {
 		c.Assert(data, gc.DeepEquals, params.PermResponse{
-			Read: []string{params.Everyone},
+			Read:  []string{params.Everyone},
 			Write: []string{},
 		})
 	},
@@ -802,6 +806,17 @@ func (s *APISuite) addTestEntities(c *gc.C) []*router.ResolvedURL {
 
 func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 	s.idmServer.SetDefaultUser("charmers")
+	// Force a user authentication so that the test is more deterministic later.
+	do := bakeryDo(nil)
+	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+		Handler: s.srv,
+		Do:      do,
+		URL:     storeURL("/whoami"),
+		ExpectBody: params.WhoAmIResponse{
+			User:   "charmers",
+			Groups: []string{},
+		},
+	})
 	urls := s.addTestEntities(c)
 	for i, ep := range metaEndpoints {
 		c.Logf("test %d. %s", i, ep.name)
@@ -819,7 +834,7 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 			if isNull(expectData) {
 				httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 					Handler:      s.srv,
-					Do:           bakeryDo(nil),
+					Do:           do,
 					URL:          storeURL(path),
 					ExpectStatus: http.StatusNotFound,
 					ExpectBody: params.Error{
@@ -831,7 +846,12 @@ func (s *APISuite) TestMetaEndpointsSingle(c *gc.C) {
 			}
 			tested = true
 			c.Logf("	path %q: %#v", url, path)
-			s.assertGet(c, path, expectData)
+			httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+				Handler:    s.srv,
+				Do:         do,
+				URL:        storeURL(path),
+				ExpectBody: expectData,
+			})
 		}
 		if !tested {
 			c.Errorf("endpoint %q is null for all endpoints, so is not properly tested", ep.name)
@@ -1194,7 +1214,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Do:      bakeryDo(nil),
 			URL:     storeURL("precise/wordpress-24/meta/perm"),
 			ExpectBody: params.PermResponse{
-				Read: []string{"mike"},
+				Read:  []string{"mike"},
 				Write: []string{},
 			},
 		})
@@ -1237,7 +1257,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 			Do:      bakeryDo(nil),
 			URL:     storeURL("~charmers/trusty/wordpress-1/meta/perm"),
 			ExpectBody: params.PermResponse{
-				Read: []string{"charmers"},
+				Read:  []string{"charmers"},
 				Write: []string{},
 			},
 		})
@@ -1322,7 +1342,7 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 
 	s.doAsUser("bob", func() {
 		s.assertGet(c, "wordpress/meta/perm", params.PermResponse{
-			Read: []string{params.Everyone},
+			Read:  []string{params.Everyone},
 			Write: []string{},
 		})
 		s.assertGet(c, "wordpress/meta/perm/read", []string{params.Everyone})


### PR DESCRIPTION
The previous change to the meta/perm endpoint broke the "charm grant/revoke" commands, which rely on the GET perm/meta to always return the real ACLs even when the user only has read permission. We try to be more smart here about how the permissions are returned to the user.