### PR TITLE
internal/v5: fix panic getting permissions

### DIFF
--- a/internal/v5/api_test.go
+++ b/internal/v5/api_test.go
@@ -1559,6 +1559,21 @@ func (s *APISuite) TestMetaPerm(c *gc.C) {
 	})
 }
 
+func (s *APISuite) TestMetaPermGetAsAdmin(c *gc.C) {
+	for _, u := range []*router.ResolvedURL{
+		newResolvedURL("~charmers/precise/wordpress-23", 23),
+		newResolvedURL("~charmers/precise/wordpress-24", 24),
+		newResolvedURL("~charmers/trusty/wordpress-1", 1),
+	} {
+		err := s.store.AddCharmWithArchive(u, storetesting.NewCharm(nil))
+		c.Assert(err, gc.Equals, nil)
+	}
+	s.assertGetAsAdmin(c, "~charmers/precise/wordpress-24/meta/perm", params.PermResponse{
+		Read:  []string{"charmers"},
+		Write: []string{"charmers"},
+	})
+}
+
 func (s *APISuite) TestMetaPermPutUnauthorized(c *gc.C) {
 	id := "precise/wordpress-23"
 	s.addPublicCharmFromRepo(c, "wordpress", newResolvedURL("~charmers/"+id, 23))

--- a/internal/v5/common_test.go
+++ b/internal/v5/common_test.go
@@ -429,12 +429,25 @@ func (s *commonSuite) assertPut0(c *gc.C, url string, val interface{}, asAdmin b
 }
 
 func (s *commonSuite) assertGet(c *gc.C, url string, expectVal interface{}) {
-	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
+	s.assertGet0(c, url, expectVal, false)
+}
+
+func (s *commonSuite) assertGetAsAdmin(c *gc.C, url string, expectVal interface{}) {
+	s.assertGet0(c, url, expectVal, true)
+}
+
+func (s *commonSuite) assertGet0(c *gc.C, url string, expectVal interface{}, asAdmin bool) {
+	p := httptesting.JSONCallParams{
 		Handler:    s.srv,
 		Do:         bakeryDo(nil),
 		URL:        storeURL(url),
 		ExpectBody: expectVal,
-	})
+	}
+	if asAdmin {
+		p.Username = testUsername
+		p.Password = testPassword
+	}
+	httptesting.AssertJSONCall(c, p)
 }
 
 // assertGetIsUnauthorized asserts that a GET to the given URL results


### PR DESCRIPTION
This fixes a bug which causes a panic when getting meta/perm as the
admin user.