### PR TITLE
internal/charmstore: disable statistics queries

### DIFF
--- a/internal/charmstore/search_test.go
+++ b/internal/charmstore/search_test.go
@@ -88,12 +88,11 @@ func (s *StoreSearchSuite) TestSuccessfulExport(c *gc.C) {
 			series = []string{"bundle"}
 		}
 		doc := SearchDoc{
-			Entity:         entity,
-			TotalDownloads: int64(ent.Downloads),
-			ReadACLs:       ent.ACL,
-			Series:         series,
-			AllSeries:      true,
-			SingleSeries:   ent.URL.Series != "",
+			Entity:       entity,
+			ReadACLs:     ent.ACL,
+			Series:       series,
+			AllSeries:    true,
+			SingleSeries: ent.URL.Series != "",
 		}
 		c.Assert(string(actual), jc.JSONEquals, doc)
 	}
@@ -781,30 +780,30 @@ func (s *StoreSearchSuite) TestSorting(c *gc.C) {
 			storetesting.SearchEntities["wordpress-simple"],
 			storetesting.SearchEntities["cloud-controller-worker-v2"],
 		},
-	}, {
-		about:     "downloads ascending",
-		sortQuery: "downloads,name",
-		results: []storetesting.SearchEntity{
-			storetesting.SearchEntities["multi-series"],
-			storetesting.SearchEntities["wordpress"],
-			storetesting.SearchEntities["wordpress-simple"],
-			storetesting.SearchEntities["squid-forwardproxy"],
-			storetesting.SearchEntities["mysql"],
-			storetesting.SearchEntities["cloud-controller-worker-v2"],
-			storetesting.SearchEntities["varnish"],
-		},
-	}, {
-		about:     "downloads descending",
-		sortQuery: "-downloads,name",
-		results: []storetesting.SearchEntity{
-			storetesting.SearchEntities["varnish"],
-			storetesting.SearchEntities["cloud-controller-worker-v2"],
-			storetesting.SearchEntities["mysql"],
-			storetesting.SearchEntities["squid-forwardproxy"],
-			storetesting.SearchEntities["wordpress-simple"],
-			storetesting.SearchEntities["multi-series"],
-			storetesting.SearchEntities["wordpress"],
-		},
+		//	}, {
+		//		about:     "downloads ascending",
+		//		sortQuery: "downloads,name",
+		//		results: []storetesting.SearchEntity{
+		//			storetesting.SearchEntities["multi-series"],
+		//			storetesting.SearchEntities["wordpress"],
+		//			storetesting.SearchEntities["wordpress-simple"],
+		//			storetesting.SearchEntities["squid-forwardproxy"],
+		//			storetesting.SearchEntities["mysql"],
+		//			storetesting.SearchEntities["cloud-controller-worker-v2"],
+		//			storetesting.SearchEntities["varnish"],
+		//		},
+		//	}, {
+		//		about:     "downloads descending",
+		//		sortQuery: "-downloads,name",
+		//		results: []storetesting.SearchEntity{
+		//			storetesting.SearchEntities["varnish"],
+		//			storetesting.SearchEntities["cloud-controller-worker-v2"],
+		//			storetesting.SearchEntities["mysql"],
+		//			storetesting.SearchEntities["squid-forwardproxy"],
+		//			storetesting.SearchEntities["wordpress-simple"],
+		//			storetesting.SearchEntities["multi-series"],
+		//			storetesting.SearchEntities["wordpress"],
+		//		},
 	}}
 	for i, test := range tests {
 		c.Logf("test %d. %s", i, test.about)

--- a/internal/charmstore/stats_test.go
+++ b/internal/charmstore/stats_test.go
@@ -36,11 +36,15 @@ func (s *StatsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *StatsSuite) TearDownTest(c *gc.C) {
-	s.store.Close()
+	if s.store != nil {
+		s.store.Close()
+	}
 	s.IsolatedMgoSuite.TearDownTest(c)
 }
 
 func (s *StatsSuite) TestSumCounters(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -118,6 +122,8 @@ func (s *StatsSuite) TestSumCounters(c *gc.C) {
 }
 
 func (s *StatsSuite) TestCountersReadOnlySum(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -134,6 +140,8 @@ func (s *StatsSuite) TestCountersReadOnlySum(c *gc.C) {
 }
 
 func (s *StatsSuite) TestCountersTokenCaching(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -193,6 +201,8 @@ func (s *StatsSuite) TestCountersTokenCaching(c *gc.C) {
 }
 
 func (s *StatsSuite) TestCounterTokenUniqueness(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -218,6 +228,8 @@ func (s *StatsSuite) TestCounterTokenUniqueness(c *gc.C) {
 }
 
 func (s *StatsSuite) TestListCounters(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -285,6 +297,8 @@ func (s *StatsSuite) TestListCounters(c *gc.C) {
 }
 
 func (s *StatsSuite) TestListCountersBy(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -559,6 +573,8 @@ var archiveDownloadCountsTests = []struct {
 }}
 
 func (s *StatsSuite) TestArchiveDownloadCounts(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	for i, test := range archiveDownloadCountsTests {
 		c.Logf("%d: %s", i, test.about)
 		// Clear everything
@@ -604,6 +620,8 @@ func setDownloadCounts(c *gc.C, s *charmstore.Store, id *charm.URL, t time.Time,
 }
 
 func (s *StatsSuite) TestIncrementDownloadCounts(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ch := storetesting.Charms.CharmDir("wordpress")
 	id := charmstore.MustParseResolvedURL("0 ~charmers/trusty/wordpress-1")
 	err := s.store.AddCharmWithArchive(id, ch)
@@ -627,6 +645,8 @@ func (s *StatsSuite) TestIncrementDownloadCounts(c *gc.C) {
 }
 
 func (s *StatsSuite) TestIncrementDownloadCountsOnPromulgatedMultiSeriesCharm(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ch := storetesting.Charms.CharmDir("multi-series")
 	id := charmstore.MustParseResolvedURL("0 ~charmers/wordpress-1")
 	err := s.store.AddCharmWithArchive(id, ch)
@@ -650,6 +670,8 @@ func (s *StatsSuite) TestIncrementDownloadCountsOnPromulgatedMultiSeriesCharm(c 
 }
 
 func (s *StatsSuite) TestIncrementDownloadCountsOnIdWithPreferredSeries(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ch := storetesting.Charms.CharmDir("multi-series")
 	id := charmstore.MustParseResolvedURL("0 ~charmers/wordpress-1")
 	id.PreferredSeries = "trusty"
@@ -674,6 +696,8 @@ func (s *StatsSuite) TestIncrementDownloadCountsOnIdWithPreferredSeries(c *gc.C)
 }
 
 func (s *StatsSuite) TestIncrementDownloadCountsCaching(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ch := storetesting.Charms.CharmDir("wordpress")
 	id := charmstore.MustParseResolvedURL("0 ~charmers/trusty/wordpress-1")
 	err := s.store.AddCharmWithArchive(id, ch)

--- a/internal/legacy/api_test.go
+++ b/internal/legacy/api_test.go
@@ -28,7 +28,6 @@ import (
 	"gopkg.in/juju/charmstore.v5/internal/legacy"
 	"gopkg.in/juju/charmstore.v5/internal/router"
 	"gopkg.in/juju/charmstore.v5/internal/storetesting"
-	"gopkg.in/juju/charmstore.v5/internal/storetesting/stats"
 )
 
 var serverParams = charmstore.ServerParams{
@@ -282,20 +281,21 @@ func (s *APISuite) TestCharmInfoCounters(c *gc.C) {
 	requestInfo("precise/django-0", 2)
 
 	// The charm-info count for the promulgated charm has been updated.
-	key := []string{params.StatsCharmInfo, "utopic", "wordpress"}
-	stats.CheckCounterSum(c, s.store, key, false, 4)
+	// Statistics Disabled
+	//key := []string{params.StatsCharmInfo, "utopic", "wordpress"}
+	//stats.CheckCounterSum(c, s.store, key, false, 4)
 
 	// The charm-info count for the user owned charm has been updated.
-	key = []string{params.StatsCharmInfo, "trusty", "wordpress", "who"}
-	stats.CheckCounterSum(c, s.store, key, false, 3)
+	//key = []string{params.StatsCharmInfo, "trusty", "wordpress", "who"}
+	//stats.CheckCounterSum(c, s.store, key, false, 3)
 
 	// The charm-missing count for the missing charm has been updated.
-	key = []string{params.StatsCharmMissing, "precise", "django"}
-	stats.CheckCounterSum(c, s.store, key, false, 2)
+	//key = []string{params.StatsCharmMissing, "precise", "django"}
+	//stats.CheckCounterSum(c, s.store, key, false, 2)
 
 	// The charm-info count for the missing charm is still zero.
-	key = []string{params.StatsCharmInfo, "precise", "django"}
-	stats.CheckCounterSum(c, s.store, key, false, 0)
+	//key = []string{params.StatsCharmInfo, "precise", "django"}
+	//stats.CheckCounterSum(c, s.store, key, false, 0)
 }
 
 func (s *APISuite) TestAPIInfoWithGatedCharm(c *gc.C) {

--- a/internal/v4/api_test.go
+++ b/internal/v4/api_test.go
@@ -2203,18 +2203,18 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {0: 1},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 1,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 1,
-			Day:   1,
-			Week:  1,
-			Month: 1,
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 1,
-			Day:   1,
-			Week:  1,
-			Month: 1,
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2224,12 +2224,12 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {100: 1},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 1,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 1,
+			Total: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 1,
+			Total: 0,
 		},
 	},
 }, {
@@ -2239,14 +2239,14 @@ var metaStatsTests = []struct {
 		"utopic/wordpress-47": {20: 2, 25: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 2 + 5,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 2 + 5,
-			Month: 2 + 5,
+			Total: 0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 2 + 5,
-			Month: 2 + 5,
+			Total: 0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2256,18 +2256,18 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {100: 1, 12: 3, 8: 5, 4: 10, 2: 1, 0: 3},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 1 + 3 + 5 + 10 + 1 + 3,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 1 + 3 + 5 + 10 + 1 + 3,
-			Day:   3,
-			Week:  10 + 1 + 3,
-			Month: 3 + 5 + 10 + 1 + 3,
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 1 + 3 + 5 + 10 + 1 + 3,
-			Day:   3,
-			Week:  10 + 1 + 3,
-			Month: 3 + 5 + 10 + 1 + 3,
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2277,16 +2277,16 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {200: 3, 27: 4, 3: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 3 + 4 + 5,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 3 + 4 + 5,
-			Week:  5,
-			Month: 4 + 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 3 + 4 + 5,
-			Week:  5,
-			Month: 4 + 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2296,16 +2296,16 @@ var metaStatsTests = []struct {
 		"bundle/django-simple-2": {200: 3, 27: 4, 3: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 3 + 4 + 5,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 3 + 4 + 5,
-			Week:  5,
-			Month: 4 + 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 3 + 4 + 5,
-			Week:  5,
-			Month: 4 + 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2317,16 +2317,16 @@ var metaStatsTests = []struct {
 		"trusty/mysql-0":  {200: 1, 14: 2, 1: 7},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 2 + 10,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 2 + 10,
-			Week:  10,
-			Month: 2 + 10,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 2 + 10,
-			Week:  10,
-			Month: 2 + 10,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2338,17 +2338,17 @@ var metaStatsTests = []struct {
 		"precise/rails-2": {6: 10, 0: 9},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 5 + 3 + 7,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 5 + 3 + 7,
-			Week:  7,
-			Month: 3 + 7,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: (1 + 2) + (5 + 3 + 7) + (10 + 9),
-			Day:   0 + 0 + 9,
-			Week:  0 + 7 + (10 + 9),
-			Month: 0 + (3 + 7) + (10 + 9),
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2361,7 +2361,7 @@ var metaStatsTests = []struct {
 	},
 	expectResponse: params.StatsResponse{
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 10,
+			Total: 0,
 		},
 	},
 }, {
@@ -2374,10 +2374,10 @@ var metaStatsTests = []struct {
 	},
 	expectResponse: params.StatsResponse{
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: (7 + 1 + 2 + 1) + (9 + 2),
-			Day:   1 + 2,
-			Week:  (2 + 1) + (9 + 2),
-			Month: (1 + 2 + 1) + (9 + 2),
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2388,16 +2388,16 @@ var metaStatsTests = []struct {
 		"~who/utopic/django-0": {2: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 5,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 5,
-			Week:  5,
-			Month: 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 5,
-			Week:  5,
-			Month: 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }}

--- a/internal/v4/archive_test.go
+++ b/internal/v4/archive_test.go
@@ -32,8 +32,7 @@ import (
 	"gopkg.in/juju/charmstore.v5/internal/mongodoc"
 	"gopkg.in/juju/charmstore.v5/internal/router"
 	"gopkg.in/juju/charmstore.v5/internal/storetesting"
-	"gopkg.in/juju/charmstore.v5/internal/storetesting/stats"
-	"gopkg.in/juju/charmstore.v5/internal/v5"
+	v5 "gopkg.in/juju/charmstore.v5/internal/v5"
 )
 
 type ArchiveSuite struct {
@@ -161,11 +160,12 @@ func (s *ArchiveSuite) TestGetCounters(c *gc.C) {
 		)
 
 		// Check that the downloads count for the entity has been updated.
-		key := []string{params.StatsArchiveDownload, "utopic", "mysql", id.URL.User, "42"}
-		stats.CheckCounterSum(c, s.store, key, false, 1)
+		// Statistics Disabled
+		//key := []string{params.StatsArchiveDownload, "utopic", "mysql", id.URL.User, "42"}
+		//stats.CheckCounterSum(c, s.store, key, false, 1)
 		// Check that the promulgated download count for the entity has also been updated
-		key = []string{params.StatsArchiveDownloadPromulgated, "utopic", "mysql", "", "42"}
-		stats.CheckCounterSum(c, s.store, key, false, 1)
+		//key = []string{params.StatsArchiveDownloadPromulgated, "utopic", "mysql", "", "42"}
+		//stats.CheckCounterSum(c, s.store, key, false, 1)
 	}
 }
 
@@ -183,8 +183,9 @@ func (s *ArchiveSuite) TestGetCountersDisabled(c *gc.C) {
 	)
 
 	// Check that the downloads count for the entity has not been updated.
-	key := []string{params.StatsArchiveDownload, "utopic", "mysql", "", "42"}
-	stats.CheckCounterSum(c, s.store, key, false, 0)
+	// Statistics Disabled
+	//key := []string{params.StatsArchiveDownload, "utopic", "mysql", "", "42"}
+	//stats.CheckCounterSum(c, s.store, key, false, 0)
 }
 
 var archivePostErrorsTests = []struct {
@@ -700,8 +701,9 @@ func (s *ArchiveSuite) TestPostCounters(c *gc.C) {
 	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress")
 
 	// Check that the upload count for the entity has been updated.
-	key := []string{params.StatsArchiveUpload, "precise", "wordpress", "charmers"}
-	stats.CheckCounterSum(c, s.store, key, false, 1)
+	// Statistics Disabled
+	//key := []string{params.StatsArchiveUpload, "precise", "wordpress", "charmers"}
+	//stats.CheckCounterSum(c, s.store, key, false, 1)
 }
 
 func (s *ArchiveSuite) TestPostFailureCounters(c *gc.C) {
@@ -733,8 +735,9 @@ func (s *ArchiveSuite) TestPostFailureCounters(c *gc.C) {
 	doPost("~charmers/utopic/wordpress/archive?hash="+hash, http.StatusBadRequest)
 
 	// Check that the failed upload count for the entity has been updated.
-	key := []string{params.StatsArchiveFailedUpload, "utopic", "wordpress", "charmers"}
-	stats.CheckCounterSum(c, s.store, key, false, 3)
+	// Statistics Disabled
+	//key := []string{params.StatsArchiveFailedUpload, "utopic", "wordpress", "charmers"}
+	//stats.CheckCounterSum(c, s.store, key, false, 3)
 }
 
 func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
@@ -1367,7 +1370,8 @@ func (s *ArchiveSearchSuite) TestGetSearchUpdate(c *gc.C) {
 		c.Assert(rec.Code, gc.Equals, http.StatusOK)
 
 		// Check that the search record for the entity has been updated.
-		stats.CheckSearchTotalDownloads(c, s.store, &url.URL, 1)
+		// Statistics Disabled
+		//stats.CheckSearchTotalDownloads(c, s.store, &url.URL, 1)
 	}
 }
 

--- a/internal/v4/search_test.go
+++ b/internal/v4/search_test.go
@@ -638,6 +638,8 @@ func (s *SearchSuite) TestSortUnsupportedField(c *gc.C) {
 }
 
 func (s *SearchSuite) TestDownloadsBoost(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	charmDownloads := map[string]int{
 		"mysql":     0,
 		"wordpress": 1,

--- a/internal/v4/stats_test.go
+++ b/internal/v4/stats_test.go
@@ -27,6 +27,8 @@ type StatsSuite struct {
 var _ = gc.Suite(&StatsSuite{})
 
 func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	tests := []struct {
 		path    string
 		status  int
@@ -88,6 +90,8 @@ func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 }
 
 func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ref := charm.MustParseURL("~charmers/precise/wordpress-23")
 	tests := []struct {
 		path          string
@@ -157,6 +161,8 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 }
 
 func (s *StatsSuite) TestServerStatsArchiveDownloadOnPromulgatedEntity(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ref := charm.MustParseURL("~charmers/precise/wordpress-23")
 	path := "/stats/counter/archive-download:*"
 
@@ -197,6 +203,8 @@ func (s *StatsSuite) TestServerStatsArchiveDownloadOnPromulgatedEntity(c *gc.C) 
 }
 
 func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ref := charm.MustParseURL("~charmers/precise/wordpress-23")
 	tests := []struct {
 		path          string
@@ -264,6 +272,8 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 }
 
 func (s *StatsSuite) TestServerStatsUpdateNonAdmin(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,
 		URL:     storeURL("stats/update"),
@@ -301,6 +311,8 @@ func (s *StatsSuite) TestServerStatsUpdateNonAdmin(c *gc.C) {
 }
 
 func (s *StatsSuite) TestStatsCounter(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -339,6 +351,8 @@ func (s *StatsSuite) TestStatsCounter(c *gc.C) {
 }
 
 func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -425,6 +439,8 @@ func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
 }
 
 func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -632,6 +648,8 @@ func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {
 }
 
 func (s *StatsSuite) TestStatsEnabled(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	statsEnabled := func(url string) bool {
 		req, _ := http.NewRequest("GET", url, nil)
 		return v5.StatsEnabled(req)

--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -2698,18 +2698,18 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {0: 1},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 1,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 1,
-			Day:   1,
-			Week:  1,
-			Month: 1,
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 1,
-			Day:   1,
-			Week:  1,
-			Month: 1,
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2719,12 +2719,12 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {100: 1},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 1,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 1,
+			Total: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 1,
+			Total: 0,
 		},
 	},
 }, {
@@ -2734,14 +2734,14 @@ var metaStatsTests = []struct {
 		"utopic/wordpress-47": {20: 2, 25: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 2 + 5,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 2 + 5,
-			Month: 2 + 5,
+			Total: 0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 2 + 5,
-			Month: 2 + 5,
+			Total: 0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2751,18 +2751,18 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {100: 1, 12: 3, 8: 5, 4: 10, 2: 1, 0: 3},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 1 + 3 + 5 + 10 + 1 + 3,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 1 + 3 + 5 + 10 + 1 + 3,
-			Day:   3,
-			Week:  10 + 1 + 3,
-			Month: 3 + 5 + 10 + 1 + 3,
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 1 + 3 + 5 + 10 + 1 + 3,
-			Day:   3,
-			Week:  10 + 1 + 3,
-			Month: 3 + 5 + 10 + 1 + 3,
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2772,16 +2772,16 @@ var metaStatsTests = []struct {
 		"utopic/django-42": {200: 3, 27: 4, 3: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 3 + 4 + 5,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 3 + 4 + 5,
-			Week:  5,
-			Month: 4 + 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 3 + 4 + 5,
-			Week:  5,
-			Month: 4 + 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2791,16 +2791,16 @@ var metaStatsTests = []struct {
 		"bundle/django-simple-2": {200: 3, 27: 4, 3: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 3 + 4 + 5,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 3 + 4 + 5,
-			Week:  5,
-			Month: 4 + 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 3 + 4 + 5,
-			Week:  5,
-			Month: 4 + 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2812,16 +2812,16 @@ var metaStatsTests = []struct {
 		"trusty/mysql-0":  {200: 1, 14: 2, 1: 7},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 2 + 10,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 2 + 10,
-			Week:  10,
-			Month: 2 + 10,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 2 + 10,
-			Week:  10,
-			Month: 2 + 10,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2833,17 +2833,17 @@ var metaStatsTests = []struct {
 		"precise/rails-2": {6: 10, 0: 9},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 5 + 3 + 7,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 5 + 3 + 7,
-			Week:  7,
-			Month: 3 + 7,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: (1 + 2) + (5 + 3 + 7) + (10 + 9),
-			Day:   0 + 0 + 9,
-			Week:  0 + 7 + (10 + 9),
-			Month: 0 + (3 + 7) + (10 + 9),
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2856,7 +2856,7 @@ var metaStatsTests = []struct {
 	},
 	expectResponse: params.StatsResponse{
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 10,
+			Total: 0,
 		},
 	},
 }, {
@@ -2869,10 +2869,10 @@ var metaStatsTests = []struct {
 	},
 	expectResponse: params.StatsResponse{
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: (7 + 1 + 2 + 1) + (9 + 2),
-			Day:   1 + 2,
-			Week:  (2 + 1) + (9 + 2),
-			Month: (1 + 2 + 1) + (9 + 2),
+			Total: 0,
+			Day:   0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }, {
@@ -2883,16 +2883,16 @@ var metaStatsTests = []struct {
 		"~who/utopic/django-0": {2: 5},
 	},
 	expectResponse: params.StatsResponse{
-		ArchiveDownloadCount: 5,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 5,
-			Week:  5,
-			Month: 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 5,
-			Week:  5,
-			Month: 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	},
 }}
@@ -2983,16 +2983,16 @@ func (s *APISuite) TestMetaStatsWhenChangedtoMultiSeries(c *gc.C) {
 		}
 	}
 	expectResponse := params.StatsResponse{
-		ArchiveDownloadCount: 5,
+		ArchiveDownloadCount: 0,
 		ArchiveDownload: params.StatsCount{
-			Total: 5,
-			Week:  5,
-			Month: 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 5,
-			Week:  5,
-			Month: 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	}
 	s.assertGet(c, "utopic/django-0/meta/stats", expectResponse)
@@ -3009,9 +3009,9 @@ func (s *APISuite) TestMetaStatsWhenChangedtoMultiSeries(c *gc.C) {
 			Month: 0,
 		},
 		ArchiveDownloadAllRevisions: params.StatsCount{
-			Total: 5,
-			Week:  5,
-			Month: 5,
+			Total: 0,
+			Week:  0,
+			Month: 0,
 		},
 	}
 	s.assertGet(c, "django-1/meta/stats", expectResponse)

--- a/internal/v5/archive_test.go
+++ b/internal/v5/archive_test.go
@@ -159,11 +159,12 @@ func (s *ArchiveSuite) TestGetCounters(c *gc.C) {
 		)
 
 		// Check that the downloads count for the entity has been updated.
-		key := []string{params.StatsArchiveDownload, "utopic", "mysql", id.URL.User, "42"}
-		stats.CheckCounterSum(c, s.store, key, false, 1)
+		// Statistics Disabled
+		//key := []string{params.StatsArchiveDownload, "utopic", "mysql", id.URL.User, "42"}
+		//stats.CheckCounterSum(c, s.store, key, false, 1)
 		// Check that the promulgated download count for the entity has also been updated
-		key = []string{params.StatsArchiveDownloadPromulgated, "utopic", "mysql", "", "42"}
-		stats.CheckCounterSum(c, s.store, key, false, 1)
+		// key = []string{params.StatsArchiveDownloadPromulgated, "utopic", "mysql", "", "42"}
+		// stats.CheckCounterSum(c, s.store, key, false, 1)
 	}
 }
 
@@ -846,8 +847,9 @@ func (s *ArchiveSuite) TestPostCounters(c *gc.C) {
 	s.assertUploadCharm(c, "POST", newResolvedURL("~charmers/precise/wordpress-0", -1), "wordpress", nil)
 
 	// Check that the upload count for the entity has been updated.
-	key := []string{params.StatsArchiveUpload, "precise", "wordpress", "charmers"}
-	stats.CheckCounterSum(c, s.store, key, false, 1)
+	// Statistics Disabled
+	// key := []string{params.StatsArchiveUpload, "precise", "wordpress", "charmers"}
+	// stats.CheckCounterSum(c, s.store, key, false, 1)
 }
 
 func (s *ArchiveSuite) TestPostFailureCounters(c *gc.C) {
@@ -879,8 +881,9 @@ func (s *ArchiveSuite) TestPostFailureCounters(c *gc.C) {
 	doPost("~charmers/utopic/wordpress/archive?hash="+hash, http.StatusBadRequest)
 
 	// Check that the failed upload count for the entity has been updated.
-	key := []string{params.StatsArchiveFailedUpload, "utopic", "wordpress", "charmers"}
-	stats.CheckCounterSum(c, s.store, key, false, 3)
+	// Statistics Disabled
+	// key := []string{params.StatsArchiveFailedUpload, "utopic", "wordpress", "charmers"}
+	// stats.CheckCounterSum(c, s.store, key, false, 3)
 }
 
 func (s *ArchiveSuite) TestUploadOfCurrentCharmReadsFully(c *gc.C) {
@@ -1389,8 +1392,9 @@ func (s *ArchiveSuite) TestDeleteCounters(c *gc.C) {
 	})
 
 	// Check that the delete count for the entity has been updated.
-	key := []string{params.StatsArchiveDelete, "utopic", "mysql", "charmers", "41"}
-	stats.CheckCounterSum(c, s.store, key, false, 1)
+	// Statistics Disabled
+	// key := []string{params.StatsArchiveDelete, "utopic", "mysql", "charmers", "41"}
+	// stats.CheckCounterSum(c, s.store, key, false, 1)
 }
 
 type basicAuthArchiveSuite struct {
@@ -1673,7 +1677,8 @@ func (s *ArchiveSearchSuite) TestGetSearchUpdate(c *gc.C) {
 		c.Assert(rec.Code, gc.Equals, http.StatusOK)
 
 		// Check that the search record for the entity has been updated.
-		stats.CheckSearchTotalDownloads(c, s.store, &url.URL, 1)
+		// Stats Disabled
+		// stats.CheckSearchTotalDownloads(c, s.store, &url.URL, 1)
 	}
 }
 

--- a/internal/v5/resources_test.go
+++ b/internal/v5/resources_test.go
@@ -1100,25 +1100,25 @@ func (s *ResourceSuite) TestDelete(c *gc.C) {
 	})
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Method: "DELETE",
-		URL: storeURL(fmt.Sprintf("%s/resource/someResource/1", id0.URL.Path())),
+		Handler:      s.srv,
+		Method:       "DELETE",
+		URL:          storeURL(fmt.Sprintf("%s/resource/someResource/1", id0.URL.Path())),
 		ExpectStatus: http.StatusOK,
-		Do: s.bakeryDoAsUser("charmers"),		
+		Do:           s.bakeryDoAsUser("charmers"),
 	})
 
 	// check we can't access version 1 anymore.
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Method: "GET",
-		URL: storeURL(fmt.Sprintf("%s/resource/someResource/1", id0.URL.Path())),
+		Handler:      s.srv,
+		Method:       "GET",
+		URL:          storeURL(fmt.Sprintf("%s/resource/someResource/1", id0.URL.Path())),
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
-			Code: "not found",
+			Code:    "not found",
 			Message: `cs:~charmers/precise/wordpress-0 has no "someResource/1" resource`,
 		},
-		Do: s.bakeryDoAsUser("charmers"),		
-	})	
+		Do: s.bakeryDoAsUser("charmers"),
+	})
 }
 
 func (s *ResourceSuite) TestDeleteNotFound(c *gc.C) {
@@ -1127,16 +1127,16 @@ func (s *ResourceSuite) TestDeleteNotFound(c *gc.C) {
 	s.addPublicCharm(c, storetesting.NewCharm(meta), id0)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Method: "DELETE",
-		URL: storeURL(fmt.Sprintf("%s/resource/someResource/1", id0.URL.Path())),
+		Handler:      s.srv,
+		Method:       "DELETE",
+		URL:          storeURL(fmt.Sprintf("%s/resource/someResource/1", id0.URL.Path())),
 		ExpectStatus: http.StatusNotFound,
 		ExpectBody: params.Error{
-			Code: "not found",
+			Code:    "not found",
 			Message: `cs:~charmers/precise/wordpress-0 has no "someResource/1" resource`,
 		},
-		Do: s.bakeryDoAsUser("charmers"),		
-	})	
+		Do: s.bakeryDoAsUser("charmers"),
+	})
 }
 
 func (s *ResourceSuite) TestDeletePublished(c *gc.C) {
@@ -1161,16 +1161,16 @@ func (s *ResourceSuite) TestDeletePublished(c *gc.C) {
 	})
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Method: "DELETE",
-		URL: storeURL(fmt.Sprintf("%s/resource/someResource/0", id0.URL.Path())),
+		Handler:      s.srv,
+		Method:       "DELETE",
+		URL:          storeURL(fmt.Sprintf("%s/resource/someResource/0", id0.URL.Path())),
 		ExpectStatus: http.StatusForbidden,
 		ExpectBody: params.Error{
-			Code: "forbidden",
+			Code:    "forbidden",
 			Message: `cannot delete "cs:~charmers/precise/wordpress-0/someResource/0" because it is the current revision in channels [stable]`,
 		},
-		Do: s.bakeryDoAsUser("charmers"),		
-	})	
+		Do: s.bakeryDoAsUser("charmers"),
+	})
 }
 
 func (s *ResourceSuite) TestDeleteLastResource(c *gc.C) {
@@ -1179,14 +1179,14 @@ func (s *ResourceSuite) TestDeleteLastResource(c *gc.C) {
 	s.addPublicCharm(c, storetesting.NewCharm(meta), id0)
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
-		Handler: s.srv,
-		Method: "DELETE",
-		URL: storeURL(fmt.Sprintf("%s/resource/someResource/0", id0.URL.Path())),
+		Handler:      s.srv,
+		Method:       "DELETE",
+		URL:          storeURL(fmt.Sprintf("%s/resource/someResource/0", id0.URL.Path())),
 		ExpectStatus: http.StatusForbidden,
 		ExpectBody: params.Error{
-			Code: "forbidden",
+			Code:    "forbidden",
 			Message: `cannot delete last revision of resource`,
 		},
-		Do: s.bakeryDoAsUser("charmers"),		
-	})	
+		Do: s.bakeryDoAsUser("charmers"),
+	})
 }

--- a/internal/v5/search_test.go
+++ b/internal/v5/search_test.go
@@ -801,6 +801,8 @@ func (s *SearchSuite) TestSortUnsupportedField(c *gc.C) {
 }
 
 func (s *SearchSuite) TestDownloadsBoost(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	charmDownloads := map[string]int{
 		"mysql":     0,
 		"wordpress": 1,

--- a/internal/v5/stats_test.go
+++ b/internal/v5/stats_test.go
@@ -17,7 +17,7 @@ import (
 
 	"gopkg.in/juju/charmstore.v5/internal/charmstore"
 	"gopkg.in/juju/charmstore.v5/internal/storetesting"
-	"gopkg.in/juju/charmstore.v5/internal/v5"
+	v5 "gopkg.in/juju/charmstore.v5/internal/v5"
 )
 
 type StatsSuite struct {
@@ -32,6 +32,8 @@ func (s *StatsSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	tests := []struct {
 		path    string
 		status  int
@@ -93,6 +95,8 @@ func (s *StatsSuite) TestServerStatsStatus(c *gc.C) {
 }
 
 func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ref := charm.MustParseURL("~charmers/precise/wordpress-23")
 	tests := []struct {
 		path          string
@@ -162,6 +166,8 @@ func (s *StatsSuite) TestServerStatsUpdate(c *gc.C) {
 }
 
 func (s *StatsSuite) TestServerStatsArchiveDownloadOnPromulgatedEntity(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ref := charm.MustParseURL("~charmers/precise/wordpress-23")
 	path := "/stats/counter/archive-download:*"
 
@@ -202,6 +208,8 @@ func (s *StatsSuite) TestServerStatsArchiveDownloadOnPromulgatedEntity(c *gc.C) 
 }
 
 func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	ref := charm.MustParseURL("~charmers/precise/wordpress-23")
 	tests := []struct {
 		path          string
@@ -269,6 +277,8 @@ func (s *StatsSuite) TestServerStatsUpdateErrors(c *gc.C) {
 }
 
 func (s *StatsSuite) TestServerStatsUpdateNotPartOfStatsUpdateGroup(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler: s.srv,
 		URL:     storeURL("stats/update"),
@@ -303,6 +313,8 @@ func (s *StatsSuite) TestServerStatsUpdateNotPartOfStatsUpdateGroup(c *gc.C) {
 }
 
 func (s *StatsSuite) TestServerStatsUpdatePartOfStatsUpdateGroup(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	s.addPublicCharm(c, storetesting.Charms.CharmDir("wordpress"), newResolvedURL("~charmers/precise/wordpress-23", 23))
 
 	s.idmServer.AddUser("statsupdate", "statsupdate@cs")
@@ -322,6 +334,8 @@ func (s *StatsSuite) TestServerStatsUpdatePartOfStatsUpdateGroup(c *gc.C) {
 }
 
 func (s *StatsSuite) TestStatsCounter(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -360,6 +374,8 @@ func (s *StatsSuite) TestStatsCounter(c *gc.C) {
 }
 
 func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -446,6 +462,8 @@ func (s *StatsSuite) TestStatsCounterList(c *gc.C) {
 }
 
 func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	if !storetesting.MongoJSEnabled() {
 		c.Skip("MongoDB JavaScript not available")
 	}
@@ -653,6 +671,8 @@ func (s *StatsSuite) TestStatsCounterBy(c *gc.C) {
 }
 
 func (s *StatsSuite) TestStatsEnabled(c *gc.C) {
+	c.Skip("Statistics Disabled")
+
 	statsEnabled := func(url string) bool {
 		req, _ := http.NewRequest("GET", url, nil)
 		return v5.StatsEnabled(req)


### PR DESCRIPTION
Disable retrieving of statistics information from the database.
These queries are causing database failures so are being disabled as a
temporary measure, while a less resource intensive statistics mechanism
is developed.